### PR TITLE
feat(ci): 恢复插件发布工作流 -f 强制重发入口

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -6,6 +6,12 @@ name: Publish plugins
 # 本仓库自带 GITHUB_TOKEN 不能跨仓库写。
 on:
   workflow_call:
+    inputs:
+      publish_args:
+        description: '可选发布参数；填写 -f 时强制重编译并覆盖上传所有插件资产'
+        required: false
+        type: string
+        default: ''
     secrets:
       PLUGINS_REPO_TOKEN:
         required: true
@@ -14,6 +20,12 @@ on:
       PLUGIN_SIGNING_PRIVATE_KEY_PEM:
         required: false
   workflow_dispatch:
+    inputs:
+      publish_args:
+        description: '可选发布参数；填写 -f 时强制重编译并覆盖上传所有插件资产'
+        required: false
+        type: string
+        default: ''
 
 # 本仓库只需读（checkout）；对分发仓库的写全部经 PAT，不靠默认 GITHUB_TOKEN。
 permissions:
@@ -120,14 +132,16 @@ jobs:
           }
           [System.IO.File]::AppendAllText($env:GITHUB_ENV, "PLUGIN_SIGNING_PRIVATE_KEY_FILE=$privateKeyFile`n", (New-Object System.Text.UTF8Encoding($false)))
 
-      - name: Build + publish updated plugins (per-plugin, version-gated)
+      - name: Build + publish updated plugins (per-plugin, version-gated or forced)
         # 仅对「plugin.version 尚无对应 Release」的插件单独编译（mvn -pl <module> -am，不全量构建）并发布；
         # 版本已发布的插件跳过、绝不重编译 / 重上传（不可变）。更新一个插件 = 只编译并发布这一个。
+        # 手动触发时 publish_args 填 -f 会强制每个插件都重编译，并先删除同名 Release 资产后重新上传。
         # 布局偏好调查的四个公开客户端配置经 Repository Variables（vars 上下文，不是 secrets）注入，
         # 只作用于 download-workbench 插件；上游仓库缺少任意一项时构建明确失败。
         shell: powershell
         env:
           GH_TOKEN: ${{ secrets.PLUGINS_REPO_TOKEN }}
+          PUBLISH_PLUGIN_ARGS: ${{ inputs.publish_args || '' }}
           PIXIV_LAYOUT_SURVEY_PROJECT_TOKEN: ${{ vars.PIXIV_LAYOUT_SURVEY_PROJECT_TOKEN }}
           PIXIV_LAYOUT_SURVEY_ID: ${{ vars.PIXIV_LAYOUT_SURVEY_ID }}
           PIXIV_LAYOUT_SURVEY_API_HOST: ${{ vars.PIXIV_LAYOUT_SURVEY_API_HOST }}
@@ -138,6 +152,17 @@ jobs:
             Repo = $env:PLUGINS_REPO
             OfficialKeyId = $env:PLUGIN_SIGNING_KEY_ID
             PrivateKeyFile = $env:PLUGIN_SIGNING_PRIVATE_KEY_FILE
+          }
+          $inputTokens = @()
+          if (-not [string]::IsNullOrWhiteSpace($env:PUBLISH_PLUGIN_ARGS)) {
+            $inputTokens = @($env:PUBLISH_PLUGIN_ARGS -split '\s+' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+          }
+          $unsupportedTokens = @($inputTokens | Where-Object { $_ -notin @("-f", "-Force") })
+          if ($unsupportedTokens.Count -gt 0) {
+            throw "Unsupported publish_args value(s): $($unsupportedTokens -join ', '). Only -f is supported."
+          }
+          if (@($inputTokens | Where-Object { $_ -in @("-f", "-Force") }).Count -gt 0) {
+            $publishArgs["Force"] = $true
           }
           .\scripts\publish-plugin-releases.ps1 @publishArgs
 

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
@@ -98,7 +98,7 @@ class PluginReleaseScriptsTest {
         );
         assertThat(script).doesNotContain("already published; skip (immutable");
         assertThat(script).contains("Bump plugin.version instead of publishing new bytes under an existing tag");
-        assertThat(script).doesNotContain(
+        assertThat(script).contains(
                 "[switch]$Force",
                 "Remove-ExistingReleaseAssets",
                 "gh release delete-asset",
@@ -646,6 +646,7 @@ class PluginReleaseScriptsTest {
                 "Repo = $env:PLUGINS_REPO",
                 "OfficialKeyId = $env:PLUGIN_SIGNING_KEY_ID",
                 "PrivateKeyFile = $env:PLUGIN_SIGNING_PRIVATE_KEY_FILE",
+                "$publishArgs[\"Force\"] = $true",
                 ".\\scripts\\publish-plugin-releases.ps1 @publishArgs",
                 "-OfficialKeyId $env:PLUGIN_SIGNING_KEY_ID",
                 "-PrivateKeyFile $env:PLUGIN_SIGNING_PRIVATE_KEY_FILE",
@@ -654,7 +655,7 @@ class PluginReleaseScriptsTest {
                 "Cleanup plugin signing private key");
         assertThat(workflow).doesNotContain("tags:");
         assertThat(workflow).doesNotContain("schedule:");
-        assertThat(workflow).doesNotContain("publish_args", "PUBLISH_PLUGIN_ARGS", "[\"Force\"]");
+        assertThat(workflow).contains("publish_args", "PUBLISH_PLUGIN_ARGS", "[\"Force\"]");
         assertThat(workflow).doesNotContain("-----BEGIN PRIVATE KEY-----");
         assertThat(workflow).doesNotContain("\"-Repo\", $env:PLUGINS_REPO");
         assertThat(workflow).doesNotContain("\"-PrivateKeyFile\", $env:PLUGIN_SIGNING_PRIVATE_KEY_FILE");

--- a/scripts/publish-plugin-releases.ps1
+++ b/scripts/publish-plugin-releases.ps1
@@ -1,7 +1,8 @@
 <#
 .SYNOPSIS
     Per-plugin, version-gated build + publish / repair: for each official required or optional plugin, create the
-    GitHub Release when missing, or supplement missing checksum/signature companions from immutable artifact bytes.
+    GitHub Release when missing, supplement missing checksum/signature companions from immutable artifact bytes, or
+    force rebuild and replace release assets.
 
 .DESCRIPTION
     Version is the immutability key. For each plugin:
@@ -19,12 +20,18 @@
     The market manifest is generated separately (generate-market-manifest.ps1) from the published releases.
     ASCII source; runs under Windows PowerShell / pwsh. Needs gh + GH_TOKEN and Maven (mvnw / mvn).
 
+    With -Force/-f, every official plugin is rebuilt for the source plugin.version. Existing expected release
+    assets (artifact + .sha256 + .sig) are deleted before the freshly built files are uploaded, so a manual
+    repair can replace an already-published asset set without changing the release tag.
+
 .PARAMETER Repo
     owner/repo of the plugin distribution repository. Default Sywyar/PixivDownloader-plugins.
 
 .PARAMETER ProjectRoot
     Repo root. Default = parent of this script's dir.
 
+.PARAMETER Force
+    Rebuild every official plugin and replace existing expected release assets for the current plugin.version.
 #>
 [CmdletBinding()]
 param(
@@ -32,7 +39,9 @@ param(
     [string]$ProjectRoot,
     [string]$OfficialKeyId,
     [string]$PrivateKeyFile,
-    [string]$SignatureToolJar
+    [string]$SignatureToolJar,
+    [Alias("f")]
+    [switch]$Force
 )
 
 $ErrorActionPreference = "Stop"
@@ -240,6 +249,25 @@ function Upload-ReleaseAssetFiles {
     if ($LASTEXITCODE -ne 0) { throw "gh release upload failed for $Tag." }
 }
 
+function Remove-ExistingReleaseAssets {
+    param(
+        [Parameter(Mandatory = $true)][string]$Tag,
+        [Parameter(Mandatory = $true)][string[]]$AssetNames,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [string[]]$ExistingAssetNames
+    )
+
+    foreach ($assetName in $AssetNames) {
+        if ($ExistingAssetNames -notcontains $assetName) {
+            continue
+        }
+        Write-Host "==> Deleting existing asset $assetName from $Tag before force upload."
+        gh release delete-asset $Tag $assetName --repo $Repo --yes
+        if ($LASTEXITCODE -ne 0) { throw "gh release delete-asset failed for $Tag asset $assetName." }
+    }
+}
+
 $mvn = Get-MavenCommand $ProjectRoot
 $stageDir = Join-Path $ProjectRoot "build/release-plugins"
 New-Item -ItemType Directory -Force -Path $stageDir | Out-Null
@@ -255,6 +283,28 @@ foreach ($plugin in $plugins) {
     $expectedAssets = @($assetName, $shaAssetName, $sigAssetName)
     $release = Get-ReleaseAssetState $tag
     $assetNames = @($release.AssetNames)
+
+    if ($Force) {
+        if ($release.Exists) {
+            Write-Host "==> Force publishing $tag; rebuilding and replacing expected assets."
+        } else {
+            Write-Host "==> Force publishing $tag; release does not exist yet."
+        }
+
+        $stagedArtifact = Build-StagedPluginArtifact -Plugin $plugin -Version $version -AssetName $assetName
+        $companions = Write-StagedCompanionFiles -StagedArtifact $stagedArtifact -AssetName $assetName -Plugin $plugin -Version $version
+
+        if ($release.Exists) {
+            Remove-ExistingReleaseAssets -Tag $tag -AssetNames $expectedAssets -ExistingAssetNames $assetNames
+        } else {
+            gh release create $tag --repo $Repo --title $tag --notes "Plugin $($plugin.Id) $version"
+            if ($LASTEXITCODE -ne 0) { throw "gh release create failed for $tag." }
+        }
+
+        Upload-ReleaseAssetFiles -Tag $tag -Paths @($stagedArtifact, $companions.ShaFile, $companions.SigFile)
+        $published += "$tag (forced)"
+        continue
+    }
 
     if ($release.Exists) {
         $missingAssets = @($expectedAssets | Where-Object { $assetNames -notcontains $_ })


### PR DESCRIPTION
- 恢复 workflow_call / workflow_dispatch 的 publish_args 输入与 -f / -Force 参数校验透传，手动触发可强制重编译并覆盖上传所有插件资产
- publish-plugin-releases.ps1 恢复 Force 分支与远端资产删除（gh release delete-asset）后重新上传
- 保留已存在发布缺主 artifact 时 fail closed 要求提升版本的硬化行为
