### PR TITLE
fix(i18n): 加固 verifier 单调合同并建立 Epoch 3 接入桥

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -127,23 +127,25 @@ jobs:
                   base="${{ github.event.merge_group.base_sha }}"
                   ;;
                 push)
-                  before="${{ github.event.before }}"
-                  if [ -n "$before" ] && [ "$before" != "$zero" ] \
-                      && git rev-parse --verify --quiet "$before^{commit}" >/dev/null 2>&1; then
-                    base="$before"
-                  else
-                    # 新分支（before 全零）：不伪装成「默认分支 tip → candidate」。
-                    # fork base = merge-base(candidate, protected default branch)；
-                    # 随后统一验证 root <= forkBase < candidate。
-                    default_branch="${{ github.event.repository.default_branch }}"
-                    if ! git fetch -q origin "refs/heads/$default_branch" 2>/dev/null; then
-                      echo "warning: cannot fetch the default branch; continuing (may fail closed later)" >&2
-                    fi
-                    default_tip="$(git rev-parse --verify --quiet "refs/remotes/origin/$default_branch" 2>/dev/null || printf '%s' '')"
-                    if [ -z "$default_tip" ]; then
-                      echo "cannot resolve the protected default branch remote ref for a new branch; fail closed" >&2
+                  default_branch="${{ github.event.repository.default_branch }}"
+                  if ! git fetch -q origin "refs/heads/$default_branch:refs/remotes/origin/$default_branch" 2>/dev/null; then
+                    echo "warning: cannot fetch the protected default branch; continuing (may fail closed later)" >&2
+                  fi
+                  default_tip="$(git rev-parse --verify --quiet "refs/remotes/origin/$default_branch" 2>/dev/null || printf '%s' '')"
+                  if [ -z "$default_tip" ]; then
+                    echo "cannot resolve the protected default branch remote ref; fail closed" >&2
+                    exit 1
+                  fi
+                  if [ "$GITHUB_REF" = "refs/heads/$default_branch" ]; then
+                    before="${{ github.event.before }}"
+                    if [ -z "$before" ] || [ "$before" = "$zero" ] \
+                        || ! git rev-parse --verify --quiet "$before^{commit}" >/dev/null 2>&1; then
+                      echo "protected branch push has no valid event.before; fail closed" >&2
                       exit 1
                     fi
+                    base="$before"
+                  else
+                    # Feature branch event.before is not trusted: it may be a previously failed verifier.
                     fork_base="$(git merge-base "$GITHUB_SHA" "$default_tip" 2>/dev/null || printf '%s' '')"
                     if ! [[ "$fork_base" =~ ^[0-9a-f]{40}$ ]]; then
                       echo "cannot determine a fork base between the candidate and the protected default branch; fail closed" >&2
@@ -182,37 +184,64 @@ jobs:
               exit 1
             fi
             if ! git merge-base --is-ancestor "$base" "$GITHUB_SHA" >/dev/null 2>&1; then
-              echo "trusted base $base is not an ancestor of the candidate $GITHUB_SHA; sibling / unrelated / descendant / pre-root trusted bases are refused; fail closed" >&2
+              echo "signature-guard trusted base $base is not an ancestor of candidate $GITHUB_SHA; fail closed" >&2
               exit 1
+            fi
+            default_branch="${{ github.event.repository.default_branch }}"
+            if ! git fetch -q origin "refs/heads/$default_branch:refs/remotes/origin/$default_branch" 2>/dev/null; then
+              echo "warning: cannot fetch the protected default branch; continuing (will fail closed if unavailable)" >&2
+            fi
+            default_tip="$(git rev-parse --verify --quiet "refs/remotes/origin/$default_branch" 2>/dev/null || printf '%s' '')"
+            if [ -z "$default_tip" ] || ! git merge-base --is-ancestor "$base" "$default_tip" >/dev/null 2>&1; then
+              echo "trusted base $base is not in the protected default branch history; fail closed" >&2
+              exit 1
+            fi
+            if [ -n "${{ inputs.trusted_base_sha }}" ]; then
+              if [ "$default_tip" = "$GITHUB_SHA" ]; then
+                protected_predecessor="$(git rev-parse --verify --quiet "$GITHUB_SHA^{commit}^" 2>/dev/null || printf '%s' '')"
+              else
+                protected_predecessor="$(git merge-base "$GITHUB_SHA" "$default_tip" 2>/dev/null || printf '%s' '')"
+              fi
+              if [ -z "$protected_predecessor" ] || [ "$base" != "$protected_predecessor" ]; then
+                echo "explicit trusted_base_sha $base is not the protected predecessor $protected_predecessor; fail closed" >&2
+                exit 1
+              fi
             fi
           else
             base="$root"
             echo "ROOT ADMISSION MODE: candidate is the Gate Epoch 2 trust root candidate; running the root gate with the full root self-protection suite." >&2
-          # 当前 verifier baseline：trusted base（或 ROOT_ADMISSION root candidate）必须携带
-          # gate-policy.json 且 contractVersion >= 4 / schemaVersion >= 3 / verifier 本体齐全；
-          # 旧 verifier 无资格审核新标准候选（verifier rollback 拒绝）→ FAIL CLOSED
+          fi
+          # Candidate policy proposes the next monotonic minimum. The protected predecessor must
+          # satisfy it before any verifier code is materialized or executed.
+          minimum_json="$(node -e 'const fs=require("fs"),p=JSON.parse(fs.readFileSync("scripts/i18n/gate-policy.json","utf8")),m=p.minimumTrustedVerifier;if(!m||!Number.isInteger(m.contractVersion)||m.contractVersion<1||!Number.isInteger(m.schemaVersion)||m.schemaVersion<1||!Array.isArray(m.requiredFiles)||!m.requiredFiles.length||m.requiredFiles.some(r=>typeof r!=="string"||!r||r.startsWith("/")||r.includes("\\")||r.split("/").includes("..")))process.exit(1);process.stdout.write(JSON.stringify(m))' 2>/dev/null || printf '%s' '')"
+          if [ -z "$minimum_json" ]; then
+            echo "candidate gate-policy.json has no valid minimumTrustedVerifier; fail closed" >&2
+            exit 1
+          fi
           base_policy="$(git show "$base:scripts/i18n/gate-policy.json" 2>/dev/null || printf '%s' '')"
           if [ -z "$base_policy" ]; then
-            echo "trusted base $base has no gate-policy.json; it does not satisfy the current Gate Epoch 2 verifier baseline; fail closed" >&2
+            echo "trusted base $base has no gate-policy.json; fail closed" >&2
             exit 1
           fi
-          base_contract="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(typeof j.contractVersion==="number"?String(j.contractVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
-          base_schema="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(typeof j.schemaVersion==="number"?String(j.schemaVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
-          if ! [[ "$base_contract" =~ ^[0-9]+$ ]] || [ "$base_contract" -lt 4 ]; then
-            echo "trusted base $base contractVersion ($base_contract) is below the current minimum 4; verifier rollback is refused; fail closed" >&2
+          base_contract="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(Number.isInteger(j.contractVersion)?String(j.contractVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
+          base_schema="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(Number.isInteger(j.schemaVersion)?String(j.schemaVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
+          minimum_contract="$(node -e 'process.stdout.write(String(JSON.parse(process.argv[1]).contractVersion))' "$minimum_json")"
+          minimum_schema="$(node -e 'process.stdout.write(String(JSON.parse(process.argv[1]).schemaVersion))' "$minimum_json")"
+          if ! [[ "$base_contract" =~ ^[0-9]+$ ]] || [ "$base_contract" -lt "$minimum_contract" ]; then
+            echo "trusted base $base contractVersion ($base_contract) is below minimumTrustedVerifier $minimum_contract; verifier rollback is refused; fail closed" >&2
             exit 1
           fi
-          if ! [[ "$base_schema" =~ ^[0-9]+$ ]] || [ "$base_schema" -lt 3 ]; then
-            echo "trusted base $base schemaVersion ($base_schema) is below the current minimum 3; fail closed" >&2
+          if ! [[ "$base_schema" =~ ^[0-9]+$ ]] || [ "$base_schema" -lt "$minimum_schema" ]; then
+            echo "trusted base $base schemaVersion ($base_schema) is below minimumTrustedVerifier $minimum_schema; fail closed" >&2
             exit 1
           fi
-          for rel in scripts/ci/gate-surface.json scripts/ci/gate-invariants.json scripts/ci/gate-parity.mjs scripts/ci/resolve-trusted-base.mjs scripts/ci/materialize-trusted-gate.sh scripts/ci/doctor-github-ruleset.mjs; do
-            if ! git cat-file -e "$base:$rel" >/dev/null 2>&1; then
-              echo "trusted base $base is missing $rel; it does not satisfy the current Gate Epoch 2 verifier baseline; fail closed" >&2
+          minimum_files="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).requiredFiles.join("\n"))' "$minimum_json")"
+          while IFS= read -r rel; do
+            if [ -z "$rel" ] || ! git cat-file -e "$base:$rel" >/dev/null 2>&1; then
+              echo "trusted base $base is missing minimumTrustedVerifier file $rel; fail closed" >&2
               exit 1
             fi
-          done
-          fi
+          done <<< "$minimum_files"
           # 物化 trusted gate bundle（checkout-index --stdin 必须显式提供 < paths-file）
           gate="$RUNNER_TEMP/gate"
           paths_file="$gate/paths.txt"
@@ -254,7 +283,7 @@ jobs:
           # 与 trusted helper 交叉验证（helper 来自 trusted base；候选不能自我批准）
           if [ -f "$out/scripts/ci/resolve-trusted-base.mjs" ]; then
             helper="$(node "$out/scripts/ci/resolve-trusted-base.mjs" \
-              --repo-root "$PWD" --event-name "$GITHUB_EVENT_NAME" --candidate "$GITHUB_SHA" \
+              --repo-root "$PWD" --event-name "$GITHUB_EVENT_NAME" --candidate "$GITHUB_SHA" --ref "$GITHUB_REF" \
               --before "${{ github.event.before }}" \
               --pr-base "${{ github.event.pull_request.base.sha }}" \
               --merge-group-base "${{ github.event.merge_group.base_sha }}" \
@@ -409,23 +438,25 @@ jobs:
                   base="${{ github.event.merge_group.base_sha }}"
                   ;;
                 push)
-                  before="${{ github.event.before }}"
-                  if [ -n "$before" ] && [ "$before" != "$zero" ] \
-                      && git rev-parse --verify --quiet "$before^{commit}" >/dev/null 2>&1; then
-                    base="$before"
-                  else
-                    # 新分支（before 全零）：不伪装成「默认分支 tip → candidate」。
-                    # fork base = merge-base(candidate, protected default branch)；
-                    # 随后统一验证 root <= forkBase < candidate。
-                    default_branch="${{ github.event.repository.default_branch }}"
-                    if ! git fetch -q origin "refs/heads/$default_branch" 2>/dev/null; then
-                      echo "warning: cannot fetch the default branch; continuing (may fail closed later)" >&2
-                    fi
-                    default_tip="$(git rev-parse --verify --quiet "refs/remotes/origin/$default_branch" 2>/dev/null || printf '%s' '')"
-                    if [ -z "$default_tip" ]; then
-                      echo "cannot resolve the protected default branch remote ref for a new branch; fail closed" >&2
+                  default_branch="${{ github.event.repository.default_branch }}"
+                  if ! git fetch -q origin "refs/heads/$default_branch:refs/remotes/origin/$default_branch" 2>/dev/null; then
+                    echo "warning: cannot fetch the protected default branch; continuing (may fail closed later)" >&2
+                  fi
+                  default_tip="$(git rev-parse --verify --quiet "refs/remotes/origin/$default_branch" 2>/dev/null || printf '%s' '')"
+                  if [ -z "$default_tip" ]; then
+                    echo "cannot resolve the protected default branch remote ref; fail closed" >&2
+                    exit 1
+                  fi
+                  if [ "$GITHUB_REF" = "refs/heads/$default_branch" ]; then
+                    before="${{ github.event.before }}"
+                    if [ -z "$before" ] || [ "$before" = "$zero" ] \
+                        || ! git rev-parse --verify --quiet "$before^{commit}" >/dev/null 2>&1; then
+                      echo "protected branch push has no valid event.before; fail closed" >&2
                       exit 1
                     fi
+                    base="$before"
+                  else
+                    # Feature branch event.before is not trusted: it may be a previously failed verifier.
                     fork_base="$(git merge-base "$GITHUB_SHA" "$default_tip" 2>/dev/null || printf '%s' '')"
                     if ! [[ "$fork_base" =~ ^[0-9a-f]{40}$ ]]; then
                       echo "cannot determine a fork base between the candidate and the protected default branch; fail closed" >&2
@@ -464,37 +495,64 @@ jobs:
               exit 1
             fi
             if ! git merge-base --is-ancestor "$base" "$GITHUB_SHA" >/dev/null 2>&1; then
-              echo "trusted base $base is not an ancestor of the candidate $GITHUB_SHA; sibling / unrelated / descendant / pre-root trusted bases are refused; fail closed" >&2
+              echo "trusted-gate-contract base $base is not an ancestor of candidate $GITHUB_SHA; fail closed" >&2
               exit 1
+            fi
+            default_branch="${{ github.event.repository.default_branch }}"
+            if ! git fetch -q origin "refs/heads/$default_branch:refs/remotes/origin/$default_branch" 2>/dev/null; then
+              echo "warning: cannot fetch the protected default branch; continuing (will fail closed if unavailable)" >&2
+            fi
+            default_tip="$(git rev-parse --verify --quiet "refs/remotes/origin/$default_branch" 2>/dev/null || printf '%s' '')"
+            if [ -z "$default_tip" ] || ! git merge-base --is-ancestor "$base" "$default_tip" >/dev/null 2>&1; then
+              echo "trusted base $base is not in the protected default branch history; fail closed" >&2
+              exit 1
+            fi
+            if [ -n "${{ inputs.trusted_base_sha }}" ]; then
+              if [ "$default_tip" = "$GITHUB_SHA" ]; then
+                protected_predecessor="$(git rev-parse --verify --quiet "$GITHUB_SHA^{commit}^" 2>/dev/null || printf '%s' '')"
+              else
+                protected_predecessor="$(git merge-base "$GITHUB_SHA" "$default_tip" 2>/dev/null || printf '%s' '')"
+              fi
+              if [ -z "$protected_predecessor" ] || [ "$base" != "$protected_predecessor" ]; then
+                echo "explicit trusted_base_sha $base is not the protected predecessor $protected_predecessor; fail closed" >&2
+                exit 1
+              fi
             fi
           else
             base="$root"
             echo "ROOT ADMISSION MODE: candidate is the Gate Epoch 2 trust root candidate; running the root gate with the full root self-protection suite." >&2
-          # 当前 verifier baseline：trusted base（或 ROOT_ADMISSION root candidate）必须携带
-          # gate-policy.json 且 contractVersion >= 4 / schemaVersion >= 3 / verifier 本体齐全；
-          # 旧 verifier 无资格审核新标准候选（verifier rollback 拒绝）→ FAIL CLOSED
+          fi
+          # Candidate policy proposes the next monotonic minimum. The protected predecessor must
+          # satisfy it before any verifier code is materialized or executed.
+          minimum_json="$(node -e 'const fs=require("fs"),p=JSON.parse(fs.readFileSync("scripts/i18n/gate-policy.json","utf8")),m=p.minimumTrustedVerifier;if(!m||!Number.isInteger(m.contractVersion)||m.contractVersion<1||!Number.isInteger(m.schemaVersion)||m.schemaVersion<1||!Array.isArray(m.requiredFiles)||!m.requiredFiles.length||m.requiredFiles.some(r=>typeof r!=="string"||!r||r.startsWith("/")||r.includes("\\")||r.split("/").includes("..")))process.exit(1);process.stdout.write(JSON.stringify(m))' 2>/dev/null || printf '%s' '')"
+          if [ -z "$minimum_json" ]; then
+            echo "candidate gate-policy.json has no valid minimumTrustedVerifier; fail closed" >&2
+            exit 1
+          fi
           base_policy="$(git show "$base:scripts/i18n/gate-policy.json" 2>/dev/null || printf '%s' '')"
           if [ -z "$base_policy" ]; then
-            echo "trusted base $base has no gate-policy.json; it does not satisfy the current Gate Epoch 2 verifier baseline; fail closed" >&2
+            echo "trusted base $base has no gate-policy.json; fail closed" >&2
             exit 1
           fi
-          base_contract="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(typeof j.contractVersion==="number"?String(j.contractVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
-          base_schema="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(typeof j.schemaVersion==="number"?String(j.schemaVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
-          if ! [[ "$base_contract" =~ ^[0-9]+$ ]] || [ "$base_contract" -lt 4 ]; then
-            echo "trusted base $base contractVersion ($base_contract) is below the current minimum 4; verifier rollback is refused; fail closed" >&2
+          base_contract="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(Number.isInteger(j.contractVersion)?String(j.contractVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
+          base_schema="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(Number.isInteger(j.schemaVersion)?String(j.schemaVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
+          minimum_contract="$(node -e 'process.stdout.write(String(JSON.parse(process.argv[1]).contractVersion))' "$minimum_json")"
+          minimum_schema="$(node -e 'process.stdout.write(String(JSON.parse(process.argv[1]).schemaVersion))' "$minimum_json")"
+          if ! [[ "$base_contract" =~ ^[0-9]+$ ]] || [ "$base_contract" -lt "$minimum_contract" ]; then
+            echo "trusted base $base contractVersion ($base_contract) is below minimumTrustedVerifier $minimum_contract; verifier rollback is refused; fail closed" >&2
             exit 1
           fi
-          if ! [[ "$base_schema" =~ ^[0-9]+$ ]] || [ "$base_schema" -lt 3 ]; then
-            echo "trusted base $base schemaVersion ($base_schema) is below the current minimum 3; fail closed" >&2
+          if ! [[ "$base_schema" =~ ^[0-9]+$ ]] || [ "$base_schema" -lt "$minimum_schema" ]; then
+            echo "trusted base $base schemaVersion ($base_schema) is below minimumTrustedVerifier $minimum_schema; fail closed" >&2
             exit 1
           fi
-          for rel in scripts/ci/gate-surface.json scripts/ci/gate-invariants.json scripts/ci/gate-parity.mjs scripts/ci/resolve-trusted-base.mjs scripts/ci/materialize-trusted-gate.sh scripts/ci/doctor-github-ruleset.mjs; do
-            if ! git cat-file -e "$base:$rel" >/dev/null 2>&1; then
-              echo "trusted base $base is missing $rel; it does not satisfy the current Gate Epoch 2 verifier baseline; fail closed" >&2
+          minimum_files="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).requiredFiles.join("\n"))' "$minimum_json")"
+          while IFS= read -r rel; do
+            if [ -z "$rel" ] || ! git cat-file -e "$base:$rel" >/dev/null 2>&1; then
+              echo "trusted base $base is missing minimumTrustedVerifier file $rel; fail closed" >&2
               exit 1
             fi
-          done
-          fi
+          done <<< "$minimum_files"
           gate="$RUNNER_TEMP/gate"
           paths_file="$gate/paths.txt"
           index_file="$gate/index"
@@ -534,7 +592,7 @@ jobs:
           }
           if [ -f "$out/scripts/ci/resolve-trusted-base.mjs" ]; then
             helper="$(node "$out/scripts/ci/resolve-trusted-base.mjs" \
-              --repo-root "$PWD" --event-name "$GITHUB_EVENT_NAME" --candidate "$GITHUB_SHA" \
+              --repo-root "$PWD" --event-name "$GITHUB_EVENT_NAME" --candidate "$GITHUB_SHA" --ref "$GITHUB_REF" \
               --before "${{ github.event.before }}" \
               --pr-base "${{ github.event.pull_request.base.sha }}" \
               --merge-group-base "${{ github.event.merge_group.base_sha }}" \
@@ -625,8 +683,8 @@ jobs:
           echo "  - Do NOT allow bypassing branch protection."
           echo "  - Configure Quality Gate jobs (java-tests, javascript-tests, signature-guard,"
           echo "    trusted-gate-contract, i18n-check) as required checks."
-          echo "  - Configure 'Shared Snippet Drift Check / check-shared-snippets' as a required"
-          echo "    external check (strict required status checks, no permanent always bypass)."
+          echo "  - Configure 'check-shared-snippets' as a required external check"
+          echo "    (strict required status checks, no bypass actors)."
           echo "  - Create the annotated tag i18n-gate-epoch-2-root at the reviewed Epoch 2 root"
           echo "    commit and protect it with a Ruleset (no delete, no force update, no bypass)."
           echo "  - Gate surface (.github/workflows/quality-gate.yml, shared-snippets-check.yml,"
@@ -714,23 +772,25 @@ jobs:
                   base="${{ github.event.merge_group.base_sha }}"
                   ;;
                 push)
-                  before="${{ github.event.before }}"
-                  if [ -n "$before" ] && [ "$before" != "$zero" ] \
-                      && git rev-parse --verify --quiet "$before^{commit}" >/dev/null 2>&1; then
-                    base="$before"
-                  else
-                    # 新分支（before 全零）：不伪装成「默认分支 tip → candidate」。
-                    # fork base = merge-base(candidate, protected default branch)；
-                    # 随后统一验证 root <= forkBase < candidate。
-                    default_branch="${{ github.event.repository.default_branch }}"
-                    if ! git fetch -q origin "refs/heads/$default_branch" 2>/dev/null; then
-                      echo "warning: cannot fetch the default branch; continuing (may fail closed later)" >&2
-                    fi
-                    default_tip="$(git rev-parse --verify --quiet "refs/remotes/origin/$default_branch" 2>/dev/null || printf '%s' '')"
-                    if [ -z "$default_tip" ]; then
-                      echo "cannot resolve the protected default branch remote ref for a new branch; fail closed" >&2
+                  default_branch="${{ github.event.repository.default_branch }}"
+                  if ! git fetch -q origin "refs/heads/$default_branch:refs/remotes/origin/$default_branch" 2>/dev/null; then
+                    echo "warning: cannot fetch the protected default branch; continuing (may fail closed later)" >&2
+                  fi
+                  default_tip="$(git rev-parse --verify --quiet "refs/remotes/origin/$default_branch" 2>/dev/null || printf '%s' '')"
+                  if [ -z "$default_tip" ]; then
+                    echo "cannot resolve the protected default branch remote ref; fail closed" >&2
+                    exit 1
+                  fi
+                  if [ "$GITHUB_REF" = "refs/heads/$default_branch" ]; then
+                    before="${{ github.event.before }}"
+                    if [ -z "$before" ] || [ "$before" = "$zero" ] \
+                        || ! git rev-parse --verify --quiet "$before^{commit}" >/dev/null 2>&1; then
+                      echo "protected branch push has no valid event.before; fail closed" >&2
                       exit 1
                     fi
+                    base="$before"
+                  else
+                    # Feature branch event.before is not trusted: it may be a previously failed verifier.
                     fork_base="$(git merge-base "$GITHUB_SHA" "$default_tip" 2>/dev/null || printf '%s' '')"
                     if ! [[ "$fork_base" =~ ^[0-9a-f]{40}$ ]]; then
                       echo "cannot determine a fork base between the candidate and the protected default branch; fail closed" >&2
@@ -772,34 +832,61 @@ jobs:
               echo "trusted base $base is not an ancestor of the candidate $GITHUB_SHA; sibling / unrelated / descendant / pre-root trusted bases are refused; fail closed" >&2
               exit 1
             fi
+            default_branch="${{ github.event.repository.default_branch }}"
+            if ! git fetch -q origin "refs/heads/$default_branch:refs/remotes/origin/$default_branch" 2>/dev/null; then
+              echo "warning: cannot fetch the protected default branch; continuing (will fail closed if unavailable)" >&2
+            fi
+            default_tip="$(git rev-parse --verify --quiet "refs/remotes/origin/$default_branch" 2>/dev/null || printf '%s' '')"
+            if [ -z "$default_tip" ] || ! git merge-base --is-ancestor "$base" "$default_tip" >/dev/null 2>&1; then
+              echo "trusted base $base is not in the protected default branch history; fail closed" >&2
+              exit 1
+            fi
+            if [ -n "${{ inputs.trusted_base_sha }}" ]; then
+              if [ "$default_tip" = "$GITHUB_SHA" ]; then
+                protected_predecessor="$(git rev-parse --verify --quiet "$GITHUB_SHA^{commit}^" 2>/dev/null || printf '%s' '')"
+              else
+                protected_predecessor="$(git merge-base "$GITHUB_SHA" "$default_tip" 2>/dev/null || printf '%s' '')"
+              fi
+              if [ -z "$protected_predecessor" ] || [ "$base" != "$protected_predecessor" ]; then
+                echo "explicit trusted_base_sha $base is not the protected predecessor $protected_predecessor; fail closed" >&2
+                exit 1
+              fi
+            fi
           else
             base="$root"
             echo "ROOT ADMISSION MODE: candidate is the Gate Epoch 2 trust root candidate; running the root gate with the full root self-protection suite." >&2
-          # 当前 verifier baseline：trusted base（或 ROOT_ADMISSION root candidate）必须携带
-          # gate-policy.json 且 contractVersion >= 4 / schemaVersion >= 3 / verifier 本体齐全；
-          # 旧 verifier 无资格审核新标准候选（verifier rollback 拒绝）→ FAIL CLOSED
+          fi
+          # Candidate policy proposes the next monotonic minimum. The protected predecessor must
+          # satisfy it before any verifier code is materialized or executed.
+          minimum_json="$(node -e 'const fs=require("fs"),p=JSON.parse(fs.readFileSync("scripts/i18n/gate-policy.json","utf8")),m=p.minimumTrustedVerifier;if(!m||!Number.isInteger(m.contractVersion)||m.contractVersion<1||!Number.isInteger(m.schemaVersion)||m.schemaVersion<1||!Array.isArray(m.requiredFiles)||!m.requiredFiles.length||m.requiredFiles.some(r=>typeof r!=="string"||!r||r.startsWith("/")||r.includes("\\")||r.split("/").includes("..")))process.exit(1);process.stdout.write(JSON.stringify(m))' 2>/dev/null || printf '%s' '')"
+          if [ -z "$minimum_json" ]; then
+            echo "candidate gate-policy.json has no valid minimumTrustedVerifier; fail closed" >&2
+            exit 1
+          fi
           base_policy="$(git show "$base:scripts/i18n/gate-policy.json" 2>/dev/null || printf '%s' '')"
           if [ -z "$base_policy" ]; then
-            echo "trusted base $base has no gate-policy.json; it does not satisfy the current Gate Epoch 2 verifier baseline; fail closed" >&2
+            echo "trusted base $base has no gate-policy.json; fail closed" >&2
             exit 1
           fi
-          base_contract="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(typeof j.contractVersion==="number"?String(j.contractVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
-          base_schema="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(typeof j.schemaVersion==="number"?String(j.schemaVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
-          if ! [[ "$base_contract" =~ ^[0-9]+$ ]] || [ "$base_contract" -lt 4 ]; then
-            echo "trusted base $base contractVersion ($base_contract) is below the current minimum 4; verifier rollback is refused; fail closed" >&2
+          base_contract="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(Number.isInteger(j.contractVersion)?String(j.contractVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
+          base_schema="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(Number.isInteger(j.schemaVersion)?String(j.schemaVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
+          minimum_contract="$(node -e 'process.stdout.write(String(JSON.parse(process.argv[1]).contractVersion))' "$minimum_json")"
+          minimum_schema="$(node -e 'process.stdout.write(String(JSON.parse(process.argv[1]).schemaVersion))' "$minimum_json")"
+          if ! [[ "$base_contract" =~ ^[0-9]+$ ]] || [ "$base_contract" -lt "$minimum_contract" ]; then
+            echo "trusted base $base contractVersion ($base_contract) is below minimumTrustedVerifier $minimum_contract; verifier rollback is refused; fail closed" >&2
             exit 1
           fi
-          if ! [[ "$base_schema" =~ ^[0-9]+$ ]] || [ "$base_schema" -lt 3 ]; then
-            echo "trusted base $base schemaVersion ($base_schema) is below the current minimum 3; fail closed" >&2
+          if ! [[ "$base_schema" =~ ^[0-9]+$ ]] || [ "$base_schema" -lt "$minimum_schema" ]; then
+            echo "trusted base $base schemaVersion ($base_schema) is below minimumTrustedVerifier $minimum_schema; fail closed" >&2
             exit 1
           fi
-          for rel in scripts/ci/gate-surface.json scripts/ci/gate-invariants.json scripts/ci/gate-parity.mjs scripts/ci/resolve-trusted-base.mjs scripts/ci/materialize-trusted-gate.sh scripts/ci/doctor-github-ruleset.mjs; do
-            if ! git cat-file -e "$base:$rel" >/dev/null 2>&1; then
-              echo "trusted base $base is missing $rel; it does not satisfy the current Gate Epoch 2 verifier baseline; fail closed" >&2
+          minimum_files="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).requiredFiles.join("\n"))' "$minimum_json")"
+          while IFS= read -r rel; do
+            if [ -z "$rel" ] || ! git cat-file -e "$base:$rel" >/dev/null 2>&1; then
+              echo "trusted base $base is missing minimumTrustedVerifier file $rel; fail closed" >&2
               exit 1
             fi
-          done
-          fi
+          done <<< "$minimum_files"
           gate="$RUNNER_TEMP/gate"
           paths_file="$gate/paths.txt"
           index_file="$gate/index"
@@ -839,7 +926,7 @@ jobs:
           }
           if [ -f "$out/scripts/ci/resolve-trusted-base.mjs" ]; then
             helper="$(node "$out/scripts/ci/resolve-trusted-base.mjs" \
-              --repo-root "$PWD" --event-name "$GITHUB_EVENT_NAME" --candidate "$GITHUB_SHA" \
+              --repo-root "$PWD" --event-name "$GITHUB_EVENT_NAME" --candidate "$GITHUB_SHA" --ref "$GITHUB_REF" \
               --before "${{ github.event.before }}" \
               --pr-base "${{ github.event.pull_request.base.sha }}" \
               --merge-group-base "${{ github.event.merge_group.base_sha }}" \

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -2,7 +2,9 @@ name: Quality Gate
 
 on:
   push:
-    branches: [master]
+    # 任意代码分支 push 都触发完整 Quality Gate（不再限定 master）；
+    # gh-pages 是纯文档分支，历史不包含 Epoch 2 root，触发只会确定性失败，因此排除
+    branches-ignore: [gh-pages]
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -212,6 +212,7 @@ jobs:
               exit 1
             fi
           done
+          fi
           # 物化 trusted gate bundle（checkout-index --stdin 必须显式提供 < paths-file）
           gate="$RUNNER_TEMP/gate"
           paths_file="$gate/paths.txt"
@@ -493,6 +494,7 @@ jobs:
               exit 1
             fi
           done
+          fi
           gate="$RUNNER_TEMP/gate"
           paths_file="$gate/paths.txt"
           index_file="$gate/index"
@@ -797,6 +799,7 @@ jobs:
               exit 1
             fi
           done
+          fi
           gate="$RUNNER_TEMP/gate"
           paths_file="$gate/paths.txt"
           index_file="$gate/index"

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -73,7 +73,8 @@ jobs:
       # - candidate == root → ROOT_ADMISSION（root 自身 gate + 全量 root self-protection）；
       # - candidate 是 root 后代 → NORMAL：trusted base 优先级 = inputs.trusted_base_sha
       #   （reusable workflow 的 github.event_name 是调用方原始 event，不能依赖它）→
-      #   pull_request base.sha / merge_group base_sha / push event.before（全零则默认分支远端）/
+      #   pull_request base.sha / merge_group base_sha / protected push event.before /
+      #   other push merge-base(candidate, protected default branch) /
       #   workflow_dispatch 默认分支远端；base 必须 != candidate、必须包含 Epoch 2 root；
       # - 其它 candidate（不包含 root）→ fail closed，不尝试任何 v1 / legacy / transition 路径；
       # - 物化路径含 package-lock.json；物化结果与 trusted helper
@@ -282,9 +283,15 @@ jobs:
           }
           # 与 trusted helper 交叉验证（helper 来自 trusted base；候选不能自我批准）
           if [ -f "$out/scripts/ci/resolve-trusted-base.mjs" ]; then
+            helper_default_branch="${{ github.event.repository.default_branch }}"
+            helper_before="${{ github.event.before }}"
+            if [ "$GITHUB_EVENT_NAME" = "push" ] \
+                && [ "$GITHUB_REF" != "refs/heads/$helper_default_branch" ]; then
+              helper_before="$zero"
+            fi
             helper="$(node "$out/scripts/ci/resolve-trusted-base.mjs" \
-              --repo-root "$PWD" --event-name "$GITHUB_EVENT_NAME" --candidate "$GITHUB_SHA" --ref "$GITHUB_REF" \
-              --before "${{ github.event.before }}" \
+              --repo-root "$PWD" --event-name "$GITHUB_EVENT_NAME" --candidate "$GITHUB_SHA" \
+              --before "$helper_before" \
               --pr-base "${{ github.event.pull_request.base.sha }}" \
               --merge-group-base "${{ github.event.merge_group.base_sha }}" \
               --input-base "${{ inputs.trusted_base_sha }}" \
@@ -591,9 +598,15 @@ jobs:
             exit 1
           }
           if [ -f "$out/scripts/ci/resolve-trusted-base.mjs" ]; then
+            helper_default_branch="${{ github.event.repository.default_branch }}"
+            helper_before="${{ github.event.before }}"
+            if [ "$GITHUB_EVENT_NAME" = "push" ] \
+                && [ "$GITHUB_REF" != "refs/heads/$helper_default_branch" ]; then
+              helper_before="$zero"
+            fi
             helper="$(node "$out/scripts/ci/resolve-trusted-base.mjs" \
-              --repo-root "$PWD" --event-name "$GITHUB_EVENT_NAME" --candidate "$GITHUB_SHA" --ref "$GITHUB_REF" \
-              --before "${{ github.event.before }}" \
+              --repo-root "$PWD" --event-name "$GITHUB_EVENT_NAME" --candidate "$GITHUB_SHA" \
+              --before "$helper_before" \
               --pr-base "${{ github.event.pull_request.base.sha }}" \
               --merge-group-base "${{ github.event.merge_group.base_sha }}" \
               --input-base "${{ inputs.trusted_base_sha }}" \
@@ -925,9 +938,15 @@ jobs:
             exit 1
           }
           if [ -f "$out/scripts/ci/resolve-trusted-base.mjs" ]; then
+            helper_default_branch="${{ github.event.repository.default_branch }}"
+            helper_before="${{ github.event.before }}"
+            if [ "$GITHUB_EVENT_NAME" = "push" ] \
+                && [ "$GITHUB_REF" != "refs/heads/$helper_default_branch" ]; then
+              helper_before="$zero"
+            fi
             helper="$(node "$out/scripts/ci/resolve-trusted-base.mjs" \
-              --repo-root "$PWD" --event-name "$GITHUB_EVENT_NAME" --candidate "$GITHUB_SHA" --ref "$GITHUB_REF" \
-              --before "${{ github.event.before }}" \
+              --repo-root "$PWD" --event-name "$GITHUB_EVENT_NAME" --candidate "$GITHUB_SHA" \
+              --before "$helper_before" \
               --pr-base "${{ github.event.pull_request.base.sha }}" \
               --merge-group-base "${{ github.event.merge_group.base_sha }}" \
               --input-base "${{ inputs.trusted_base_sha }}" \

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -186,7 +186,30 @@ jobs:
           else
             base="$root"
             echo "ROOT ADMISSION MODE: candidate is the Gate Epoch 2 trust root candidate; running the root gate with the full root self-protection suite." >&2
+          # 当前 verifier baseline：trusted base（或 ROOT_ADMISSION root candidate）必须携带
+          # gate-policy.json 且 contractVersion >= 4 / schemaVersion >= 3 / verifier 本体齐全；
+          # 旧 verifier 无资格审核新标准候选（verifier rollback 拒绝）→ FAIL CLOSED
+          base_policy="$(git show "$base:scripts/i18n/gate-policy.json" 2>/dev/null || printf '%s' '')"
+          if [ -z "$base_policy" ]; then
+            echo "trusted base $base has no gate-policy.json; it does not satisfy the current Gate Epoch 2 verifier baseline; fail closed" >&2
+            exit 1
           fi
+          base_contract="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(typeof j.contractVersion==="number"?String(j.contractVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
+          base_schema="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(typeof j.schemaVersion==="number"?String(j.schemaVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
+          if ! [[ "$base_contract" =~ ^[0-9]+$ ]] || [ "$base_contract" -lt 4 ]; then
+            echo "trusted base $base contractVersion ($base_contract) is below the current minimum 4; verifier rollback is refused; fail closed" >&2
+            exit 1
+          fi
+          if ! [[ "$base_schema" =~ ^[0-9]+$ ]] || [ "$base_schema" -lt 3 ]; then
+            echo "trusted base $base schemaVersion ($base_schema) is below the current minimum 3; fail closed" >&2
+            exit 1
+          fi
+          for rel in scripts/ci/gate-surface.json scripts/ci/gate-invariants.json scripts/ci/gate-parity.mjs scripts/ci/resolve-trusted-base.mjs scripts/ci/materialize-trusted-gate.sh scripts/ci/doctor-github-ruleset.mjs; do
+            if ! git cat-file -e "$base:$rel" >/dev/null 2>&1; then
+              echo "trusted base $base is missing $rel; it does not satisfy the current Gate Epoch 2 verifier baseline; fail closed" >&2
+              exit 1
+            fi
+          done
           # 物化 trusted gate bundle（checkout-index --stdin 必须显式提供 < paths-file）
           gate="$RUNNER_TEMP/gate"
           paths_file="$gate/paths.txt"
@@ -219,11 +242,12 @@ jobs:
           test -f "$out/scripts/i18n/gate-policy.json" || { echo "gate materialization misses the policy; fail closed" >&2; exit 1; }
           test -f "$out/scripts/ci/gate-parity.mjs" || { echo "gate materialization misses gate-parity; fail closed" >&2; exit 1; }
           test -f "$out/scripts/ci/gate-invariants.json" || { echo "gate materialization misses gate-invariants; fail closed" >&2; exit 1; }
-          # trusted base 早于 gate-surface.json（如 Epoch 2 root cb587e01）时不做硬性物化要求；
-          # 引入清单之后的 base 必须完整物化（与 materialize-trusted-gate.sh 的 cat-file -e 模式一致）
-          if git cat-file -e "$base:scripts/ci/gate-surface.json" >/dev/null 2>&1; then
-            test -f "$out/scripts/ci/gate-surface.json" || { echo "gate materialization misses gate-surface; fail closed" >&2; exit 1; }
-          fi
+          # trusted base 必须满足当前 verifier baseline：gate-surface.json 是强制物化合同。
+          # 旧 verifier（predates 清单 / 旧 contract）一律无资格审核新标准候选 → FAIL CLOSED
+          test -f "$out/scripts/ci/gate-surface.json" || {
+            echo "trusted base $base does not satisfy the current Gate Epoch 2 verifier baseline; fail closed" >&2
+            exit 1
+          }
           # 与 trusted helper 交叉验证（helper 来自 trusted base；候选不能自我批准）
           if [ -f "$out/scripts/ci/resolve-trusted-base.mjs" ]; then
             helper="$(node "$out/scripts/ci/resolve-trusted-base.mjs" \
@@ -443,7 +467,30 @@ jobs:
           else
             base="$root"
             echo "ROOT ADMISSION MODE: candidate is the Gate Epoch 2 trust root candidate; running the root gate with the full root self-protection suite." >&2
+          # 当前 verifier baseline：trusted base（或 ROOT_ADMISSION root candidate）必须携带
+          # gate-policy.json 且 contractVersion >= 4 / schemaVersion >= 3 / verifier 本体齐全；
+          # 旧 verifier 无资格审核新标准候选（verifier rollback 拒绝）→ FAIL CLOSED
+          base_policy="$(git show "$base:scripts/i18n/gate-policy.json" 2>/dev/null || printf '%s' '')"
+          if [ -z "$base_policy" ]; then
+            echo "trusted base $base has no gate-policy.json; it does not satisfy the current Gate Epoch 2 verifier baseline; fail closed" >&2
+            exit 1
           fi
+          base_contract="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(typeof j.contractVersion==="number"?String(j.contractVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
+          base_schema="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(typeof j.schemaVersion==="number"?String(j.schemaVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
+          if ! [[ "$base_contract" =~ ^[0-9]+$ ]] || [ "$base_contract" -lt 4 ]; then
+            echo "trusted base $base contractVersion ($base_contract) is below the current minimum 4; verifier rollback is refused; fail closed" >&2
+            exit 1
+          fi
+          if ! [[ "$base_schema" =~ ^[0-9]+$ ]] || [ "$base_schema" -lt 3 ]; then
+            echo "trusted base $base schemaVersion ($base_schema) is below the current minimum 3; fail closed" >&2
+            exit 1
+          fi
+          for rel in scripts/ci/gate-surface.json scripts/ci/gate-invariants.json scripts/ci/gate-parity.mjs scripts/ci/resolve-trusted-base.mjs scripts/ci/materialize-trusted-gate.sh scripts/ci/doctor-github-ruleset.mjs; do
+            if ! git cat-file -e "$base:$rel" >/dev/null 2>&1; then
+              echo "trusted base $base is missing $rel; it does not satisfy the current Gate Epoch 2 verifier baseline; fail closed" >&2
+              exit 1
+            fi
+          done
           gate="$RUNNER_TEMP/gate"
           paths_file="$gate/paths.txt"
           index_file="$gate/index"
@@ -475,11 +522,12 @@ jobs:
           test -f "$out/scripts/i18n/gate-policy.json" || { echo "gate materialization misses the policy; fail closed" >&2; exit 1; }
           test -f "$out/scripts/ci/gate-parity.mjs" || { echo "gate materialization misses gate-parity; fail closed" >&2; exit 1; }
           test -f "$out/scripts/ci/gate-invariants.json" || { echo "gate materialization misses gate-invariants; fail closed" >&2; exit 1; }
-          # trusted base 早于 gate-surface.json（如 Epoch 2 root cb587e01）时不做硬性物化要求；
-          # 引入清单之后的 base 必须完整物化（与 materialize-trusted-gate.sh 的 cat-file -e 模式一致）
-          if git cat-file -e "$base:scripts/ci/gate-surface.json" >/dev/null 2>&1; then
-            test -f "$out/scripts/ci/gate-surface.json" || { echo "gate materialization misses gate-surface; fail closed" >&2; exit 1; }
-          fi
+          # trusted base 必须满足当前 verifier baseline：gate-surface.json 是强制物化合同。
+          # 旧 verifier（predates 清单 / 旧 contract）一律无资格审核新标准候选 → FAIL CLOSED
+          test -f "$out/scripts/ci/gate-surface.json" || {
+            echo "trusted base $base does not satisfy the current Gate Epoch 2 verifier baseline; fail closed" >&2
+            exit 1
+          }
           if [ -f "$out/scripts/ci/resolve-trusted-base.mjs" ]; then
             helper="$(node "$out/scripts/ci/resolve-trusted-base.mjs" \
               --repo-root "$PWD" --event-name "$GITHUB_EVENT_NAME" --candidate "$GITHUB_SHA" \
@@ -723,7 +771,30 @@ jobs:
           else
             base="$root"
             echo "ROOT ADMISSION MODE: candidate is the Gate Epoch 2 trust root candidate; running the root gate with the full root self-protection suite." >&2
+          # 当前 verifier baseline：trusted base（或 ROOT_ADMISSION root candidate）必须携带
+          # gate-policy.json 且 contractVersion >= 4 / schemaVersion >= 3 / verifier 本体齐全；
+          # 旧 verifier 无资格审核新标准候选（verifier rollback 拒绝）→ FAIL CLOSED
+          base_policy="$(git show "$base:scripts/i18n/gate-policy.json" 2>/dev/null || printf '%s' '')"
+          if [ -z "$base_policy" ]; then
+            echo "trusted base $base has no gate-policy.json; it does not satisfy the current Gate Epoch 2 verifier baseline; fail closed" >&2
+            exit 1
           fi
+          base_contract="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(typeof j.contractVersion==="number"?String(j.contractVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
+          base_schema="$(printf '%s' "$base_policy" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);process.stdout.write(typeof j.schemaVersion==="number"?String(j.schemaVersion):"")}catch(e){process.stdout.write("")}})' 2>/dev/null || printf '%s' '')"
+          if ! [[ "$base_contract" =~ ^[0-9]+$ ]] || [ "$base_contract" -lt 4 ]; then
+            echo "trusted base $base contractVersion ($base_contract) is below the current minimum 4; verifier rollback is refused; fail closed" >&2
+            exit 1
+          fi
+          if ! [[ "$base_schema" =~ ^[0-9]+$ ]] || [ "$base_schema" -lt 3 ]; then
+            echo "trusted base $base schemaVersion ($base_schema) is below the current minimum 3; fail closed" >&2
+            exit 1
+          fi
+          for rel in scripts/ci/gate-surface.json scripts/ci/gate-invariants.json scripts/ci/gate-parity.mjs scripts/ci/resolve-trusted-base.mjs scripts/ci/materialize-trusted-gate.sh scripts/ci/doctor-github-ruleset.mjs; do
+            if ! git cat-file -e "$base:$rel" >/dev/null 2>&1; then
+              echo "trusted base $base is missing $rel; it does not satisfy the current Gate Epoch 2 verifier baseline; fail closed" >&2
+              exit 1
+            fi
+          done
           gate="$RUNNER_TEMP/gate"
           paths_file="$gate/paths.txt"
           index_file="$gate/index"
@@ -755,11 +826,12 @@ jobs:
           test -f "$out/scripts/i18n/gate-policy.json" || { echo "gate materialization misses the policy; fail closed" >&2; exit 1; }
           test -f "$out/scripts/ci/gate-parity.mjs" || { echo "gate materialization misses gate-parity; fail closed" >&2; exit 1; }
           test -f "$out/scripts/ci/gate-invariants.json" || { echo "gate materialization misses gate-invariants; fail closed" >&2; exit 1; }
-          # trusted base 早于 gate-surface.json（如 Epoch 2 root cb587e01）时不做硬性物化要求；
-          # 引入清单之后的 base 必须完整物化（与 materialize-trusted-gate.sh 的 cat-file -e 模式一致）
-          if git cat-file -e "$base:scripts/ci/gate-surface.json" >/dev/null 2>&1; then
-            test -f "$out/scripts/ci/gate-surface.json" || { echo "gate materialization misses gate-surface; fail closed" >&2; exit 1; }
-          fi
+          # trusted base 必须满足当前 verifier baseline：gate-surface.json 是强制物化合同。
+          # 旧 verifier（predates 清单 / 旧 contract）一律无资格审核新标准候选 → FAIL CLOSED
+          test -f "$out/scripts/ci/gate-surface.json" || {
+            echo "trusted base $base does not satisfy the current Gate Epoch 2 verifier baseline; fail closed" >&2
+            exit 1
+          }
           if [ -f "$out/scripts/ci/resolve-trusted-base.mjs" ]; then
             helper="$(node "$out/scripts/ci/resolve-trusted-base.mjs" \
               --repo-root "$PWD" --event-name "$GITHUB_EVENT_NAME" --candidate "$GITHUB_SHA" \

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
@@ -669,7 +669,9 @@ class PluginReleaseScriptsTest {
 
         assertThat(workflow).contains(
                 "push:",
-                "branches: [master]",
+                // push 触发不再限定 master：任意代码分支 push 都运行完整质量门禁；
+                // gh-pages 纯文档分支历史不含 Epoch 2 root，触发只会确定性失败，故排除
+                "branches-ignore: [gh-pages]",
                 "pull_request:",
                 "merge_group:",
                 "workflow_call:",
@@ -701,6 +703,7 @@ class PluginReleaseScriptsTest {
                 "GATE_DIR",
                 "actions/checkout@v7");
         assertThat(workflow.split(Pattern.quote("ref: ${{ github.sha }}"), -1)).hasSize(6);
+        assertThat(workflow).doesNotContain("branches: [master]");
         assertThat(workflow).doesNotContain("-DskipTests", "-Dmaven.test.skip");
         assertThat(workflow).doesNotContain("LEGACY_BOOTSTRAP_REF");
         assertThat(workflow).doesNotContain("FORCE_JAVASCRIPT_ACTIONS_TO_NODE24");

--- a/scripts/ci/doctor-github-ruleset.mjs
+++ b/scripts/ci/doctor-github-ruleset.mjs
@@ -8,6 +8,14 @@
  *   bypass actors（permanent always bypass 禁止）/ deletion / non-fast-forward；
  * - refs/tags/i18n-gate-epoch-2-root ruleset：no deletion / no non-fast-forward / no bypass。
  *
+ * REST API 使用（正确流程）：
+ *   GET /repos/{owner}/{repo}/rulesets            → 摘要列表（只含 id / name / target /
+ *                                                   conditions / enforcement）
+ *   GET /repos/{owner}/{repo}/rulesets/{id}       → detail（rules[].parameters.required_status_checks、
+ *                                                   bypass_actors 等完整字段）
+ * 摘要列表对象不含 conditions 之外的 rules / bypass_actors 完整语义，
+ * 因此必须逐个 follow detail endpoint 后再检查（doctor 的退出码以此为准）。
+ *
  * 期望不变量声明：scripts/ci/github-ruleset-invariants.json（仓库内愿望清单，不是远端事实）。
  *
  * 凭据：GITHUB_TOKEN 或 GH_TOKEN（需要 repo metadata + rulesets read 权限）。
@@ -17,6 +25,9 @@
  * 用法：
  *   node scripts/ci/doctor-github-ruleset.mjs [--repo owner/name]
  *   npm run doctor:github-gate
+ *
+ * 测试：runDoctor 接受注入的 fetchJson，单元测试不依赖真实 GitHub（见
+ * scripts/i18n/test/doctor-github-ruleset.test.mjs）。
  */
 import fs from 'fs';
 import path from 'path';
@@ -25,7 +36,7 @@ import { fileURLToPath } from 'url';
 const OWN_DIR = path.dirname(fileURLToPath(import.meta.url));
 const INVARIANTS_REL = path.posix.join('github-ruleset-invariants.json');
 
-function loadInvariants() {
+export function loadInvariants() {
     const file = path.join(OWN_DIR, INVARIANTS_REL);
     if (!fs.existsSync(file)) {
         throw new Error('missing scripts/ci/github-ruleset-invariants.json');
@@ -45,8 +56,8 @@ function parseArgs(argv) {
     return args;
 }
 
-async function api(baseUrl, repo, pathname, token) {
-    const url = `${baseUrl}/repos/${repo}/${pathname}?per_page=100`;
+/** 默认 fetchJson：HTTP fetch + GitHub 认证头。返回 {status, body}；网络错误抛错。 */
+async function defaultFetchJson(url, token) {
     const response = await fetch(url, {
         headers: {
             Authorization: 'Bearer ' + token,
@@ -55,17 +66,194 @@ async function api(baseUrl, repo, pathname, token) {
             'User-Agent': 'pixivdownloader-gate-doctor',
         },
     });
-    if (response.status === 404) {
-        return { missing: true };
+    let body = null;
+    if (response.status !== 204) {
+        try {
+            body = await response.json();
+        } catch (e) {
+            body = null;
+        }
     }
-    if (response.status === 403 || response.status === 401) {
-        throw new Error('GitHub API access denied (HTTP ' + response.status
-            + '): the token needs repo metadata + rulesets read permission');
+    return { status: response.status, body };
+}
+
+function isBranchRulesetFor(rs, ref) {
+    return rs && rs.target === 'branch' && (rs.conditions || {}).ref_name
+        && Array.isArray((rs.conditions.ref_name || {}).include)
+        && rs.conditions.ref_name.include.includes(ref);
+}
+
+function isTagRulesetFor(rs, ref) {
+    return rs && rs.target === 'tag' && (rs.conditions || {}).ref_name
+        && Array.isArray((rs.conditions.ref_name || {}).include)
+        && rs.conditions.ref_name.include.includes(ref);
+}
+
+/**
+ * 审核单个 master ruleset detail（detail 才含 rules / bypass_actors 完整语义）。
+ */
+function auditMasterDetail(detail, invariants, problems, report) {
+    const name = detail.name;
+    report.push('master ruleset: ' + name + ' (enforcement: ' + detail.enforcement + ')');
+    if (detail.enforcement !== 'active') {
+        problems.push('master ruleset ' + name + ' is not active (enforcement: ' + detail.enforcement + ')');
     }
-    if (!response.ok) {
-        throw new Error('GitHub API error HTTP ' + response.status + ' for ' + pathname);
+    const rules = Array.isArray(detail.rules) ? detail.rules : [];
+    const statusRule = rules.find((r) => r && r.type === 'required_status_checks');
+    if (statusRule) {
+        const parameters = statusRule.parameters && typeof statusRule.parameters === 'object'
+            ? statusRule.parameters : {};
+        // detail 字段：rules[].parameters.required_status_checks[]（每项有 context）；
+        // 不存在 required_checks 之类旧字段，不要读错键
+        const checks = Array.isArray(parameters.required_status_checks)
+            ? parameters.required_status_checks : [];
+        const checkNames = checks.map((c) => (c && typeof c.context === 'string' ? c.context : ''));
+        for (const expected of invariants.requiredChecks) {
+            if (!checkNames.includes(expected)) {
+                problems.push('master ruleset ' + name + ' misses required check "' + expected
+                    + '" (found: ' + (checkNames.join(', ') || 'none') + ')');
+            }
+        }
+        if (parameters.strict_required_status_checks_policy !== true) {
+            problems.push('master ruleset ' + name + ' has strict_required_status_checks_policy disabled'
+                + ' (Require branches to be up to date before merging must be on)');
+        }
+    } else {
+        problems.push('master ruleset ' + name + ' has no required_status_checks rule');
     }
-    return response.json();
+    for (const expectedRule of ['deletion', 'non_fast_forward']) {
+        const present = rules.some((r) => r && r.type === expectedRule);
+        const shouldDisable = expectedRule === 'deletion'
+            ? !invariants.allowDeletion : !invariants.allowNonFastForward;
+        if (shouldDisable && !present) {
+            problems.push('master ruleset ' + name + ' does not block ' + expectedRule);
+        }
+    }
+    const alwaysBypass = (Array.isArray(detail.bypass_actors) ? detail.bypass_actors : [])
+        .filter((a) => a && a.bypass_mode === 'always');
+    if (alwaysBypass.length > 0 && !invariants.allowBypass) {
+        problems.push('master ruleset ' + name + ' has permanent always-bypass actors: '
+            + alwaysBypass.map((a) => (a.actor_type + ':' + (a.actor_id || '?'))).join(', '));
+    }
+}
+
+/**
+ * 审核单个 root tag ruleset detail。
+ */
+function auditTagDetail(detail, invariants, problems, report) {
+    const name = detail.name;
+    report.push('root tag ruleset: ' + name + ' (enforcement: ' + detail.enforcement + ')');
+    if (detail.enforcement !== 'active') {
+        problems.push('root tag ruleset ' + name + ' is not active');
+    }
+    const rules = Array.isArray(detail.rules) ? detail.rules : [];
+    if (!rules.some((r) => r && r.type === 'deletion') && !invariants.allowDeletion) {
+        problems.push('root tag ruleset ' + name + ' does not block deletion');
+    }
+    if (!rules.some((r) => r && r.type === 'non_fast_forward') && !invariants.allowNonFastForward) {
+        problems.push('root tag ruleset ' + name + ' does not block non-fast-forward updates');
+    }
+    const alwaysBypass = (Array.isArray(detail.bypass_actors) ? detail.bypass_actors : [])
+        .filter((a) => a && a.bypass_mode === 'always');
+    if (alwaysBypass.length > 0 && !invariants.allowBypass) {
+        problems.push('root tag ruleset ' + name + ' has permanent always-bypass actors');
+    }
+}
+
+/**
+ * 运行 Ruleset doctor（fetch 注入，可单测；不依赖真实 GitHub）。
+ * @param {Object} opts
+ * @param {(url: string, token: string) => Promise<{status: number, body: any}>} opts.fetchJson
+ * @param {string} opts.token
+ * @param {string} opts.repo owner/name
+ * @param {string} [opts.baseUrl]
+ * @param {Object} opts.invariants github-ruleset-invariants.json 解析结果
+ * @returns {Promise<{exitCode: 0|1|2, problems: string[], report: string[], cannotVerify: string|null}>}
+ */
+export async function runDoctor({ fetchJson, token, repo, baseUrl, invariants }) {
+    const problems = [];
+    const report = [];
+    const base = baseUrl || process.env.GITHUB_API_URL || 'https://api.github.com';
+    const masterInvariants = invariants.master;
+    const tagInvariants = invariants['i18n-gate-epoch-2-root'];
+
+    // 1. list endpoint：只提供摘要（id / name / target / conditions / enforcement）
+    let list;
+    try {
+        list = await fetchJson(base + '/repos/' + repo + '/rulesets?per_page=100', token);
+    } catch (e) {
+        return { exitCode: 2, problems, report,
+            cannotVerify: 'GitHub API request failed for the rulesets list: '
+                + (e && e.message ? e.message : e) };
+    }
+    if (list.status === 404) {
+        return { exitCode: 2, problems, report,
+            cannotVerify: 'no rulesets endpoint for ' + repo
+                + ' (missing or read-restricted); this is a report, not a pass' };
+    }
+    if (list.status === 403 || list.status === 401) {
+        return { exitCode: 2, problems, report,
+            cannotVerify: 'GitHub API access denied (HTTP ' + list.status
+                + '): the token needs repo metadata + rulesets read permission' };
+    }
+    if (list.status !== 200) {
+        return { exitCode: 2, problems, report,
+            cannotVerify: 'GitHub API error HTTP ' + list.status + ' for the rulesets list' };
+    }
+    if (!Array.isArray(list.body)) {
+        return { exitCode: 2, problems, report,
+            cannotVerify: 'unexpected rulesets response shape; this is a report, not a pass' };
+    }
+
+    // 2. 逐个 follow detail endpoint：list 摘要不含 conditions / rules / bypass_actors 完整语义
+    //    （真实 API 的摘要对象 conditions 为 null），必须用 detail 的 target + conditions 分类，
+    //    再用 detail 的 rules / bypass_actors 检查
+    const fetchDetail = async (id) => {
+        const detail = await fetchJson(base + '/repos/' + repo + '/rulesets/' + id, token);
+        if (detail.status === 404 || detail.status === 403 || detail.status === 401) {
+            return { error: 'cannot read ruleset detail ' + id + ' (HTTP ' + detail.status
+                + '); this is a report, not a pass' };
+        }
+        if (detail.status !== 200 || !detail.body || typeof detail.body !== 'object') {
+            return { error: 'unexpected ruleset detail response HTTP ' + detail.status
+                + ' for ruleset ' + id + '; this is a report, not a pass' };
+        }
+        return { detail: detail.body };
+    };
+
+    const masterMatches = [];
+    const tagMatches = [];
+    for (const rs of list.body) {
+        const fetched = await fetchDetail(rs.id);
+        if (fetched.error) {
+            return { exitCode: 2, problems, report, cannotVerify: fetched.error };
+        }
+        if (isBranchRulesetFor(fetched.detail, 'refs/heads/master')) {
+            masterMatches.push(fetched.detail);
+        }
+        if (isTagRulesetFor(fetched.detail, 'refs/tags/i18n-gate-epoch-2-root')) {
+            tagMatches.push(fetched.detail);
+        }
+    }
+
+    if (masterMatches.length === 0) {
+        problems.push('no branch ruleset covers refs/heads/master');
+    } else {
+        for (const detail of masterMatches) {
+            auditMasterDetail(detail, masterInvariants, problems, report);
+        }
+    }
+
+    if (tagMatches.length === 0) {
+        problems.push('no tag ruleset covers refs/tags/i18n-gate-epoch-2-root');
+    } else {
+        for (const detail of tagMatches) {
+            auditTagDetail(detail, tagInvariants, problems, report);
+        }
+    }
+
+    const exitCode = problems.length > 0 ? 1 : 0;
+    return { exitCode, problems, report, cannotVerify: null };
 }
 
 async function main() {
@@ -74,7 +262,7 @@ async function main() {
         args = parseArgs(process.argv.slice(2));
     } catch (e) {
         console.error('doctor-github-ruleset ERROR: ' + e.message);
-        process.exit(2);
+        process.exitCode = 2;
         return;
     }
     const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || '';
@@ -82,7 +270,7 @@ async function main() {
         console.error('doctor-github-ruleset: CANNOT VERIFY — no GITHUB_TOKEN / GH_TOKEN in the'
             + ' environment; the GitHub repository settings cannot be read without token'
             + ' (metadata + rulesets read). This is a report, not a pass.');
-        process.exit(2);
+        process.exitCode = 2;
         return;
     }
     let invariants;
@@ -90,137 +278,53 @@ async function main() {
         invariants = loadInvariants();
     } catch (e) {
         console.error('doctor-github-ruleset ERROR: ' + e.message);
-        process.exit(2);
+        process.exitCode = 2;
         return;
     }
     const repo = args.repo || process.env.GITHUB_REPOSITORY;
     if (!repo || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
         console.error('doctor-github-ruleset ERROR: repository must be owner/name'
             + ' (--repo or GITHUB_REPOSITORY)');
-        process.exit(2);
+        process.exitCode = 2;
         return;
     }
-    const baseUrl = process.env.GITHUB_API_URL || 'https://api.github.com';
 
-    let rulesets;
+    let result;
     try {
-        rulesets = await api(baseUrl, repo, 'rulesets', token);
+        result = await runDoctor({ fetchJson: defaultFetchJson, token, repo, invariants });
     } catch (e) {
-        console.error('doctor-github-ruleset: CANNOT VERIFY — ' + e.message);
-        process.exit(2);
+        console.error('doctor-github-ruleset: CANNOT VERIFY — '
+            + (e && e.message ? e.message : e));
+        process.exitCode = 2;
         return;
     }
-    if (rulesets && rulesets.missing) {
-        console.error('doctor-github-ruleset: CANNOT VERIFY — no rulesets endpoint for ' + repo
-            + ' (missing or read-restricted); this is a report, not a pass.');
-        process.exit(2);
+    if (result.cannotVerify) {
+        console.error('doctor-github-ruleset: CANNOT VERIFY — ' + result.cannotVerify);
+        process.exitCode = 2;
         return;
-    }
-    if (!Array.isArray(rulesets)) {
-        console.error('doctor-github-ruleset: CANNOT VERIFY — unexpected rulesets response shape;'
-            + ' this is a report, not a pass.');
-        process.exit(2);
-        return;
-    }
-
-    const problems = [];
-    const report = [];
-    const masterInvariants = invariants.master;
-    const tagInvariants = invariants['i18n-gate-epoch-2-root'];
-
-    const masterRulesets = rulesets.filter((r) => r.target === 'branch'
-        && (r.conditions || {}).ref_name && (r.conditions.ref_name.include || []).includes('refs/heads/master'));
-    const tagRulesets = rulesets.filter((r) => r.target === 'tag'
-        && (r.conditions || {}).ref_name
-        && (r.conditions.ref_name.include || []).includes('refs/tags/i18n-gate-epoch-2-root'));
-
-    if (masterRulesets.length === 0) {
-        problems.push('no branch ruleset covers refs/heads/master');
-    } else {
-        for (const rs of masterRulesets) {
-            const name = rs.name;
-            report.push('master ruleset: ' + name + ' (enforcement: ' + rs.enforcement + ')');
-            if (rs.enforcement !== 'active') {
-                problems.push('master ruleset ' + name + ' is not active (enforcement: ' + rs.enforcement + ')');
-            }
-            const rules = rs.rules || [];
-            const statusRule = rules.find((r) => r.type === 'required_status_checks');
-            if (statusRule) {
-                const checks = (statusRule.parameters && statusRule.parameters.required_checks) || [];
-                const checkNames = checks.map((c) => c.context);
-                for (const expected of masterInvariants.requiredChecks) {
-                    if (!checkNames.includes(expected)) {
-                        problems.push('master ruleset ' + name + ' misses required check "' + expected
-                            + '" (found: ' + (checkNames.join(', ') || 'none') + ')');
-                    }
-                }
-                const strict = statusRule.parameters && statusRule.parameters.strict_required_status_checks_policy;
-                if (!strict) {
-                    problems.push('master ruleset ' + name + ' has strict_required_status_checks_policy=false'
-                        + ' (Require branches to be up to date before merging must be on)');
-                }
-            } else {
-                problems.push('master ruleset ' + name + ' has no required_status_checks rule');
-            }
-            for (const expectedRule of ['deletion', 'non_fast_forward']) {
-                const present = rules.some((r) => r.type === expectedRule);
-                const shouldDisable = expectedRule === 'deletion'
-                    ? !masterInvariants.allowDeletion : !masterInvariants.allowNonFastForward;
-                if (shouldDisable && !present) {
-                    problems.push('master ruleset ' + name + ' does not block ' + expectedRule);
-                }
-            }
-            const bypassActors = rs.bypass_actors || [];
-            const alwaysBypass = bypassActors.filter((a) => a.bypass_mode === 'always');
-            if (alwaysBypass.length > 0 && !masterInvariants.allowBypass) {
-                problems.push('master ruleset ' + name + ' has permanent always-bypass actors: '
-                    + alwaysBypass.map((a) => (a.actor_type + ':' + (a.actor_id || '?'))).join(', '));
-            }
-        }
-    }
-
-    if (tagRulesets.length === 0) {
-        problems.push('no tag ruleset covers refs/tags/i18n-gate-epoch-2-root');
-    } else {
-        for (const rs of tagRulesets) {
-            const name = rs.name;
-            report.push('root tag ruleset: ' + name + ' (enforcement: ' + rs.enforcement + ')');
-            if (rs.enforcement !== 'active') {
-                problems.push('root tag ruleset ' + name + ' is not active');
-            }
-            const rules = rs.rules || [];
-            if (!rules.some((r) => r.type === 'deletion') && !tagInvariants.allowDeletion) {
-                problems.push('root tag ruleset ' + name + ' does not block deletion');
-            }
-            if (!rules.some((r) => r.type === 'non_fast_forward') && !tagInvariants.allowNonFastForward) {
-                problems.push('root tag ruleset ' + name + ' does not block non-fast-forward updates');
-            }
-            const alwaysBypass = (rs.bypass_actors || []).filter((a) => a.bypass_mode === 'always');
-            if (alwaysBypass.length > 0 && !tagInvariants.allowBypass) {
-                problems.push('root tag ruleset ' + name + ' has permanent always-bypass actors');
-            }
-        }
     }
 
     console.log('doctor-github-ruleset: repository ' + repo);
-    for (const line of report) {
+    for (const line of result.report) {
         console.log('  ' + line);
     }
-    if (problems.length > 0) {
+    if (result.problems.length > 0) {
         console.error('doctor-github-ruleset: VIOLATIONS FOUND');
-        for (const p of problems) {
+        for (const p of result.problems) {
             console.error('  - ' + p);
         }
         console.error('doctor-github-ruleset: admin must fix the GitHub Ruleset settings;'
             + ' repository code cannot change them.');
-        process.exit(1);
+        process.exitCode = 1;
         return;
     }
     console.log('doctor-github-ruleset: VERIFIED — master and root-tag rulesets match'
         + ' scripts/ci/github-ruleset-invariants.json.');
 }
 
-main().catch((e) => {
-    console.error('doctor-github-ruleset: CANNOT VERIFY — ' + (e && e.message ? e.message : e));
-    process.exit(2);
-});
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    main().catch((e) => {
+        console.error('doctor-github-ruleset: CANNOT VERIFY — ' + (e && e.message ? e.message : e));
+        process.exitCode = 2;
+    });
+}

--- a/scripts/ci/doctor-github-ruleset.mjs
+++ b/scripts/ci/doctor-github-ruleset.mjs
@@ -5,8 +5,8 @@
  *
  * 检查（全部只读）：
  * - master 分支 ruleset：required checks 完整集合 / strict_required_status_checks_policy /
- *   bypass actors（permanent always bypass 禁止）/ deletion / non-fast-forward；
- * - refs/tags/i18n-gate-epoch-2-root ruleset：no deletion / no non-fast-forward / no bypass。
+ *   bypass actors（allowBypass=false 时必须为空）/ deletion / non-fast-forward；
+ * - invariants 中声明的每个 verifier root tag ruleset：no deletion / no non-fast-forward / no bypass。
  *
  * REST API 使用（正确流程）：
  *   GET /repos/{owner}/{repo}/rulesets            → 摘要列表（只含 id / name / target /
@@ -129,11 +129,11 @@ function auditMasterDetail(detail, invariants, problems, report) {
             problems.push('master ruleset ' + name + ' does not block ' + expectedRule);
         }
     }
-    const alwaysBypass = (Array.isArray(detail.bypass_actors) ? detail.bypass_actors : [])
-        .filter((a) => a && a.bypass_mode === 'always');
-    if (alwaysBypass.length > 0 && !invariants.allowBypass) {
-        problems.push('master ruleset ' + name + ' has permanent always-bypass actors: '
-            + alwaysBypass.map((a) => (a.actor_type + ':' + (a.actor_id || '?'))).join(', '));
+    const bypassActors = Array.isArray(detail.bypass_actors) ? detail.bypass_actors : [];
+    if (bypassActors.length > 0 && !invariants.allowBypass) {
+        problems.push('master ruleset ' + name + ' has bypass actors while allowBypass=false: '
+            + bypassActors.map((a) => (a.actor_type + ':' + (a.actor_id || '?')
+                + ':' + (a.bypass_mode || '?'))).join(', '));
     }
 }
 
@@ -153,10 +153,9 @@ function auditTagDetail(detail, invariants, problems, report) {
     if (!rules.some((r) => r && r.type === 'non_fast_forward') && !invariants.allowNonFastForward) {
         problems.push('root tag ruleset ' + name + ' does not block non-fast-forward updates');
     }
-    const alwaysBypass = (Array.isArray(detail.bypass_actors) ? detail.bypass_actors : [])
-        .filter((a) => a && a.bypass_mode === 'always');
-    if (alwaysBypass.length > 0 && !invariants.allowBypass) {
-        problems.push('root tag ruleset ' + name + ' has permanent always-bypass actors');
+    const bypassActors = Array.isArray(detail.bypass_actors) ? detail.bypass_actors : [];
+    if (bypassActors.length > 0 && !invariants.allowBypass) {
+        problems.push('root tag ruleset ' + name + ' has bypass actors while allowBypass=false');
     }
 }
 
@@ -175,7 +174,9 @@ export async function runDoctor({ fetchJson, token, repo, baseUrl, invariants })
     const report = [];
     const base = baseUrl || process.env.GITHUB_API_URL || 'https://api.github.com';
     const masterInvariants = invariants.master;
-    const tagInvariants = invariants['i18n-gate-epoch-2-root'];
+    const tagInvariants = Object.entries(invariants)
+        .filter(([name, value]) => /^i18n-gate-epoch-[2-9][0-9]*-root$/.test(name)
+            && value && typeof value === 'object');
 
     // 1. list endpoint：只提供摘要（id / name / target / conditions / enforcement）
     let list;
@@ -222,7 +223,7 @@ export async function runDoctor({ fetchJson, token, repo, baseUrl, invariants })
     };
 
     const masterMatches = [];
-    const tagMatches = [];
+    const tagMatches = new Map(tagInvariants.map(([name]) => [name, []]));
     for (const rs of list.body) {
         const fetched = await fetchDetail(rs.id);
         if (fetched.error) {
@@ -231,8 +232,10 @@ export async function runDoctor({ fetchJson, token, repo, baseUrl, invariants })
         if (isBranchRulesetFor(fetched.detail, 'refs/heads/master')) {
             masterMatches.push(fetched.detail);
         }
-        if (isTagRulesetFor(fetched.detail, 'refs/tags/i18n-gate-epoch-2-root')) {
-            tagMatches.push(fetched.detail);
+        for (const [name] of tagInvariants) {
+            if (isTagRulesetFor(fetched.detail, 'refs/tags/' + name)) {
+                tagMatches.get(name).push(fetched.detail);
+            }
         }
     }
 
@@ -244,11 +247,14 @@ export async function runDoctor({ fetchJson, token, repo, baseUrl, invariants })
         }
     }
 
-    if (tagMatches.length === 0) {
-        problems.push('no tag ruleset covers refs/tags/i18n-gate-epoch-2-root');
-    } else {
-        for (const detail of tagMatches) {
-            auditTagDetail(detail, tagInvariants, problems, report);
+    for (const [name, expected] of tagInvariants) {
+        const matches = tagMatches.get(name);
+        if (matches.length === 0) {
+            problems.push('no tag ruleset covers refs/tags/' + name);
+        } else {
+            for (const detail of matches) {
+                auditTagDetail(detail, expected, problems, report);
+            }
         }
     }
 
@@ -318,7 +324,7 @@ async function main() {
         process.exitCode = 1;
         return;
     }
-    console.log('doctor-github-ruleset: VERIFIED — master and root-tag rulesets match'
+    console.log('doctor-github-ruleset: VERIFIED — master and all declared root-tag rulesets match'
         + ' scripts/ci/github-ruleset-invariants.json.');
 }
 

--- a/scripts/ci/gate-invariants.json
+++ b/scripts/ci/gate-invariants.json
@@ -1,6 +1,24 @@
 {
   "gateEpoch": 2,
   "contractVersion": 4,
+  "minimumTrustedVerifier": {
+    "contractVersion": 4,
+    "schemaVersion": 3,
+    "requiredFiles": [
+      "scripts/ci/gate-surface.json",
+      "scripts/ci/gate-invariants.json",
+      "scripts/ci/gate-parity.mjs",
+      "scripts/ci/resolve-trusted-base.mjs",
+      "scripts/ci/materialize-trusted-gate.sh",
+      "scripts/ci/doctor-github-ruleset.mjs",
+      "scripts/i18n/trust-gate.mjs"
+    ]
+  },
+  "qualityGatePushCoverage": {
+    "exclude": [
+      "gh-pages"
+    ]
+  },
   "requiredJobs": [
     "java-tests",
     "javascript-tests",
@@ -29,6 +47,7 @@
     "scripts/i18n/check.mjs",
     "scripts/i18n/gate-contract.mjs",
     "scripts/i18n/gate-policy.json",
+    "scripts/i18n/trust-gate.mjs",
     "scripts/hooks/pre-commit",
     "scripts/hooks/pre-push",
     "scripts/hooks/pre-push-guard.sh",

--- a/scripts/ci/gate-invariants.json
+++ b/scripts/ci/gate-invariants.json
@@ -36,6 +36,7 @@
     "scripts/ci/gate-invariants.json",
     "scripts/ci/gate-surface.json",
     "scripts/ci/github-ruleset-invariants.json",
+    "scripts/ci/doctor-github-ruleset.mjs",
     ".github/workflows/quality-gate.yml"
   ],
   "requiredWorkflowFiles": [

--- a/scripts/ci/gate-parity.mjs
+++ b/scripts/ci/gate-parity.mjs
@@ -65,11 +65,13 @@ const EXTERNAL_WORKFLOW_RELS = [
     path.posix.join('.github', 'workflows', 'publish-plugins.yml'),
 ];
 
+const RULESET_INVARIANTS_REL = path.posix.join('scripts', 'ci', 'github-ruleset-invariants.json');
+
 const REQUIRED_TRIGGERS = ['push', 'pull_request', 'merge_group', 'workflow_dispatch', 'workflow_call'];
 const REQUIRED_WORKFLOW_JOBS = ['java-tests', 'javascript-tests', 'signature-guard', 'trusted-gate-contract', 'i18n-check'];
 /** Epoch 2 门禁的最低 package scripts 集合（policy.requiredPackageScripts 在此基础上只增不减）。 */
 const REQUIRED_SCRIPTS = ['test:i18n', 'i18n:check', 'i18n:generate-static', 'i18n:trust-gate',
-    'i18n:gate-contract', 'i18n:gate-parity', 'test:js', 'test:web-standards'];
+    'i18n:gate-contract', 'i18n:gate-parity', 'test:js', 'test:web-standards', 'doctor:github-gate'];
 const TRUSTED_LOC = /\$GATE_DIR|\$RUNNER_TEMP|\bguard\/out\b|materialize-trusted-gate/;
 
 const SHA_RE = /^[0-9a-f]{40}$/;
@@ -640,11 +642,11 @@ function auditGateSurface(checks, trustedDir, candidateRoot) {
     const trustedFile = path.join(trustedDir, ...SURFACE_REL.split('/'));
     const candidateFile = path.join(candidateRoot, ...SURFACE_REL.split('/'));
     if (!fs.existsSync(trustedFile)) {
-        // trusted base predates gate-surface.json（如 Epoch 2 root cb587e01）：
-        // 无法做 trusted→candidate 单调比较，只报告；候选侧删除清单仍 fail closed
-        pushCheck('candidate gate-surface.json preserved (trusted predates the manifest)',
-            fs.existsSync(candidateFile),
-            'candidate deleted scripts/ci/gate-surface.json; fail closed');
+        // trusted verifier 无新标准 manifest → verifier 本身无资格审核新标准 candidate；
+        // 不存在 predates / fallback / legacy 兼容路径，一律 fail closed
+        pushCheck('trusted verifier carries gate-surface.json', false,
+            'trusted verifier does not satisfy the current verifier baseline'
+                + ' (missing scripts/ci/gate-surface.json); fail closed');
         return;
     }
     let trustedSurface;
@@ -680,6 +682,123 @@ function auditGateSurface(checks, trustedDir, candidateRoot) {
     pushCheck('candidate gate-surface.json declares only real paths',
         phantom.length === 0,
         'candidate gate-surface.json declares non-existent paths: ' + phantom.join(', '));
+}
+
+/**
+ * github-ruleset-invariants.json 安全语义单调审计（严格度只能增加，不能降低）：
+ * - NORMAL：trusted invariant vs candidate invariant；
+ *   requiredChecks 只能增加（trusted ⊆ candidate）；
+ *   requireStrict 允许 false→true，禁止 true→false；
+ *   allowBypass / allowDeletion / allowNonFastForward 允许 true→false，禁止 false→true；
+ *   schemaVersion 只增不减（字段缺失 → fail closed）；
+ * - invariants 模式（trustedDir == null）：候选必须满足最低安全合同
+ *   （master.requireStrict=true、master/root-tag allow*=false、requiredChecks 非空）。
+ */
+function auditGithubRulesetInvariants(checks, trustedDir, candidateRoot) {
+    const pushCheck = (name, ok, diagnostic) => {
+        checks.push({ name, kind: 'invariant', expected: ok ? 'kept' : 'weakened', status: null, ok,
+            diagnostic: ok ? '' : diagnostic });
+    };
+    const candidateFile = path.join(candidateRoot, ...RULESET_INVARIANTS_REL.split('/'));
+    if (!fs.existsSync(candidateFile)) {
+        pushCheck('candidate github-ruleset-invariants.json present', false,
+            'candidate has no scripts/ci/github-ruleset-invariants.json; fail closed');
+        return;
+    }
+    let candidate;
+    try {
+        candidate = JSON.parse(fs.readFileSync(candidateFile, 'utf8'));
+    } catch (e) {
+        pushCheck('candidate github-ruleset-invariants.json parses as JSON', false,
+            'candidate github-ruleset-invariants.json is invalid: ' + e.message);
+        return;
+    }
+    const cs = Number.isInteger(candidate.schemaVersion) ? candidate.schemaVersion : null;
+    if (cs === null) {
+        pushCheck('candidate ruleset invariants schemaVersion present', false,
+            'candidate github-ruleset-invariants.json has no integer schemaVersion; fail closed');
+        return;
+    }
+    const cMaster = candidate.master && typeof candidate.master === 'object' ? candidate.master : null;
+    const cTag = candidate['i18n-gate-epoch-2-root'] && typeof candidate['i18n-gate-epoch-2-root'] === 'object'
+        ? candidate['i18n-gate-epoch-2-root'] : null;
+
+    if (trustedDir) {
+        const trustedFile = path.join(trustedDir, ...RULESET_INVARIANTS_REL.split('/'));
+        if (!fs.existsSync(trustedFile)) {
+            pushCheck('trusted verifier carries github-ruleset-invariants.json', false,
+                'trusted verifier does not satisfy the current verifier baseline; fail closed');
+            return;
+        }
+        let trusted;
+        try {
+            trusted = JSON.parse(fs.readFileSync(trustedFile, 'utf8'));
+        } catch (e) {
+            pushCheck('trusted github-ruleset-invariants.json parses as JSON', false,
+                'trusted github-ruleset-invariants.json is invalid: ' + e.message);
+            return;
+        }
+        const ts = Number.isInteger(trusted.schemaVersion) ? trusted.schemaVersion : null;
+        pushCheck('ruleset invariants schemaVersion not lowered',
+            ts !== null && cs >= ts,
+            'candidate ruleset invariants schemaVersion ' + cs + (ts === null
+                ? ' (trusted schemaVersion missing)' : ' < trusted ' + ts) + '; fail closed');
+        const tMaster = trusted.master && typeof trusted.master === 'object' ? trusted.master : null;
+        const tTag = trusted['i18n-gate-epoch-2-root'] && typeof trusted['i18n-gate-epoch-2-root'] === 'object'
+            ? trusted['i18n-gate-epoch-2-root'] : null;
+        const tChecks = Array.isArray(tMaster && tMaster.requiredChecks)
+            ? tMaster.requiredChecks.filter((c) => typeof c === 'string') : [];
+        const cChecks = Array.isArray(cMaster && cMaster.requiredChecks)
+            ? cMaster.requiredChecks.filter((c) => typeof c === 'string') : [];
+        const removedChecks = tChecks.filter((c) => !cChecks.includes(c));
+        pushCheck('ruleset required checks not reduced', removedChecks.length === 0,
+            'candidate dropped required status checks: ' + removedChecks.join(', '));
+        // 布尔安全语义单调：requireStrict 只允许 false→true；allow* 只允许 true→false
+        for (const [key, stricterIs] of [['requireStrict', true], ['allowBypass', false],
+            ['allowDeletion', false], ['allowNonFastForward', false]]) {
+            if (!tMaster || !cMaster || typeof tMaster[key] !== 'boolean' || typeof cMaster[key] !== 'boolean') {
+                pushCheck('ruleset master.' + key + ' strictness not weakened', false,
+                    'ruleset invariants master.' + key + ' must be a boolean on both sides; fail closed');
+                continue;
+            }
+            const weakened = stricterIs
+                ? (tMaster[key] === true && cMaster[key] === false)
+                : (tMaster[key] === false && cMaster[key] === true);
+            pushCheck('ruleset master.' + key + ' strictness not weakened', !weakened,
+                'candidate weakened master.' + key + ' from ' + tMaster[key] + ' to '
+                    + cMaster[key] + '; fail closed');
+        }
+        for (const key of ['allowDeletion', 'allowNonFastForward', 'allowBypass']) {
+            if (!tTag || !cTag || typeof tTag[key] !== 'boolean' || typeof cTag[key] !== 'boolean') {
+                pushCheck('ruleset root tag ' + key + ' strictness not weakened', false,
+                    'ruleset invariants root-tag ' + key + ' must be a boolean on both sides; fail closed');
+                continue;
+            }
+            const weakened = tTag[key] === false && cTag[key] === true;
+            pushCheck('ruleset root tag ' + key + ' strictness not weakened', !weakened,
+                'candidate weakened root-tag ' + key + ' from ' + tTag[key] + ' to '
+                    + cTag[key] + '; fail closed');
+        }
+    } else {
+        // invariants 模式：候选必须满足最低安全合同（不允许弱于当前期望）
+        pushCheck('invariant: ruleset master requireStrict == true',
+            !!(cMaster && cMaster.requireStrict === true),
+            'candidate ruleset invariants master.requireStrict != true; fail closed');
+        for (const key of ['allowBypass', 'allowDeletion', 'allowNonFastForward']) {
+            pushCheck('invariant: ruleset master ' + key + ' == false',
+                !!(cMaster && cMaster[key] === false),
+                'candidate ruleset invariants master.' + key + ' != false; fail closed');
+        }
+        for (const key of ['allowDeletion', 'allowNonFastForward', 'allowBypass']) {
+            pushCheck('invariant: ruleset root tag ' + key + ' == false',
+                !!(cTag && cTag[key] === false),
+                'candidate ruleset invariants root-tag ' + key + ' != false; fail closed');
+        }
+        pushCheck('invariant: ruleset required checks non-empty',
+            Array.isArray(cMaster && cMaster.requiredChecks)
+                && cMaster.requiredChecks.some((c) => typeof c === 'string' && c.length > 0),
+            'candidate ruleset invariants master.requiredChecks must be non-empty; fail closed');
+    }
 }
 
 function auditPolicy(checks, trustedPolicy, candidatePolicy) {
@@ -888,6 +1007,7 @@ function main() {
         if (args.invariants) {
             // root admission / root adoption：没有 trusted predecessor，用 invariants 作为最低线
             auditInvariants(checks, invariants, candidatePolicy, candidateDoc, candidatePkg, candidateRoot, repoRoot);
+            auditGithubRulesetInvariants(checks, null, candidateRoot);
             if (candidatePolicy) {
                 auditPackage(checks, REQUIRED_SCRIPTS, candidatePkg);
             }
@@ -922,6 +1042,7 @@ function main() {
                 auditExternalWorkflow(checks, trustedExt, candidateExt, rel);
             }
             auditGateSurface(checks, args.trustedDir, candidateRoot);
+            auditGithubRulesetInvariants(checks, args.trustedDir, candidateRoot);
             auditPackage(checks, [...REQUIRED_SCRIPTS, ...(trustedPolicy.requiredPackageScripts || [])], candidatePkg);
             if (invariants) {
                 auditInvariants(checks, invariants, candidatePolicy, candidateDoc, candidatePkg, candidateRoot, repoRoot);

--- a/scripts/ci/gate-parity.mjs
+++ b/scripts/ci/gate-parity.mjs
@@ -357,6 +357,22 @@ function auditWorkflow(checks, trustedDoc, candidateDoc, candidateRoot) {
                 'candidate workflow dropped the required ' + trigger + ' trigger');
         }
     }
+    const trustedPush = trustedDoc && trustedDoc.on && trustedDoc.on.push
+        && typeof trustedDoc.on.push === 'object' ? trustedDoc.on.push : {};
+    const candidatePush = candidateDoc && candidateDoc.on && candidateDoc.on.push
+        && typeof candidateDoc.on.push === 'object' ? candidateDoc.on.push : {};
+    const hasCandidateBranches = Object.prototype.hasOwnProperty.call(candidatePush, 'branches');
+    pushCheck('push coverage does not use a positive branches allow-list', !hasCandidateBranches,
+        'candidate narrowed push coverage with branches: ' + JSON.stringify(candidatePush.branches));
+    const trustedIgnored = Array.isArray(trustedPush['branches-ignore'])
+        ? trustedPush['branches-ignore']
+        : (typeof trustedPush['branches-ignore'] === 'string' ? [trustedPush['branches-ignore']] : []);
+    const candidateIgnored = Array.isArray(candidatePush['branches-ignore'])
+        ? candidatePush['branches-ignore']
+        : (typeof candidatePush['branches-ignore'] === 'string' ? [candidatePush['branches-ignore']] : []);
+    const addedIgnored = candidateIgnored.filter((branch) => !trustedIgnored.includes(branch));
+    pushCheck('push excluded branches not increased', addedIgnored.length === 0,
+        'candidate excluded additional push branches: ' + addedIgnored.join(', '));
 
     // jobs：trusted / required job 集合必须全部存在
     const jobNames = new Set(Object.keys(candidateJobs));
@@ -437,7 +453,8 @@ function auditWorkflow(checks, trustedDoc, candidateDoc, candidateRoot) {
         const matText = fs.readFileSync(matFile, 'utf8');
         const matOk = /ls-tree/.test(matText) && /read-tree/.test(matText)
             && /checkout-index/.test(matText) && /test -s/.test(matText)
-            && /pre-push-guard\.sh/.test(matText) && !isNoopStep(matText);
+            && /pre-push-guard\.sh/.test(matText) && /minimumTrustedVerifier/.test(matText)
+            && !isNoopStep(matText);
         pushCheck('materialize-trusted-gate.sh keeps its materialization behavior', matOk,
             'candidate weakened scripts/ci/materialize-trusted-gate.sh');
     }
@@ -447,6 +464,11 @@ function auditWorkflow(checks, trustedDoc, candidateDoc, candidateRoot) {
         const resOk = /i18n-gate-epoch-2-root/.test(resText)
             && /ROOT_ADMISSION/.test(resText)
             && /trusted_base_sha/.test(resText)
+            && /minimumTrustedVerifier/.test(resText)
+            && /refs\/remotes\/origin/.test(resText)
+            && /--ref/.test(resText)
+            && /args\.gitRef\s*===\s*'refs\/heads\/'\s*\+\s*args\.defaultBranch[\s\S]{0,500}args\.before[\s\S]{0,1500}resolveForkBase/.test(resText)
+            && /isAncestor\(repoRoot, base, candidate\)/.test(resText)
             && (resText.match(/isAncestor\(repoRoot, (root|base),/g) || []).length >= 3
             && /'merge-base', candidate/.test(resText)
             && !isNoopStep(resText);
@@ -454,6 +476,16 @@ function auditWorkflow(checks, trustedDoc, candidateDoc, candidateRoot) {
             'candidate weakened scripts/ci/resolve-trusted-base.mjs (must keep the Epoch 2 root tag /'
                 + ' ROOT_ADMISSION / trusted_base_sha input-precedence logic plus the full ancestry'
                 + ' provenance root <= base < candidate; exit-0 stubs are refused)');
+    }
+    const doctorFile = path.join(candidateRoot, 'scripts', 'ci', 'doctor-github-ruleset.mjs');
+    if (fs.existsSync(doctorFile)) {
+        const doctorText = fs.readFileSync(doctorFile, 'utf8');
+        const doctorOk = (doctorText.match(
+            /bypassActors\.length\s*>\s*0\s*&&\s*!invariants\.allowBypass/g) || []).length >= 2
+            && !/\.filter\([\s\S]{0,200}bypass_mode\s*===\s*['"]always['"]/.test(doctorText)
+            && !isNoopStep(doctorText);
+        pushCheck('doctor-github-ruleset rejects every bypass actor when allowBypass=false', doctorOk,
+            'candidate weakened doctor-github-ruleset.mjs bypass detection');
     }
     const syncFile = path.join(candidateRoot, 'scripts', 'sync-shared-snippets.ps1');
     if (fs.existsSync(syncFile)) {
@@ -480,6 +512,12 @@ function auditWorkflow(checks, trustedDoc, candidateDoc, candidateRoot) {
         pushCheck(jobId + ': materialization cross-check with the trusted helper',
             jobSteps(job).some((s) => /materialize-trusted-gate\.sh/.test(stepRun(s))),
             jobId + ' must cross-check materialization against materialize-trusted-gate.sh');
+        pushCheck(jobId + ': minimumTrustedVerifier applies to NORMAL and ROOT_ADMISSION',
+            jobSteps(job).some((s) =>
+                /ROOT ADMISSION MODE:[^\n]*\n\s*fi[\s\S]{0,300}minimum_json=.*minimumTrustedVerifier/
+                    .test(stepRun(s))),
+            jobId + ' must close the NORMAL/ROOT_ADMISSION branch before enforcing'
+                + ' minimumTrustedVerifier');
     }
 
     // 失败吞没 / 条件跳过禁令：只针对运行关键门禁命令的 step；纯 no-op step 一律拒绝
@@ -720,8 +758,10 @@ function auditGithubRulesetInvariants(checks, trustedDir, candidateRoot) {
         return;
     }
     const cMaster = candidate.master && typeof candidate.master === 'object' ? candidate.master : null;
-    const cTag = candidate['i18n-gate-epoch-2-root'] && typeof candidate['i18n-gate-epoch-2-root'] === 'object'
-        ? candidate['i18n-gate-epoch-2-root'] : null;
+    const rootTagEntries = (value) => Object.entries(value)
+        .filter(([name, rule]) => /^i18n-gate-epoch-[2-9][0-9]*-root$/.test(name)
+            && rule && typeof rule === 'object');
+    const candidateTags = new Map(rootTagEntries(candidate));
 
     if (trustedDir) {
         const trustedFile = path.join(trustedDir, ...RULESET_INVARIANTS_REL.split('/'));
@@ -744,8 +784,7 @@ function auditGithubRulesetInvariants(checks, trustedDir, candidateRoot) {
             'candidate ruleset invariants schemaVersion ' + cs + (ts === null
                 ? ' (trusted schemaVersion missing)' : ' < trusted ' + ts) + '; fail closed');
         const tMaster = trusted.master && typeof trusted.master === 'object' ? trusted.master : null;
-        const tTag = trusted['i18n-gate-epoch-2-root'] && typeof trusted['i18n-gate-epoch-2-root'] === 'object'
-            ? trusted['i18n-gate-epoch-2-root'] : null;
+        const trustedTags = new Map(rootTagEntries(trusted));
         const tChecks = Array.isArray(tMaster && tMaster.requiredChecks)
             ? tMaster.requiredChecks.filter((c) => typeof c === 'string') : [];
         const cChecks = Array.isArray(cMaster && cMaster.requiredChecks)
@@ -768,16 +807,22 @@ function auditGithubRulesetInvariants(checks, trustedDir, candidateRoot) {
                 'candidate weakened master.' + key + ' from ' + tMaster[key] + ' to '
                     + cMaster[key] + '; fail closed');
         }
-        for (const key of ['allowDeletion', 'allowNonFastForward', 'allowBypass']) {
-            if (!tTag || !cTag || typeof tTag[key] !== 'boolean' || typeof cTag[key] !== 'boolean') {
-                pushCheck('ruleset root tag ' + key + ' strictness not weakened', false,
-                    'ruleset invariants root-tag ' + key + ' must be a boolean on both sides; fail closed');
-                continue;
+        for (const [name, tTag] of trustedTags) {
+            const cTag = candidateTags.get(name);
+            for (const key of ['allowDeletion', 'allowNonFastForward', 'allowBypass']) {
+                const valid = !!cTag && typeof tTag[key] === 'boolean' && typeof cTag[key] === 'boolean';
+                const weakened = valid && tTag[key] === false && cTag[key] === true;
+                pushCheck('ruleset root tag ' + name + ' ' + key + ' strictness not weakened',
+                    valid && !weakened,
+                    'candidate removed or weakened root-tag ' + name + '.' + key + '; fail closed');
             }
-            const weakened = tTag[key] === false && cTag[key] === true;
-            pushCheck('ruleset root tag ' + key + ' strictness not weakened', !weakened,
-                'candidate weakened root-tag ' + key + ' from ' + tTag[key] + ' to '
-                    + cTag[key] + '; fail closed');
+        }
+        for (const [name, cTag] of candidateTags) {
+            for (const key of ['allowDeletion', 'allowNonFastForward', 'allowBypass']) {
+                pushCheck('ruleset root tag ' + name + ' ' + key + ' is fail-closed',
+                    cTag[key] === false,
+                    'candidate root-tag ' + name + '.' + key + ' must be false; fail closed');
+            }
         }
     } else {
         // invariants 模式：候选必须满足最低安全合同（不允许弱于当前期望）
@@ -789,10 +834,14 @@ function auditGithubRulesetInvariants(checks, trustedDir, candidateRoot) {
                 !!(cMaster && cMaster[key] === false),
                 'candidate ruleset invariants master.' + key + ' != false; fail closed');
         }
-        for (const key of ['allowDeletion', 'allowNonFastForward', 'allowBypass']) {
-            pushCheck('invariant: ruleset root tag ' + key + ' == false',
-                !!(cTag && cTag[key] === false),
-                'candidate ruleset invariants root-tag ' + key + ' != false; fail closed');
+        pushCheck('invariant: at least one verifier root tag declared', candidateTags.size > 0,
+            'candidate ruleset invariants must declare a verifier root tag; fail closed');
+        for (const [name, cTag] of candidateTags) {
+            for (const key of ['allowDeletion', 'allowNonFastForward', 'allowBypass']) {
+                pushCheck('invariant: ruleset root tag ' + name + ' ' + key + ' == false',
+                    cTag[key] === false,
+                    'candidate ruleset invariants root-tag ' + name + '.' + key + ' != false; fail closed');
+            }
         }
         pushCheck('invariant: ruleset required checks non-empty',
             Array.isArray(cMaster && cMaster.requiredChecks)
@@ -817,6 +866,21 @@ function auditPolicy(checks, trustedPolicy, candidatePolicy) {
         candidatePolicy.contractVersion >= trustedPolicy.contractVersion,
         'candidate contractVersion ' + candidatePolicy.contractVersion
             + ' < trusted ' + trustedPolicy.contractVersion);
+    pushCheck('schemaVersion not lowered',
+        candidatePolicy.schemaVersion >= trustedPolicy.schemaVersion,
+        'candidate schemaVersion ' + candidatePolicy.schemaVersion
+            + ' < trusted ' + trustedPolicy.schemaVersion);
+    const trustedMinimum = trustedPolicy.minimumTrustedVerifier;
+    const candidateMinimum = candidatePolicy.minimumTrustedVerifier;
+    for (const key of ['contractVersion', 'schemaVersion']) {
+        pushCheck('minimum trusted verifier ' + key + ' not lowered',
+            candidateMinimum[key] >= trustedMinimum[key],
+            'candidate minimumTrustedVerifier.' + key + ' ' + candidateMinimum[key]
+                + ' < trusted ' + trustedMinimum[key]);
+    }
+    const removedVerifierFiles = setReduced(trustedMinimum.requiredFiles, candidateMinimum.requiredFiles);
+    pushCheck('minimum trusted verifier required files not reduced', removedVerifierFiles.length === 0,
+        'candidate dropped minimumTrustedVerifier.requiredFiles: ' + removedVerifierFiles.join(', '));
     for (const [name, key] of [
         ['required paths', 'requiredPaths'],
         ['protected branches', 'protectedBranches'],
@@ -880,6 +944,19 @@ function auditInvariants(checks, invariants, candidatePolicy, candidateDoc, cand
             candidatePolicy.contractVersion >= invariants.contractVersion,
             'candidate contractVersion ' + candidatePolicy.contractVersion
                 + ' < invariant ' + invariants.contractVersion);
+        const minimum = invariants.minimumTrustedVerifier;
+        const candidateMinimum = candidatePolicy.minimumTrustedVerifier;
+        for (const key of ['contractVersion', 'schemaVersion']) {
+            pushCheck('invariant: minimumTrustedVerifier.' + key + ' >= ' + minimum[key],
+                candidateMinimum[key] >= minimum[key],
+                'candidate minimumTrustedVerifier.' + key + ' ' + candidateMinimum[key]
+                    + ' < invariant ' + minimum[key]);
+        }
+        const missingVerifierFiles = setReduced(minimum.requiredFiles, candidateMinimum.requiredFiles);
+        pushCheck('invariant: minimumTrustedVerifier.requiredFiles preserved',
+            missingVerifierFiles.length === 0,
+            'candidate minimumTrustedVerifier dropped invariant files: '
+                + missingVerifierFiles.join(', '));
     }
     const candidateJobs = candidateDoc && candidateDoc.jobs && typeof candidateDoc.jobs === 'object'
         ? candidateDoc.jobs : {};
@@ -894,6 +971,19 @@ function auditInvariants(checks, invariants, candidatePolicy, candidateDoc, cand
                 candidateDoc.on[trigger] !== undefined,
                 'candidate workflow dropped the invariant trigger ' + trigger);
         }
+        const pushConfig = candidateDoc.on.push && typeof candidateDoc.on.push === 'object'
+            ? candidateDoc.on.push : {};
+        const hasBranches = Object.prototype.hasOwnProperty.call(pushConfig, 'branches');
+        pushCheck('invariant: quality gate push has no branches allow-list', !hasBranches,
+            'candidate narrowed quality gate push coverage with branches: '
+                + JSON.stringify(pushConfig.branches));
+        const ignored = Array.isArray(pushConfig['branches-ignore'])
+            ? pushConfig['branches-ignore']
+            : (typeof pushConfig['branches-ignore'] === 'string' ? [pushConfig['branches-ignore']] : []);
+        const allowedExcluded = invariants.qualityGatePushCoverage.exclude;
+        const extraExcluded = ignored.filter((branch) => !allowedExcluded.includes(branch));
+        pushCheck('invariant: quality gate push exclusions do not grow', extraExcluded.length === 0,
+            'candidate excluded additional quality gate push branches: ' + extraExcluded.join(', '));
     }
     for (const command of invariants.requiredCommands || []) {
         // token 匹配：命令中每个 token 都必须出现在候选的某个实际执行命令里；

--- a/scripts/ci/materialize-trusted-gate.sh
+++ b/scripts/ci/materialize-trusted-gate.sh
@@ -13,10 +13,8 @@
 # - 独立临时 index：GIT_INDEX_FILE=<index> git read-tree <base>
 # - GIT_INDEX_FILE=<index> git -c core.autocrlf=false checkout-index --stdin --prefix=<output>/ < paths-file
 # - 物化后立即验证 scripts/i18n/check.mjs 与 scripts/hooks/pre-push-guard.sh 存在
-# - 当前 verifier baseline 是强制合同：gate-contract.mjs / gate-policy.json /
-#   lib/trusted-gate.mjs / gate-surface.json / gate-invariants.json / gate-parity.mjs /
-#   resolve-trusted-base.mjs / materialize-trusted-gate.sh / doctor-github-ruleset.mjs
-#   必须全部存在；缺任何一项 → FAIL CLOSED（旧 verifier 无资格审核新标准，无兼容路径）
+# - 当前执行中 verifier 的 gate-policy.minimumTrustedVerifier 是强制合同；trusted base 的
+#   contract / schema / required files 必须满足它，缺任何一项 → FAIL CLOSED。
 # 失败时以非零退出，绝不静默继续。
 set -euo pipefail
 
@@ -78,21 +76,18 @@ test -f "$output/scripts/hooks/pre-push-guard.sh" || {
     echo "materialize-trusted-gate: output is missing scripts/hooks/pre-push-guard.sh; fail closed" >&2
     exit 1
 }
-# 当前 verifier baseline 是强制合同：trusted base 必须携带完整当前标准 verifier 本体，
-# 缺任何一项 → FAIL CLOSED（不存在 predates / fallback / legacy 兼容路径）。
+# 核心 policy / contract / library 必须存在；额外 baseline 由执行中 policy 声明。
 for rel in \
     scripts/i18n/gate-contract.mjs \
     scripts/i18n/gate-policy.json \
-    scripts/i18n/lib/trusted-gate.mjs \
-    scripts/ci/gate-surface.json \
-    scripts/ci/gate-invariants.json \
-    scripts/ci/gate-parity.mjs \
-    scripts/ci/resolve-trusted-base.mjs \
-    scripts/ci/materialize-trusted-gate.sh \
-    scripts/ci/doctor-github-ruleset.mjs; do
+    scripts/i18n/lib/trusted-gate.mjs; do
     test -f "$output/$rel" || {
         echo "materialize-trusted-gate: trusted base $base does not satisfy the current Gate Epoch 2 verifier baseline (missing $rel); fail closed" >&2
         exit 1
     }
 done
+node -e 'const fs=require("fs"),path=require("path"),source=process.argv[1],base=process.argv[2],p=JSON.parse(fs.readFileSync(path.join(source,"scripts/i18n/gate-policy.json"),"utf8")),b=JSON.parse(fs.readFileSync(path.join(base,"scripts/i18n/gate-policy.json"),"utf8")),m=p.minimumTrustedVerifier;if(!m||!Number.isInteger(m.contractVersion)||!Number.isInteger(m.schemaVersion)||!Array.isArray(m.requiredFiles)||!m.requiredFiles.length)throw new Error("invalid minimumTrustedVerifier");if(!Number.isInteger(b.contractVersion)||b.contractVersion<m.contractVersion||!Number.isInteger(b.schemaVersion)||b.schemaVersion<m.schemaVersion)throw new Error("trusted verifier policy is below minimumTrustedVerifier");for(const rel of m.requiredFiles){if(typeof rel!=="string"||!fs.existsSync(path.join(base,...rel.split("/"))))throw new Error("missing "+rel)}' "$repo_root" "$output" || {
+    echo "materialize-trusted-gate: trusted base $base does not satisfy the executing policy.minimumTrustedVerifier; fail closed" >&2
+    exit 1
+}
 echo "materialize-trusted-gate: materialized $(wc -l < "$paths_file" | tr -d ' ') path(s) from $base into $output"

--- a/scripts/ci/materialize-trusted-gate.sh
+++ b/scripts/ci/materialize-trusted-gate.sh
@@ -13,7 +13,10 @@
 # - 独立临时 index：GIT_INDEX_FILE=<index> git read-tree <base>
 # - GIT_INDEX_FILE=<index> git -c core.autocrlf=false checkout-index --stdin --prefix=<output>/ < paths-file
 # - 物化后立即验证 scripts/i18n/check.mjs 与 scripts/hooks/pre-push-guard.sh 存在
-# - 已进入新 contract 架构的 base 再验证 gate-contract.mjs / gate-policy.json / lib/trusted-gate.mjs
+# - 当前 verifier baseline 是强制合同：gate-contract.mjs / gate-policy.json /
+#   lib/trusted-gate.mjs / gate-surface.json / gate-invariants.json / gate-parity.mjs /
+#   resolve-trusted-base.mjs / materialize-trusted-gate.sh / doctor-github-ruleset.mjs
+#   必须全部存在；缺任何一项 → FAIL CLOSED（旧 verifier 无资格审核新标准，无兼容路径）
 # 失败时以非零退出，绝不静默继续。
 set -euo pipefail
 
@@ -75,18 +78,21 @@ test -f "$output/scripts/hooks/pre-push-guard.sh" || {
     echo "materialize-trusted-gate: output is missing scripts/hooks/pre-push-guard.sh; fail closed" >&2
     exit 1
 }
-if git -C "$repo_root" cat-file -e "$base:scripts/i18n/gate-contract.mjs" >/dev/null 2>&1; then
-    test -f "$output/scripts/i18n/gate-contract.mjs" || {
-        echo "materialize-trusted-gate: trusted base has the gate contract but output lacks it; fail closed" >&2
+# 当前 verifier baseline 是强制合同：trusted base 必须携带完整当前标准 verifier 本体，
+# 缺任何一项 → FAIL CLOSED（不存在 predates / fallback / legacy 兼容路径）。
+for rel in \
+    scripts/i18n/gate-contract.mjs \
+    scripts/i18n/gate-policy.json \
+    scripts/i18n/lib/trusted-gate.mjs \
+    scripts/ci/gate-surface.json \
+    scripts/ci/gate-invariants.json \
+    scripts/ci/gate-parity.mjs \
+    scripts/ci/resolve-trusted-base.mjs \
+    scripts/ci/materialize-trusted-gate.sh \
+    scripts/ci/doctor-github-ruleset.mjs; do
+    test -f "$output/$rel" || {
+        echo "materialize-trusted-gate: trusted base $base does not satisfy the current Gate Epoch 2 verifier baseline (missing $rel); fail closed" >&2
         exit 1
     }
-    test -f "$output/scripts/i18n/gate-policy.json" || {
-        echo "materialize-trusted-gate: trusted base has the gate policy but output lacks it; fail closed" >&2
-        exit 1
-    }
-    test -f "$output/scripts/i18n/lib/trusted-gate.mjs" || {
-        echo "materialize-trusted-gate: trusted base has the trusted-gate lib but output lacks it; fail closed" >&2
-        exit 1
-    }
-fi
+done
 echo "materialize-trusted-gate: materialized $(wc -l < "$paths_file" | tr -d ' ') path(s) from $base into $output"

--- a/scripts/ci/resolve-trusted-base.mjs
+++ b/scripts/ci/resolve-trusted-base.mjs
@@ -19,18 +19,17 @@
  *    - inputs.trusted_base_sha 非空 → 使用它（workflow_call 的 github.event_name 是调用方
  *      的原始 event，不能依赖 event 猜测；调用者只 propose，本脚本负责 prove）；
  *    - 否则按当前 event：pull_request → base.sha；merge_group → base_sha；
- *      push → event.before（全零 / 不可解析 → merge-base(candidate, 受保护默认分支) 的
- *      fork base，而不是默认分支当前 tip——默认分支 tip 未必是 candidate 的祖先）；
+ *      push 到受保护默认分支 → event.before；其它分支 push（无论 before 是否非零）→
+ *      merge-base(candidate, 受保护默认分支) 的 fork base；
  *      workflow_dispatch → 默认分支远端 ref；其它 → fail closed；
  *    - 每个来源的 base 都必须满足完整 provenance：base 是 commit、base != candidate、
  *      root ancestor base、base ancestor candidate（root <= base < candidate）。
  *      sibling / descendant / unrelated / pre-root base 全部 fail closed；
- *    - push 的 before 若不是 candidate 祖先（force push / sibling 拓扑）同样 fail closed；
+ *    - 所有 NORMAL base 都必须属于受保护默认分支历史；显式 trusted_base_sha 还必须
+ *      精确等于 candidate 相对受保护默认分支的 predecessor，不能任意选择更老提交；
  *    - base 降级到 Epoch 1 历史一律 fail closed；
- * 8.4 每个 base（含 ROOT_ADMISSION 的 root candidate）还必须满足当前 verifier baseline：
- *    gate-policy.json 存在、gateEpoch == 2、contractVersion >= 4、schemaVersion >= 3、
- *    gate-surface.json / gate-invariants.json / gate-parity.mjs / resolve-trusted-base.mjs /
- *    materialize-trusted-gate.sh / doctor-github-ruleset.mjs 存在；
+ * 8.4 每个 base（含 ROOT_ADMISSION 的 root candidate）还必须满足本 verifier 自身 policy 的
+ *    minimumTrustedVerifier（contractVersion / schemaVersion / requiredFiles）；
  *    缺任何一项 → FAIL CLOSED（verifier rollback / 旧 verifier 审核新标准一律拒绝，
  *    不存在 predates / fallback / legacy / transition 兼容路径）。
  * 2. ROOT_ADMISSION 模式下 base = root（candidate 自身；这是唯一人工 root 例外）。
@@ -47,18 +46,8 @@ const ZERO = '0000000000000000000000000000000000000000';
 const SHA_RE = /^[0-9a-f]{40}$/;
 const ROOT_TAG = 'refs/tags/i18n-gate-epoch-2-root';
 
-/** 当前新标准 verifier 最低能力（与 Epoch 2 历史 root 分开；root 不要求具备，base 必须具备）。 */
-const CURRENT_MIN_CONTRACT_VERSION = 4;
-const CURRENT_MIN_SCHEMA_VERSION = 3;
 const VERIFIER_POLICY_REL = 'scripts/i18n/gate-policy.json';
-const REQUIRED_VERIFIER_FILES = [
-    'scripts/ci/gate-surface.json',
-    'scripts/ci/gate-invariants.json',
-    'scripts/ci/gate-parity.mjs',
-    'scripts/ci/resolve-trusted-base.mjs',
-    'scripts/ci/materialize-trusted-gate.sh',
-    'scripts/ci/doctor-github-ruleset.mjs',
-];
+const OWN_POLICY_FILE = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'i18n', 'gate-policy.json');
 
 function fail(message) {
     console.error('resolve-trusted-base ERROR: ' + message);
@@ -132,13 +121,31 @@ function hasFileAt(repoRoot, sha, rel) {
     }
 }
 
+function loadMinimumTrustedVerifier() {
+    let policy;
+    try {
+        policy = JSON.parse(fs.readFileSync(OWN_POLICY_FILE, 'utf8'));
+    } catch (e) {
+        fail('cannot read this verifier\'s gate-policy.json minimumTrustedVerifier: ' + e.message);
+        return null;
+    }
+    const minimum = policy && policy.minimumTrustedVerifier;
+    if (!minimum || !Number.isInteger(minimum.contractVersion)
+        || !Number.isInteger(minimum.schemaVersion) || !Array.isArray(minimum.requiredFiles)
+        || minimum.requiredFiles.length === 0
+        || minimum.requiredFiles.some((rel) => typeof rel !== 'string' || rel.length === 0)) {
+        fail('this verifier has no valid gate-policy.json minimumTrustedVerifier; fail closed');
+        return null;
+    }
+    return minimum;
+}
+
 /**
- * 校验 trusted base 是否满足当前 verifier baseline（trusted verifier 能力只增不减）。
- * base policy 必须存在、gateEpoch == 2、contractVersion >= CURRENT_MIN_CONTRACT_VERSION、
- * schemaVersion >= CURRENT_MIN_SCHEMA_VERSION、当前 verifier 本体文件齐全；
+ * 校验 trusted base 是否满足执行中 verifier policy 声明的 minimumTrustedVerifier。
+ * minimum 来自本脚本同一 trusted bundle，不能由待审核 base 自行降低。
  * 缺任何一项 → FAIL CLOSED（verifier rollback 一律拒绝，无 predates / fallback / legacy 路径）。
  */
-function assertSupportedTrustedVerifier(repoRoot, base) {
+function assertSupportedTrustedVerifier(repoRoot, base, minimum) {
     const policyText = readFileAt(repoRoot, base, VERIFIER_POLICY_REL);
     if (policyText === null) {
         fail('trusted base ' + base + ' has no gate-policy.json; it does not satisfy the'
@@ -158,21 +165,21 @@ function assertSupportedTrustedVerifier(repoRoot, base) {
         return;
     }
     if (!Number.isInteger(policy.contractVersion)
-        || policy.contractVersion < CURRENT_MIN_CONTRACT_VERSION) {
+        || policy.contractVersion < minimum.contractVersion) {
         fail('trusted base ' + base + ' contractVersion ' + policy.contractVersion
-            + ' < current minimum ' + CURRENT_MIN_CONTRACT_VERSION
+            + ' < current minimum ' + minimum.contractVersion
             + '; the trusted verifier is too old to review current-standard candidates'
             + ' (verifier rollback is refused); fail closed');
         return;
     }
     if (!Number.isInteger(policy.schemaVersion)
-        || policy.schemaVersion < CURRENT_MIN_SCHEMA_VERSION) {
+        || policy.schemaVersion < minimum.schemaVersion) {
         fail('trusted base ' + base + ' schemaVersion ' + policy.schemaVersion
-            + ' < current minimum ' + CURRENT_MIN_SCHEMA_VERSION
+            + ' < current minimum ' + minimum.schemaVersion
             + '; it does not satisfy the current verifier baseline; fail closed');
         return;
     }
-    for (const rel of REQUIRED_VERIFIER_FILES) {
+    for (const rel of minimum.requiredFiles) {
         if (!hasFileAt(repoRoot, base, rel)) {
             fail('trusted base ' + base + ' is missing ' + rel + '; it does not satisfy the'
                 + ' current Gate Epoch 2 verifier baseline; fail closed');
@@ -183,7 +190,7 @@ function assertSupportedTrustedVerifier(repoRoot, base) {
 
 function parseArgs(argv) {
     const args = {
-        repoRoot: null, eventName: null, candidate: null, before: null,
+        repoRoot: null, eventName: null, candidate: null, before: null, gitRef: null,
         prBase: null, mergeGroupBase: null, inputBase: null, defaultBranch: null,
         rootAdmission: null, rootCandidateSha: null, mode: false, version: false,
     };
@@ -198,6 +205,8 @@ function parseArgs(argv) {
             args.candidate = value();
         } else if (arg === '--before') {
             args.before = value();
+        } else if (arg === '--ref') {
+            args.gitRef = value();
         } else if (arg === '--pr-base') {
             args.prBase = value();
         } else if (arg === '--merge-group-base') {
@@ -236,6 +245,22 @@ function resolveForkBase(repoRoot, candidate, defaultBranch) {
     return SHA_RE.test(mb) ? mb : null;
 }
 
+function resolveProtectedPredecessor(repoRoot, candidate, defaultBranch) {
+    const tip = resolveDefaultBranch(repoRoot, defaultBranch);
+    if (!tip) {
+        return null;
+    }
+    if (tip === candidate) {
+        return resolveCommit(repoRoot, candidate + '^');
+    }
+    try {
+        const base = git(['merge-base', candidate, tip], repoRoot);
+        return SHA_RE.test(base) ? base : null;
+    } catch (e) {
+        return null;
+    }
+}
+
 /** 根据 event / inputs 解析 NORMAL 模式 trusted base（input 优先级最高）。 */
 function resolveNormalBase(repoRoot, args) {
     // 1. 显式 input 优先（reusable workflow 的 event_name 是调用方原始 event，不能依赖它）
@@ -250,7 +275,12 @@ function resolveNormalBase(repoRoot, args) {
         return SHA_RE.test(args.mergeGroupBase || '') ? args.mergeGroupBase : null;
     }
     if (event === 'push') {
-        if (SHA_RE.test(args.before || '') && args.before !== ZERO) {
+        if (!args.gitRef) {
+            fail('push event is missing --ref; protected-branch provenance cannot be proved');
+            return null;
+        }
+        if (args.gitRef === 'refs/heads/' + args.defaultBranch
+            && SHA_RE.test(args.before || '') && args.before !== ZERO) {
             const before = resolveCommit(repoRoot, args.before);
             if (!before) {
                 fail('event.before ' + args.before + ' is not present in the local object database');
@@ -258,9 +288,7 @@ function resolveNormalBase(repoRoot, args) {
             }
             return before;
         }
-        // 新分支：不伪装成「默认分支当前 tip → candidate」；
-        // fork base = merge-base(candidate, protected default branch)，随后统一验证
-        // root <= forkBase < candidate。
+        // 非受保护分支不能信任 event.before：它可能是上一次 CI 已失败的恶意 verifier。
         const forkBase = resolveForkBase(repoRoot, args.candidate, args.defaultBranch);
         if (!forkBase) {
             fail('cannot determine a fork base between the candidate and the protected default'
@@ -299,6 +327,10 @@ function main() {
     const candidate = resolveCommit(repoRoot, args.candidate);
     if (!candidate) {
         fail('candidate ' + args.candidate + ' does not resolve to a commit');
+        return;
+    }
+    const minimum = loadMinimumTrustedVerifier();
+    if (!minimum) {
         return;
     }
 
@@ -366,15 +398,29 @@ function main() {
                 + '; sibling / unrelated / descendant / pre-root trusted bases are refused; fail closed');
             return;
         }
-        if (args.eventName === 'push' && args.before && SHA_RE.test(args.before) && args.before !== ZERO
-            && base !== args.before) {
-            fail('trusted base ' + base + ' does not resolve to the push before commit ' + args.before);
+        const protectedTip = resolveDefaultBranch(repoRoot, args.defaultBranch);
+        if (!protectedTip || !isAncestor(repoRoot, base, protectedTip)) {
+            fail('trusted base ' + base + ' is not in the protected default branch history; fail closed');
+            return;
+        }
+        if (SHA_RE.test(args.inputBase || '')) {
+            const expected = resolveProtectedPredecessor(repoRoot, candidate, args.defaultBranch);
+            if (!expected || base !== expected) {
+                fail('explicit trusted_base_sha ' + base + ' is not the protected predecessor '
+                    + (expected || '<unresolved>') + ' for candidate ' + candidate + '; fail closed');
+                return;
+            }
+        }
+        if (args.eventName === 'push' && args.gitRef === 'refs/heads/' + args.defaultBranch
+            && args.before && SHA_RE.test(args.before) && args.before !== ZERO && base !== args.before) {
+            fail('trusted base ' + base + ' does not resolve to the protected push before commit '
+                + args.before);
             return;
         }
     }
     // 8.4：trusted base（或 ROOT_ADMISSION 的 root candidate）必须同时满足 ancestry 与
     // 当前 verifier capability（contract / schema / verifier 本体文件）。缺任何一项 → FAIL CLOSED。
-    assertSupportedTrustedVerifier(repoRoot, base);
+    assertSupportedTrustedVerifier(repoRoot, base, minimum);
 
     if (args.mode) {
         console.log(JSON.stringify({ mode, base, root: root || candidate }));

--- a/scripts/ci/resolve-trusted-base.mjs
+++ b/scripts/ci/resolve-trusted-base.mjs
@@ -275,11 +275,11 @@ function resolveNormalBase(repoRoot, args) {
         return SHA_RE.test(args.mergeGroupBase || '') ? args.mergeGroupBase : null;
     }
     if (event === 'push') {
-        if (!args.gitRef) {
-            fail('push event is missing --ref; protected-branch provenance cannot be proved');
-            return null;
-        }
-        if (args.gitRef === 'refs/heads/' + args.defaultBranch
+        // 新调用方传 --ref；contract v4 trusted helper 调用面没有该参数，因此 workflow
+        // 先把非默认分支的 before 归一化为全零。无 --ref + 非零 before 只提出 protected
+        // predecessor，后续 protected-history / ancestry 证明仍会拒绝 feature commit。
+        if ((args.gitRef === 'refs/heads/' + args.defaultBranch
+                || (!args.gitRef && SHA_RE.test(args.before || '') && args.before !== ZERO))
             && SHA_RE.test(args.before || '') && args.before !== ZERO) {
             const before = resolveCommit(repoRoot, args.before);
             if (!before) {

--- a/scripts/ci/resolve-trusted-base.mjs
+++ b/scripts/ci/resolve-trusted-base.mjs
@@ -26,7 +26,13 @@
  *      root ancestor base、base ancestor candidate（root <= base < candidate）。
  *      sibling / descendant / unrelated / pre-root base 全部 fail closed；
  *    - push 的 before 若不是 candidate 祖先（force push / sibling 拓扑）同样 fail closed；
- *    - base 降级到 Epoch 1 历史一律 fail closed。
+ *    - base 降级到 Epoch 1 历史一律 fail closed；
+ * 8.4 每个 base（含 ROOT_ADMISSION 的 root candidate）还必须满足当前 verifier baseline：
+ *    gate-policy.json 存在、gateEpoch == 2、contractVersion >= 4、schemaVersion >= 3、
+ *    gate-surface.json / gate-invariants.json / gate-parity.mjs / resolve-trusted-base.mjs /
+ *    materialize-trusted-gate.sh / doctor-github-ruleset.mjs 存在；
+ *    缺任何一项 → FAIL CLOSED（verifier rollback / 旧 verifier 审核新标准一律拒绝，
+ *    不存在 predates / fallback / legacy / transition 兼容路径）。
  * 2. ROOT_ADMISSION 模式下 base = root（candidate 自身；这是唯一人工 root 例外）。
  * 3. 结果验证（写 GITHUB_ENV 前）：40 位小写 hex commit SHA；在本地 object database 中存在。
  *
@@ -40,6 +46,19 @@ import { fileURLToPath } from 'url';
 const ZERO = '0000000000000000000000000000000000000000';
 const SHA_RE = /^[0-9a-f]{40}$/;
 const ROOT_TAG = 'refs/tags/i18n-gate-epoch-2-root';
+
+/** 当前新标准 verifier 最低能力（与 Epoch 2 历史 root 分开；root 不要求具备，base 必须具备）。 */
+const CURRENT_MIN_CONTRACT_VERSION = 4;
+const CURRENT_MIN_SCHEMA_VERSION = 3;
+const VERIFIER_POLICY_REL = 'scripts/i18n/gate-policy.json';
+const REQUIRED_VERIFIER_FILES = [
+    'scripts/ci/gate-surface.json',
+    'scripts/ci/gate-invariants.json',
+    'scripts/ci/gate-parity.mjs',
+    'scripts/ci/resolve-trusted-base.mjs',
+    'scripts/ci/materialize-trusted-gate.sh',
+    'scripts/ci/doctor-github-ruleset.mjs',
+];
 
 function fail(message) {
     console.error('resolve-trusted-base ERROR: ' + message);
@@ -92,6 +111,74 @@ function resolveDefaultBranch(repoRoot, defaultBranch) {
         return resolveCommit(repoRoot, 'refs/remotes/origin/' + defaultBranch);
     }
     return null;
+}
+
+/** 读 ref 处的文件内容；不存在返回 null。 */
+function readFileAt(repoRoot, sha, rel) {
+    try {
+        return git(['show', sha + ':' + rel], repoRoot);
+    } catch (e) {
+        return null;
+    }
+}
+
+/** ref 处是否存在文件。 */
+function hasFileAt(repoRoot, sha, rel) {
+    try {
+        git(['cat-file', '-e', sha + ':' + rel], repoRoot);
+        return true;
+    } catch (e) {
+        return false;
+    }
+}
+
+/**
+ * 校验 trusted base 是否满足当前 verifier baseline（trusted verifier 能力只增不减）。
+ * base policy 必须存在、gateEpoch == 2、contractVersion >= CURRENT_MIN_CONTRACT_VERSION、
+ * schemaVersion >= CURRENT_MIN_SCHEMA_VERSION、当前 verifier 本体文件齐全；
+ * 缺任何一项 → FAIL CLOSED（verifier rollback 一律拒绝，无 predates / fallback / legacy 路径）。
+ */
+function assertSupportedTrustedVerifier(repoRoot, base) {
+    const policyText = readFileAt(repoRoot, base, VERIFIER_POLICY_REL);
+    if (policyText === null) {
+        fail('trusted base ' + base + ' has no gate-policy.json; it does not satisfy the'
+            + ' current Gate Epoch 2 verifier baseline; fail closed');
+        return;
+    }
+    let policy;
+    try {
+        policy = JSON.parse(policyText);
+    } catch (e) {
+        fail('trusted base ' + base + ' gate-policy.json is invalid; fail closed');
+        return;
+    }
+    if (policy.gateEpoch !== 2) {
+        fail('trusted base ' + base + ' gateEpoch ' + policy.gateEpoch
+            + ' != 2; it does not satisfy the current verifier baseline; fail closed');
+        return;
+    }
+    if (!Number.isInteger(policy.contractVersion)
+        || policy.contractVersion < CURRENT_MIN_CONTRACT_VERSION) {
+        fail('trusted base ' + base + ' contractVersion ' + policy.contractVersion
+            + ' < current minimum ' + CURRENT_MIN_CONTRACT_VERSION
+            + '; the trusted verifier is too old to review current-standard candidates'
+            + ' (verifier rollback is refused); fail closed');
+        return;
+    }
+    if (!Number.isInteger(policy.schemaVersion)
+        || policy.schemaVersion < CURRENT_MIN_SCHEMA_VERSION) {
+        fail('trusted base ' + base + ' schemaVersion ' + policy.schemaVersion
+            + ' < current minimum ' + CURRENT_MIN_SCHEMA_VERSION
+            + '; it does not satisfy the current verifier baseline; fail closed');
+        return;
+    }
+    for (const rel of REQUIRED_VERIFIER_FILES) {
+        if (!hasFileAt(repoRoot, base, rel)) {
+            fail('trusted base ' + base + ' is missing ' + rel + '; it does not satisfy the'
+                + ' current Gate Epoch 2 verifier baseline; fail closed');
+            return;
+        }
+    }
 }
 
 function parseArgs(argv) {
@@ -197,7 +284,7 @@ function main() {
         return;
     }
     if (args.version) {
-        console.log('resolve-trusted-base 3');
+        console.log('resolve-trusted-base 4');
         return;
     }
     if (!args.repoRoot || !args.eventName || !args.candidate) {
@@ -285,6 +372,9 @@ function main() {
             return;
         }
     }
+    // 8.4：trusted base（或 ROOT_ADMISSION 的 root candidate）必须同时满足 ancestry 与
+    // 当前 verifier capability（contract / schema / verifier 本体文件）。缺任何一项 → FAIL CLOSED。
+    assertSupportedTrustedVerifier(repoRoot, base);
 
     if (args.mode) {
         console.log(JSON.stringify({ mode, base, root: root || candidate }));

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -49,6 +49,13 @@ set -euo pipefail
 root="$(git rev-parse --show-toplevel)"
 cd "$root"
 
+run_without_local_git_env() (
+    for name in $(git rev-parse --local-env-vars); do
+        unset "$name"
+    done
+    "$@"
+)
+
 docs_hint="see README (online docs: https://sywyar.github.io/PixivDownloader/#/zh-cn/development)"
 
 staged="$(git diff --cached --name-only 2>/dev/null || true)"
@@ -63,27 +70,26 @@ if ! command -v node >/dev/null 2>&1; then
     exit 1
 fi
 
-# ---- 1. Epoch 2 trust anchor：epoch 缺失 / 非 2 → fail closed，绝不迁移 ----
+# ---- 1. Current trust anchor: missing / invalid epoch -> fail closed ----
 epoch="$(git config --local --get pixiv.i18n.trustedGateEpoch || true)"
 trusted="$(git config --local --get pixiv.i18n.trustedGateRef || true)"
-if [ -z "$trusted" ] || [ -z "$epoch" ] || [ "$epoch" != "2" ]; then
+if [ -z "$trusted" ] || ! printf '%s' "$epoch" | grep -Eq '^[2-9][0-9]*$'; then
     echo "pre-commit: Your local gate anchor belongs to an obsolete or uninitialized epoch." >&2
-    echo "pre-commit: Run the explicit Epoch 2 root adoption command:" >&2
-    echo "pre-commit:   npm run i18n:trust-gate -- --adopt-root --ref HEAD --epoch 2" >&2
+    echo "pre-commit: Run the explicit current root adoption command." >&2
     echo "pre-commit: this is a local convenience gate; the final gate is the GitHub required check." >&2
     exit 1
 fi
 if ! git rev-parse --verify --quiet "$trusted^{commit}" >/dev/null 2>&1; then
     echo "pre-commit: trusted gate anchor $trusted does not resolve to a commit in this repository." >&2
-    echo "pre-commit: restore the anchor or re-run: npm run i18n:trust-gate -- --adopt-root --ref HEAD --epoch 2" >&2
+    echo "pre-commit: restore or explicitly re-adopt the current root." >&2
     exit 1
 fi
-# 本地已安装 Epoch 2 root tag 时，anchor 必须包含该 root（防止锚点回退到 Epoch 1 历史）
-if git rev-parse --verify --quiet "refs/tags/i18n-gate-epoch-2-root^{commit}" >/dev/null 2>&1; then
-    root_sha="$(git rev-parse --verify --quiet "refs/tags/i18n-gate-epoch-2-root^{commit}")"
+# 本地已安装当前 root tag 时，anchor 必须包含该 root。
+root_tag="i18n-gate-epoch-${epoch}-root"
+if git rev-parse --verify --quiet "refs/tags/${root_tag}^{commit}" >/dev/null 2>&1; then
+    root_sha="$(git rev-parse --verify --quiet "refs/tags/${root_tag}^{commit}")"
     if ! git merge-base --is-ancestor "$root_sha" "$trusted" >/dev/null 2>&1; then
-        echo "pre-commit: trusted anchor $trusted does not descend from the Gate Epoch 2 trust root $root_sha." >&2
-        echo "pre-commit: re-adopt the Epoch 2 root: npm run i18n:trust-gate -- --adopt-root --ref HEAD --epoch 2" >&2
+        echo "pre-commit: trusted anchor $trusted does not descend from the Gate Epoch $epoch trust root $root_sha." >&2
         exit 1
     fi
 fi
@@ -100,7 +106,11 @@ trap cleanup EXIT
 materialize_trusted_gate() {
     local out="$1"
     local paths
-    paths="$(git ls-tree -r --name-only "$trusted" -- scripts/i18n scripts/hooks scripts/ci scripts/sync-shared-snippets.ps1)"
+    paths="$(git ls-tree -r --name-only "$trusted" -- \
+        scripts/i18n scripts/hooks scripts/ci scripts/sync-shared-snippets.ps1 \
+        .github/workflows/quality-gate.yml .github/workflows/shared-snippets-check.yml \
+        .github/workflows/release.yml .github/workflows/nightly.yml \
+        .github/workflows/publish-plugins.yml package.json package-lock.json)"
     if [ -z "$paths" ]; then
         echo "pre-commit: trusted anchor $trusted does not contain the i18n gate bundle (scripts/i18n, scripts/hooks)." >&2
         exit 1
@@ -135,29 +145,36 @@ else
 fi
 
 materialize_trusted_gate "$tmpdir/trusted"
-
-# ---- 2.5 trusted verifier 必须满足当前 verifier baseline（能力只增不减，不兼容旧 verifier） ----
-# 当前新标准最低能力：contractVersion >= 4 / schemaVersion >= 3 / verifier 本体文件齐全；
-# 低于此线的 trusted anchor → OUTDATED GATE VERIFIER → fail closed（无 predates / fallback / legacy）
-for rel in scripts/ci/gate-surface.json scripts/ci/gate-invariants.json scripts/ci/gate-parity.mjs scripts/ci/resolve-trusted-base.mjs scripts/ci/materialize-trusted-gate.sh scripts/ci/doctor-github-ruleset.mjs; do
-    if [ ! -f "$tmpdir/trusted/$rel" ]; then
-        echo "pre-commit: trusted gate anchor $trusted predates the current verifier baseline (missing $rel); OUTDATED GATE VERIFIER; fail closed." >&2
-        echo "pre-commit: advance or re-adopt a current Gate Epoch 2 verifier:" >&2
-        echo "pre-commit:   npm run i18n:trust-gate -- --advance --ref <new-approved-verifier>" >&2
-        exit 1
-    fi
-done
-base_contract="$(node -e 'const p=require(process.argv[1]);process.stdout.write(String(p.contractVersion??""))' "$tmpdir/trusted/scripts/i18n/gate-policy.json" 2>/dev/null || printf '%s' '')"
-base_schema="$(node -e 'const p=require(process.argv[1]);process.stdout.write(String(p.schemaVersion??""))' "$tmpdir/trusted/scripts/i18n/gate-policy.json" 2>/dev/null || printf '%s' '')"
-if ! [[ "$base_contract" =~ ^[0-9]+$ ]] || [ "$base_contract" -lt 4 ]; then
-    echo "pre-commit: trusted gate anchor $trusted contractVersion ($base_contract) is below the current minimum 4; OUTDATED GATE VERIFIER; fail closed." >&2
-    echo "pre-commit: advance or re-adopt a current Gate Epoch 2 verifier:" >&2
-    echo "pre-commit:   npm run i18n:trust-gate -- --advance --ref <new-approved-verifier>" >&2
+trusted_policy_epoch="$(node -e 'const fs=require("fs");const p=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));process.stdout.write(String(p.gateEpoch||""))' "$tmpdir/trusted/scripts/i18n/gate-policy.json")"
+if [ "$trusted_policy_epoch" != "$epoch" ]; then
+    echo "pre-commit: configured epoch $epoch does not match trusted anchor policy epoch $trusted_policy_epoch; fail closed." >&2
     exit 1
 fi
-if ! [[ "$base_schema" =~ ^[0-9]+$ ]] || [ "$base_schema" -lt 3 ]; then
-    echo "pre-commit: trusted gate anchor $trusted schemaVersion ($base_schema) is below the current minimum 3; OUTDATED GATE VERIFIER; fail closed." >&2
-    echo "pre-commit: advance or re-adopt a current Gate Epoch 2 verifier." >&2
+
+# A next-epoch root may be committed exactly once after explicit root preparation. The ticket is
+# outside the candidate tree and binds both its staged tree and its single parent.
+prepared_epoch="$(git config --local --get pixiv.i18n.preparedRootEpoch || true)"
+prepared_parent="$(git config --local --get pixiv.i18n.preparedRootParent || true)"
+prepared_tree="$(git config --local --get pixiv.i18n.preparedRootTree || true)"
+candidate_epoch="$(git show :scripts/i18n/gate-policy.json 2>/dev/null | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(String(JSON.parse(s).gateEpoch||""))}catch{}})')"
+current_parent="$(git rev-parse HEAD)"
+current_tree="$(git write-tree)"
+next_epoch="$((epoch + 1))"
+if [ "$prepared_epoch" = "$next_epoch" ] && [ "$candidate_epoch" = "$next_epoch" ] \
+    && [ "$prepared_parent" = "$current_parent" ] && [ "$prepared_tree" = "$current_tree" ]; then
+    prepared_root=1
+else
+    prepared_root=0
+fi
+
+# ---- 2.5 trusted verifier 必须满足执行中 policy.minimumTrustedVerifier（能力只增不减） ----
+baseline_source="$root"
+if [ "$prepared_root" = "1" ]; then
+    baseline_source="$tmpdir/trusted"
+fi
+if ! node -e 'const fs=require("fs"),path=require("path"),source=process.argv[1],base=process.argv[2],sourceFile=path.join(source,"scripts/i18n/gate-policy.json"),b=JSON.parse(fs.readFileSync(path.join(base,"scripts/i18n/gate-policy.json"),"utf8")),p=fs.existsSync(sourceFile)?JSON.parse(fs.readFileSync(sourceFile,"utf8")):{},m=p.minimumTrustedVerifier||b.minimumTrustedVerifier;if(!m||!Number.isInteger(m.contractVersion)||!Number.isInteger(m.schemaVersion)||!Array.isArray(m.requiredFiles)||!m.requiredFiles.length)process.exit(1);if(!Number.isInteger(b.contractVersion)||b.contractVersion<m.contractVersion||!Number.isInteger(b.schemaVersion)||b.schemaVersion<m.schemaVersion)process.exit(1);for(const rel of m.requiredFiles){if(typeof rel!=="string"||!fs.existsSync(path.join(base,...rel.split("/"))))process.exit(1)}' "$baseline_source" "$tmpdir/trusted"; then
+    echo "pre-commit: trusted gate anchor $trusted does not satisfy the executing policy.minimumTrustedVerifier; OUTDATED GATE VERIFIER; fail closed." >&2
+    echo "pre-commit: advance or explicitly adopt a current Gate Epoch verifier." >&2
     exit 1
 fi
 
@@ -184,10 +201,14 @@ fi
 
 # ---- 6. gate 文件变更：trusted contract 验证候选 index（candidate 不能自批准） ----
 if [ "$gate_changed" = "1" ]; then
-    echo "pre-commit: gate files staged, running the trusted gate contract against the candidate index..."
-    node "$tmpdir/trusted/scripts/i18n/gate-contract.mjs" \
-        --repo-root "$root" --report-root "$root" \
-        --candidate-snapshot index
+    if [ "$prepared_root" = "1" ]; then
+        echo "pre-commit: exact prepared Gate Epoch $candidate_epoch root candidate accepted for commit."
+    else
+        echo "pre-commit: gate files staged, running the trusted gate contract against the candidate index..."
+        run_without_local_git_env node "$tmpdir/trusted/scripts/i18n/gate-contract.mjs" \
+            --repo-root "$root" --report-root "$root" \
+            --candidate-snapshot index
+    fi
 fi
 
 echo "pre-commit: index snapshot i18n gate passed."

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -136,15 +136,34 @@ fi
 
 materialize_trusted_gate "$tmpdir/trusted"
 
+# ---- 2.5 trusted verifier 必须满足当前 verifier baseline（能力只增不减，不兼容旧 verifier） ----
+# 当前新标准最低能力：contractVersion >= 4 / schemaVersion >= 3 / verifier 本体文件齐全；
+# 低于此线的 trusted anchor → OUTDATED GATE VERIFIER → fail closed（无 predates / fallback / legacy）
+for rel in scripts/ci/gate-surface.json scripts/ci/gate-invariants.json scripts/ci/gate-parity.mjs scripts/ci/resolve-trusted-base.mjs scripts/ci/materialize-trusted-gate.sh scripts/ci/doctor-github-ruleset.mjs; do
+    if [ ! -f "$tmpdir/trusted/$rel" ]; then
+        echo "pre-commit: trusted gate anchor $trusted predates the current verifier baseline (missing $rel); OUTDATED GATE VERIFIER; fail closed." >&2
+        echo "pre-commit: advance or re-adopt a current Gate Epoch 2 verifier:" >&2
+        echo "pre-commit:   npm run i18n:trust-gate -- --advance --ref <new-approved-verifier>" >&2
+        exit 1
+    fi
+done
+base_contract="$(node -e 'const p=require(process.argv[1]);process.stdout.write(String(p.contractVersion??""))' "$tmpdir/trusted/scripts/i18n/gate-policy.json" 2>/dev/null || printf '%s' '')"
+base_schema="$(node -e 'const p=require(process.argv[1]);process.stdout.write(String(p.schemaVersion??""))' "$tmpdir/trusted/scripts/i18n/gate-policy.json" 2>/dev/null || printf '%s' '')"
+if ! [[ "$base_contract" =~ ^[0-9]+$ ]] || [ "$base_contract" -lt 4 ]; then
+    echo "pre-commit: trusted gate anchor $trusted contractVersion ($base_contract) is below the current minimum 4; OUTDATED GATE VERIFIER; fail closed." >&2
+    echo "pre-commit: advance or re-adopt a current Gate Epoch 2 verifier:" >&2
+    echo "pre-commit:   npm run i18n:trust-gate -- --advance --ref <new-approved-verifier>" >&2
+    exit 1
+fi
+if ! [[ "$base_schema" =~ ^[0-9]+$ ]] || [ "$base_schema" -lt 3 ]; then
+    echo "pre-commit: trusted gate anchor $trusted schemaVersion ($base_schema) is below the current minimum 3; OUTDATED GATE VERIFIER; fail closed." >&2
+    echo "pre-commit: advance or re-adopt a current Gate Epoch 2 verifier." >&2
+    exit 1
+fi
+
 # gate 变更检测使用 trusted 的 gate-surface.json 单一清单（与 pre-push / contract / parity /
-# CI bootstrap 同一外围 Gate Surface）；trusted bundle 早于清单时回退内置默认列表。
-gate_re=""
-if [ -f "$tmpdir/trusted/scripts/ci/gate-surface.json" ]; then
-    gate_re="$(node -e 'const fs=require("fs");const m=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));const esc=(p)=>p.replace(/[.*+?^${}()|[\]\\]/g,"\\$&");process.stdout.write((m.paths||[]).filter(p=>typeof p==="string").map(esc).map(p=>"^"+p+"(/|$)").join("|"))' "$tmpdir/trusted/scripts/ci/gate-surface.json")"
-fi
-if [ -z "$gate_re" ]; then
-    gate_re='^(scripts/(i18n|hooks|ci)/|scripts/sync-shared-snippets\.ps1$|\.github/workflows/(quality-gate|shared-snippets-check|release|nightly|publish-plugins)\.yml$|package\.json$|package-lock\.json$)'
-fi
+# CI bootstrap 同一外围 Gate Surface）；baseline 已保证清单存在，不存在回退内置默认列表的路径。
+gate_re="$(node -e 'const fs=require("fs");const m=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));const esc=(p)=>p.replace(/[.*+?^${}()|[\]\\]/g,"\\$&");process.stdout.write((m.paths||[]).filter(p=>typeof p==="string").map(esc).map(p=>"^"+p+"(/|$)").join("|"))' "$tmpdir/trusted/scripts/ci/gate-surface.json")"
 if printf '%s\n' "$staged" | grep -Eq "$gate_re"; then
     gate_changed=1
 else

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -151,17 +151,21 @@ if [ "$trusted_policy_epoch" != "$epoch" ]; then
     exit 1
 fi
 
-# A next-epoch root may be committed exactly once after explicit root preparation. The ticket is
-# outside the candidate tree and binds both its staged tree and its single parent.
-prepared_epoch="$(git config --local --get pixiv.i18n.preparedRootEpoch || true)"
-prepared_parent="$(git config --local --get pixiv.i18n.preparedRootParent || true)"
-prepared_tree="$(git config --local --get pixiv.i18n.preparedRootTree || true)"
+# A next-epoch root may be committed exactly once after the previous trusted verifier issues an
+# external ticket. It binds both epochs, the exact trusted source, its parent and its staged tree.
+admission_source_epoch="$(git config --local --get pixiv.i18n.firstAdmissionSourceEpoch || true)"
+admission_target_epoch="$(git config --local --get pixiv.i18n.firstAdmissionTargetEpoch || true)"
+admission_trusted_source="$(git config --local --get pixiv.i18n.firstAdmissionTrustedSource || true)"
+admission_parent="$(git config --local --get pixiv.i18n.firstAdmissionParent || true)"
+admission_tree="$(git config --local --get pixiv.i18n.firstAdmissionTree || true)"
 candidate_epoch="$(git show :scripts/i18n/gate-policy.json 2>/dev/null | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(String(JSON.parse(s).gateEpoch||""))}catch{}})')"
 current_parent="$(git rev-parse HEAD)"
 current_tree="$(git write-tree)"
 next_epoch="$((epoch + 1))"
-if [ "$prepared_epoch" = "$next_epoch" ] && [ "$candidate_epoch" = "$next_epoch" ] \
-    && [ "$prepared_parent" = "$current_parent" ] && [ "$prepared_tree" = "$current_tree" ]; then
+if [ "$admission_source_epoch" = "$epoch" ] && [ "$admission_target_epoch" = "$next_epoch" ] \
+    && [ "$candidate_epoch" = "$next_epoch" ] && [ "$admission_trusted_source" = "$trusted" ] \
+    && [ "$admission_parent" = "$trusted" ] && [ "$admission_parent" = "$current_parent" ] \
+    && [ "$admission_tree" = "$current_tree" ]; then
     prepared_root=1
 else
     prepared_root=0
@@ -202,7 +206,7 @@ fi
 # ---- 6. gate 文件变更：trusted contract 验证候选 index（candidate 不能自批准） ----
 if [ "$gate_changed" = "1" ]; then
     if [ "$prepared_root" = "1" ]; then
-        echo "pre-commit: exact prepared Gate Epoch $candidate_epoch root candidate accepted for commit."
+        echo "pre-commit: exact trusted first-admission Gate Epoch $candidate_epoch root candidate accepted for commit."
     else
         echo "pre-commit: gate files staged, running the trusted gate contract against the candidate index..."
         run_without_local_git_env node "$tmpdir/trusted/scripts/i18n/gate-contract.mjs" \

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -64,6 +64,13 @@ set -euo pipefail
 root="$(git rev-parse --show-toplevel)"
 cd "$root"
 
+run_without_local_git_env() (
+    for name in $(git rev-parse --local-env-vars); do
+        unset "$name"
+    done
+    "$@"
+)
+
 remote_name="${1:-}"
 remote_url="${2:-}"
 if [ -z "$remote_name" ]; then
@@ -80,27 +87,26 @@ if ! command -v node >/dev/null 2>&1; then
     exit 1
 fi
 
-# ---- 1. Epoch 2 trust anchor：epoch 缺失 / 非 2 → fail closed，绝不迁移 ----
+# ---- 1. Current trust anchor: missing / invalid epoch -> fail closed ----
 epoch="$(git config --local --get pixiv.i18n.trustedGateEpoch || true)"
 trusted="$(git config --local --get pixiv.i18n.trustedGateRef || true)"
-if [ -z "$trusted" ] || [ -z "$epoch" ] || [ "$epoch" != "2" ]; then
+if [ -z "$trusted" ] || ! printf '%s' "$epoch" | grep -Eq '^[2-9][0-9]*$'; then
     echo "pre-push: Your local gate anchor belongs to an obsolete or uninitialized epoch." >&2
-    echo "pre-push: Run the explicit Epoch 2 root adoption command:" >&2
-    echo "pre-push:   npm run i18n:trust-gate -- --adopt-root --ref HEAD --epoch 2" >&2
+    echo "pre-push: Run the explicit current root adoption command." >&2
     echo "pre-push: this is a local convenience gate; the final gate is the GitHub required check." >&2
     exit 1
 fi
 if ! git rev-parse --verify --quiet "$trusted^{commit}" >/dev/null 2>&1; then
     echo "pre-push: trusted gate anchor $trusted does not resolve to a commit in this repository." >&2
-    echo "pre-push: restore the anchor or re-run: npm run i18n:trust-gate -- --adopt-root --ref HEAD --epoch 2" >&2
+    echo "pre-push: restore or explicitly re-adopt the current root." >&2
     exit 1
 fi
-# 本地已安装 Epoch 2 root tag 时，anchor 必须包含该 root
-if git rev-parse --verify --quiet "refs/tags/i18n-gate-epoch-2-root^{commit}" >/dev/null 2>&1; then
-    root_sha="$(git rev-parse --verify --quiet "refs/tags/i18n-gate-epoch-2-root^{commit}")"
+# 本地已安装当前 root tag 时，anchor 必须包含该 root
+root_tag="i18n-gate-epoch-${epoch}-root"
+if git rev-parse --verify --quiet "refs/tags/${root_tag}^{commit}" >/dev/null 2>&1; then
+    root_sha="$(git rev-parse --verify --quiet "refs/tags/${root_tag}^{commit}")"
     if ! git merge-base --is-ancestor "$root_sha" "$trusted" >/dev/null 2>&1; then
-        echo "pre-push: trusted anchor $trusted does not descend from the Gate Epoch 2 trust root $root_sha." >&2
-        echo "pre-push: re-adopt the Epoch 2 root: npm run i18n:trust-gate -- --adopt-root --ref HEAD --epoch 2" >&2
+        echo "pre-push: trusted anchor $trusted does not descend from the Gate Epoch $epoch trust root $root_sha." >&2
         exit 1
     fi
 fi
@@ -122,7 +128,11 @@ trap cleanup EXIT
 
 # ---- 2. 物化 trusted anchor 的 gate bundle（一次） ----
 trusted_dir="$tmpdir/trusted"
-trusted_paths="$(git ls-tree -r --name-only "$trusted" -- scripts/i18n scripts/hooks scripts/ci scripts/sync-shared-snippets.ps1)"
+trusted_paths="$(git ls-tree -r --name-only "$trusted" -- \
+    scripts/i18n scripts/hooks scripts/ci scripts/sync-shared-snippets.ps1 \
+    .github/workflows/quality-gate.yml .github/workflows/shared-snippets-check.yml \
+    .github/workflows/release.yml .github/workflows/nightly.yml \
+    .github/workflows/publish-plugins.yml package.json package-lock.json)"
 if [ -z "$trusted_paths" ]; then
     echo "pre-push: trusted anchor $trusted does not contain the i18n gate bundle (scripts/i18n, scripts/hooks)." >&2
     exit 1
@@ -141,12 +151,17 @@ if [ ! -f "$trusted_dir/scripts/hooks/pre-push-guard.sh" ]; then
 fi
 if [ ! -f "$trusted_dir/scripts/i18n/gate-policy.json" ]; then
     echo "pre-push: trusted gate bundle is incomplete (scripts/i18n/gate-policy.json missing at $trusted); fail closed." >&2
-    echo "pre-push: Epoch 2 anchors always carry the gate policy; obsolete epochs are not migrated." >&2
+    echo "pre-push: current anchors always carry the gate policy; obsolete epochs are not migrated." >&2
     exit 1
 fi
 if [ ! -f "$trusted_dir/scripts/i18n/gate-contract.mjs" ]; then
     echo "pre-push: trusted gate bundle is incomplete (scripts/i18n/gate-contract.mjs missing at $trusted); fail closed." >&2
-    echo "pre-push: Epoch 2 anchors always carry the gate contract; obsolete epochs are not migrated." >&2
+    echo "pre-push: current anchors always carry the gate contract; obsolete epochs are not migrated." >&2
+    exit 1
+fi
+trusted_policy_epoch="$(node -e 'const fs=require("fs");const p=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));process.stdout.write(String(p.gateEpoch||""))' "$trusted_dir/scripts/i18n/gate-policy.json")"
+if [ "$trusted_policy_epoch" != "$epoch" ]; then
+    echo "pre-push: configured epoch $epoch does not match trusted anchor policy epoch $trusted_policy_epoch; fail closed." >&2
     exit 1
 fi
 start="$(node -e 'const fs=require("fs");const p=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));process.stdout.write(p.i18nEnforcementStartCommit)' "$trusted_dir/scripts/i18n/gate-policy.json")"
@@ -156,28 +171,10 @@ if ! git rev-parse --verify --quiet "$start^{commit}" >/dev/null 2>&1; then
     exit 1
 fi
 
-# ---- 2.5 trusted verifier 必须满足当前 verifier baseline（能力只增不减，不兼容旧 verifier） ----
-# 当前新标准最低能力：contractVersion >= 4 / schemaVersion >= 3 / verifier 本体文件齐全；
-# 低于此线的 trusted anchor → OUTDATED GATE VERIFIER → fail closed（无 predates / fallback / legacy）
-for rel in scripts/ci/gate-surface.json scripts/ci/gate-invariants.json scripts/ci/gate-parity.mjs scripts/ci/resolve-trusted-base.mjs scripts/ci/materialize-trusted-gate.sh scripts/ci/doctor-github-ruleset.mjs; do
-    if [ ! -f "$trusted_dir/$rel" ]; then
-        echo "pre-push: trusted gate anchor $trusted predates the current verifier baseline (missing $rel); OUTDATED GATE VERIFIER; fail closed." >&2
-        echo "pre-push: advance or re-adopt a current Gate Epoch 2 verifier:" >&2
-        echo "pre-push:   npm run i18n:trust-gate -- --advance --ref <new-approved-verifier>" >&2
-        exit 1
-    fi
-done
-base_contract="$(node -e 'const p=require(process.argv[1]);process.stdout.write(String(p.contractVersion??""))' "$trusted_dir/scripts/i18n/gate-policy.json" 2>/dev/null || printf '%s' '')"
-base_schema="$(node -e 'const p=require(process.argv[1]);process.stdout.write(String(p.schemaVersion??""))' "$trusted_dir/scripts/i18n/gate-policy.json" 2>/dev/null || printf '%s' '')"
-if ! [[ "$base_contract" =~ ^[0-9]+$ ]] || [ "$base_contract" -lt 4 ]; then
-    echo "pre-push: trusted gate anchor $trusted contractVersion ($base_contract) is below the current minimum 4; OUTDATED GATE VERIFIER; fail closed." >&2
-    echo "pre-push: advance or re-adopt a current Gate Epoch 2 verifier:" >&2
-    echo "pre-push:   npm run i18n:trust-gate -- --advance --ref <new-approved-verifier>" >&2
-    exit 1
-fi
-if ! [[ "$base_schema" =~ ^[0-9]+$ ]] || [ "$base_schema" -lt 3 ]; then
-    echo "pre-push: trusted gate anchor $trusted schemaVersion ($base_schema) is below the current minimum 3; OUTDATED GATE VERIFIER; fail closed." >&2
-    echo "pre-push: advance or re-adopt a current Gate Epoch 2 verifier." >&2
+# ---- 2.5 trusted verifier 必须满足执行中 policy.minimumTrustedVerifier（能力只增不减） ----
+if ! node -e 'const fs=require("fs"),path=require("path"),source=process.argv[1],base=process.argv[2],sourceFile=path.join(source,"scripts/i18n/gate-policy.json"),b=JSON.parse(fs.readFileSync(path.join(base,"scripts/i18n/gate-policy.json"),"utf8")),p=fs.existsSync(sourceFile)?JSON.parse(fs.readFileSync(sourceFile,"utf8")):{},m=p.minimumTrustedVerifier||b.minimumTrustedVerifier;if(!m||!Number.isInteger(m.contractVersion)||!Number.isInteger(m.schemaVersion)||!Array.isArray(m.requiredFiles)||!m.requiredFiles.length)process.exit(1);if(!Number.isInteger(b.contractVersion)||b.contractVersion<m.contractVersion||!Number.isInteger(b.schemaVersion)||b.schemaVersion<m.schemaVersion)process.exit(1);for(const rel of m.requiredFiles){if(typeof rel!=="string"||!fs.existsSync(path.join(base,...rel.split("/"))))process.exit(1)}' "$root" "$trusted_dir"; then
+    echo "pre-push: trusted gate anchor $trusted does not satisfy the executing policy.minimumTrustedVerifier; OUTDATED GATE VERIFIER; fail closed." >&2
+    echo "pre-push: advance or explicitly adopt a current Gate Epoch verifier." >&2
     exit 1
 fi
 
@@ -406,7 +403,8 @@ echo "pre-push: verifying $count pushed commit(s) against the trusted i18n gate 
         fi
         if [ "$contract" = "1" ]; then
             echo "pre-push: commit $sha proposes gate changes; running the trusted gate contract..."
-            if ! node "$trusted_dir/scripts/i18n/gate-contract.mjs" --repo-root "$root" --report-root "$root" \
+            if ! run_without_local_git_env node "$trusted_dir/scripts/i18n/gate-contract.mjs" \
+                --repo-root "$root" --report-root "$root" \
                 --candidate-ref "$sha" >"$tmpdir/contract-$sha.log" 2>&1; then
                 echo "pre-push: FAILED — commit $sha does not pass the trusted gate contract (candidate gate cannot self-approve)." >&2
                 cat "$tmpdir/contract-$sha.log" >&2

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -156,15 +156,34 @@ if ! git rev-parse --verify --quiet "$start^{commit}" >/dev/null 2>&1; then
     exit 1
 fi
 
+# ---- 2.5 trusted verifier 必须满足当前 verifier baseline（能力只增不减，不兼容旧 verifier） ----
+# 当前新标准最低能力：contractVersion >= 4 / schemaVersion >= 3 / verifier 本体文件齐全；
+# 低于此线的 trusted anchor → OUTDATED GATE VERIFIER → fail closed（无 predates / fallback / legacy）
+for rel in scripts/ci/gate-surface.json scripts/ci/gate-invariants.json scripts/ci/gate-parity.mjs scripts/ci/resolve-trusted-base.mjs scripts/ci/materialize-trusted-gate.sh scripts/ci/doctor-github-ruleset.mjs; do
+    if [ ! -f "$trusted_dir/$rel" ]; then
+        echo "pre-push: trusted gate anchor $trusted predates the current verifier baseline (missing $rel); OUTDATED GATE VERIFIER; fail closed." >&2
+        echo "pre-push: advance or re-adopt a current Gate Epoch 2 verifier:" >&2
+        echo "pre-push:   npm run i18n:trust-gate -- --advance --ref <new-approved-verifier>" >&2
+        exit 1
+    fi
+done
+base_contract="$(node -e 'const p=require(process.argv[1]);process.stdout.write(String(p.contractVersion??""))' "$trusted_dir/scripts/i18n/gate-policy.json" 2>/dev/null || printf '%s' '')"
+base_schema="$(node -e 'const p=require(process.argv[1]);process.stdout.write(String(p.schemaVersion??""))' "$trusted_dir/scripts/i18n/gate-policy.json" 2>/dev/null || printf '%s' '')"
+if ! [[ "$base_contract" =~ ^[0-9]+$ ]] || [ "$base_contract" -lt 4 ]; then
+    echo "pre-push: trusted gate anchor $trusted contractVersion ($base_contract) is below the current minimum 4; OUTDATED GATE VERIFIER; fail closed." >&2
+    echo "pre-push: advance or re-adopt a current Gate Epoch 2 verifier:" >&2
+    echo "pre-push:   npm run i18n:trust-gate -- --advance --ref <new-approved-verifier>" >&2
+    exit 1
+fi
+if ! [[ "$base_schema" =~ ^[0-9]+$ ]] || [ "$base_schema" -lt 3 ]; then
+    echo "pre-push: trusted gate anchor $trusted schemaVersion ($base_schema) is below the current minimum 3; OUTDATED GATE VERIFIER; fail closed." >&2
+    echo "pre-push: advance or re-adopt a current Gate Epoch 2 verifier." >&2
+    exit 1
+fi
+
 # gate 变更检测使用 trusted 的 gate-surface.json 单一清单（与 pre-commit / contract / parity /
-# CI bootstrap 同一外围 Gate Surface）；trusted bundle 早于清单时回退内置默认列表。
-gate_re=""
-if [ -f "$trusted_dir/scripts/ci/gate-surface.json" ]; then
-    gate_re="$(node -e 'const fs=require("fs");const m=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));const esc=(p)=>p.replace(/[.*+?^${}()|[\]\\]/g,"\\$&");process.stdout.write((m.paths||[]).filter(p=>typeof p==="string").map(esc).map(p=>"^"+p+"(/|$)").join("|"))' "$trusted_dir/scripts/ci/gate-surface.json")"
-fi
-if [ -z "$gate_re" ]; then
-    gate_re='^(scripts/(i18n|hooks|ci)/|scripts/sync-shared-snippets\.ps1$|\.github/workflows/(quality-gate|shared-snippets-check|release|nightly|publish-plugins)\.yml$|package\.json$|package-lock\.json$)'
-fi
+# CI bootstrap 同一外围 Gate Surface）；baseline 已保证清单存在，不存在回退内置默认列表的路径。
+gate_re="$(node -e 'const fs=require("fs");const m=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));const esc=(p)=>p.replace(/[.*+?^${}()|[\]\\]/g,"\\$&");process.stdout.write((m.paths||[]).filter(p=>typeof p==="string").map(esc).map(p=>"^"+p+"(/|$)").join("|"))' "$trusted_dir/scripts/ci/gate-surface.json")"
 
 # ---- 3. 真实远端状态：ls-remote + 临时 namespace fetch（refs/remotes 不作数） ----
 remote_refs="$tmpdir/remote-refs"

--- a/scripts/i18n/epoch-2-first-admission.json
+++ b/scripts/i18n/epoch-2-first-admission.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "sourceEpoch": 2,
+  "targetEpoch": 3,
+  "protectedBranchRef": "refs/remotes/origin/master",
+  "requiredContextReplacements": {
+    "Quality Gate / java-tests": "java-tests",
+    "Quality Gate / javascript-tests": "javascript-tests",
+    "Quality Gate / signature-guard": "signature-guard",
+    "Quality Gate / trusted-gate-contract": "trusted-gate-contract",
+    "Quality Gate / i18n-check": "i18n-check",
+    "Shared Snippet Drift Check / check-shared-snippets": "check-shared-snippets"
+  },
+  "allowedChangedPaths": [
+    ".github/workflows/quality-gate.yml",
+    "scripts/ci/gate-invariants.json",
+    "scripts/ci/gate-parity.mjs",
+    "scripts/ci/github-ruleset-invariants.json",
+    "scripts/ci/resolve-trusted-base.mjs",
+    "scripts/hooks/pre-commit",
+    "scripts/hooks/pre-push",
+    "scripts/i18n/epoch-2-first-admission.json",
+    "scripts/i18n/gate-contract.mjs",
+    "scripts/i18n/gate-policy.json",
+    "scripts/i18n/lib/trusted-gate.mjs",
+    "scripts/i18n/test/doctor-github-ruleset.test.mjs",
+    "scripts/i18n/test/gate-monotonicity.test.mjs",
+    "scripts/i18n/test/hooks.test.mjs",
+    "scripts/i18n/test/quality-gate-root-admission.test.mjs",
+    "scripts/i18n/test/quality-gate-workflow.test.mjs",
+    "scripts/i18n/test/trust-gate.test.mjs",
+    "scripts/i18n/test/verifier-rollback.test.mjs",
+    "scripts/i18n/trust-gate.mjs"
+  ]
+}

--- a/scripts/i18n/epoch-2-first-admission.json
+++ b/scripts/i18n/epoch-2-first-admission.json
@@ -2,6 +2,8 @@
   "schemaVersion": 1,
   "sourceEpoch": 2,
   "targetEpoch": 3,
+  "protectedRemote": "origin",
+  "protectedBranch": "refs/heads/master",
   "protectedBranchRef": "refs/remotes/origin/master",
   "requiredContextReplacements": {
     "Quality Gate / java-tests": "java-tests",

--- a/scripts/i18n/gate-contract.mjs
+++ b/scripts/i18n/gate-contract.mjs
@@ -18,7 +18,8 @@
  *   （candidate == root 时运行 root 自身 gate + 全量 root self-protection suite，
  *   由 --force-self-protection 关闭归纳跳过）；
  * - candidate 可以提出新 policy，但当前 trusted contract 必须审核它：gateEpoch 不得改变、
- *   contractVersion 不得降低、i18nEnforcementStartCommit 不得向后移动或删除、
+ *   contractVersion / schemaVersion / minimumTrustedVerifier 不得降低、
+ *   i18nEnforcementStartCommit 不得向后移动或删除、
  *   required paths / protectedBranches / requiredWorkflowJobs / requiredPackageScripts /
  *   requiredExternalChecks 集合不得减少（允许新增）；
  * - required paths 使用 trusted ∪ candidate 并集：candidate 新声明的 required path 必须在
@@ -1145,6 +1146,31 @@ function runWorkflowContractChecks(repoRoot, candidateRoot) {
         pushCheck(checks, 'trigger ' + trigger + ' is preserved', triggers[trigger] !== undefined,
             'candidate workflow dropped the ' + trigger + ' trigger');
     }
+    const pushConfig = triggers.push && typeof triggers.push === 'object' ? triggers.push : {};
+    const hasCandidateBranches = Object.prototype.hasOwnProperty.call(pushConfig, 'branches');
+    pushCheck(checks, 'push coverage does not use a positive branches allow-list',
+        !hasCandidateBranches,
+        'candidate quality-gate.yml narrowed push coverage with branches: '
+            + JSON.stringify(pushConfig.branches) + '; fail closed');
+    try {
+        const YAML = loadYamlModule(repoRoot);
+        const trustedWorkflow = YAML.parse(fs.readFileSync(
+            path.join(OWN_DIR, '..', '..', ...WORKFLOW_REL.split('/')), 'utf8'));
+        const trustedPush = trustedWorkflow.on && trustedWorkflow.on.push
+            && typeof trustedWorkflow.on.push === 'object' ? trustedWorkflow.on.push : {};
+        const trustedIgnored = Array.isArray(trustedPush['branches-ignore'])
+            ? trustedPush['branches-ignore']
+            : (typeof trustedPush['branches-ignore'] === 'string' ? [trustedPush['branches-ignore']] : []);
+        const candidateIgnored = Array.isArray(pushConfig['branches-ignore'])
+            ? pushConfig['branches-ignore']
+            : (typeof pushConfig['branches-ignore'] === 'string' ? [pushConfig['branches-ignore']] : []);
+        const addedIgnored = candidateIgnored.filter((branch) => !trustedIgnored.includes(branch));
+        pushCheck(checks, 'push excluded branches not increased', addedIgnored.length === 0,
+            'candidate excluded additional push branches: ' + addedIgnored.join(', ') + '; fail closed');
+    } catch (e) {
+        pushCheck(checks, 'trusted push coverage can be loaded', false,
+            'cannot load trusted quality-gate push coverage: ' + e.message);
+    }
 
     // Epoch 2：workflow_dispatch 必须提供显式 root admission inputs（人工触发专用）
     const dispatch = triggers.workflow_dispatch && typeof triggers.workflow_dispatch === 'object'
@@ -1180,7 +1206,8 @@ function runWorkflowContractChecks(repoRoot, candidateRoot) {
         const matText = fs.readFileSync(matHelper, 'utf8');
         const matOk = /ls-tree/.test(matText) && /read-tree/.test(matText)
             && /checkout-index/.test(matText) && /test -s/.test(matText)
-            && /pre-push-guard\.sh/.test(matText) && !isNoopStep(matText);
+            && /pre-push-guard\.sh/.test(matText) && /minimumTrustedVerifier/.test(matText)
+            && !isNoopStep(matText);
         pushCheck(checks, 'materialize-trusted-gate.sh keeps its materialization behavior', matOk,
             'candidate weakened scripts/ci/materialize-trusted-gate.sh (must keep ls-tree/read-tree/'
                 + 'checkout-index/test -s/pre-push-guard.sh semantics; exit-0 stubs are refused)');
@@ -1191,15 +1218,33 @@ function runWorkflowContractChecks(repoRoot, candidateRoot) {
         const resOk = /i18n-gate-epoch-2-root/.test(resText)
             && /ROOT_ADMISSION/.test(resText)
             && /trusted_base_sha/.test(resText)
+            && /minimumTrustedVerifier/.test(resText)
+            && /refs\/remotes\/origin/.test(resText)
+            && /--ref/.test(resText)
+            && /args\.gitRef\s*===\s*'refs\/heads\/'\s*\+\s*args\.defaultBranch[\s\S]{0,500}args\.before[\s\S]{0,1500}resolveForkBase/.test(resText)
+            && /isAncestor\(repoRoot, base, candidate\)/.test(resText)
             && (resText.match(/isAncestor\(repoRoot, (root|base),/g) || []).length >= 3
             && /'merge-base', candidate/.test(resText)
             && !isNoopStep(resText);
         pushCheck(checks, 'resolve-trusted-base.mjs keeps root/input-precedence/ancestry semantics', resOk,
             'candidate weakened scripts/ci/resolve-trusted-base.mjs (must keep the Epoch 2 root tag /'
-                + ' ROOT_ADMISSION / trusted_base_sha input-precedence logic plus the full ancestry'
+                + ' ROOT_ADMISSION / trusted_base_sha input-precedence / minimumTrustedVerifier'
+                + ' / protected-default-history logic plus the full ancestry'
                 + ' provenance root <= base < candidate — root->candidate, root->base, base->candidate'
                 + ' isAncestor checks and the new-branch fork-base merge-base(candidate, default);'
                 + ' exit-0 stubs are refused)');
+    }
+    const doctorFile = path.join(candidateRoot, 'scripts', 'ci', 'doctor-github-ruleset.mjs');
+    if (fs.existsSync(doctorFile)) {
+        const doctorText = fs.readFileSync(doctorFile, 'utf8');
+        const doctorOk = (doctorText.match(
+            /bypassActors\.length\s*>\s*0\s*&&\s*!invariants\.allowBypass/g) || []).length >= 2
+            && !/\.filter\([\s\S]{0,200}bypass_mode\s*===\s*['"]always['"]/.test(doctorText)
+            && !isNoopStep(doctorText);
+        pushCheck(checks, 'doctor-github-ruleset rejects every bypass actor when allowBypass=false',
+            doctorOk,
+            'candidate weakened doctor-github-ruleset.mjs: allowBypass=false must reject every'
+                + ' master/root-tag bypass actor, not only bypass_mode=always');
     }
 
     // 关键行为 step 的失败吞没 / 条件跳过禁令：只针对运行关键门禁命令的 step
@@ -1277,6 +1322,13 @@ function runWorkflowContractChecks(repoRoot, candidateRoot) {
         pushCheck(checks, jobId + ': materialization cross-check with the trusted helper',
             hasMatHelper,
             jobId + ' must cross-check inline materialization against scripts/ci/materialize-trusted-gate.sh');
+        const minimumRunsInBothModes = jobSteps(job).some((s) =>
+            /ROOT ADMISSION MODE:[^\n]*\n\s*fi[\s\S]{0,300}minimum_json=.*minimumTrustedVerifier/
+                .test(stepRun(s)));
+        pushCheck(checks, jobId + ': minimumTrustedVerifier applies to NORMAL and ROOT_ADMISSION',
+            minimumRunsInBothModes,
+            jobId + ' must close the NORMAL/ROOT_ADMISSION branch before enforcing'
+                + ' minimumTrustedVerifier; NORMAL candidates cannot skip the baseline');
     }
 
     const jGuard = jobs['signature-guard'];
@@ -1800,10 +1852,11 @@ function runRulesetInvariantsContract(candidateRoot) {
 
     const tMaster = trusted.master && typeof trusted.master === 'object' ? trusted.master : null;
     const cMaster = candidate.master && typeof candidate.master === 'object' ? candidate.master : null;
-    const tTag = trusted['i18n-gate-epoch-2-root'] && typeof trusted['i18n-gate-epoch-2-root'] === 'object'
-        ? trusted['i18n-gate-epoch-2-root'] : null;
-    const cTag = candidate['i18n-gate-epoch-2-root'] && typeof candidate['i18n-gate-epoch-2-root'] === 'object'
-        ? candidate['i18n-gate-epoch-2-root'] : null;
+    const rootTagEntries = (value) => Object.entries(value)
+        .filter(([name, rule]) => /^i18n-gate-epoch-[2-9][0-9]*-root$/.test(name)
+            && rule && typeof rule === 'object');
+    const trustedTags = new Map(rootTagEntries(trusted));
+    const candidateTags = new Map(rootTagEntries(candidate));
     const tChecks = Array.isArray(tMaster && tMaster.requiredChecks)
         ? tMaster.requiredChecks.filter((c) => typeof c === 'string') : [];
     const cChecks = Array.isArray(cMaster && cMaster.requiredChecks)
@@ -1825,16 +1878,22 @@ function runRulesetInvariantsContract(candidateRoot) {
             'candidate weakened master.' + key + ' from ' + tMaster[key] + ' to '
                 + cMaster[key] + '; fail closed');
     }
-    for (const key of ['allowDeletion', 'allowNonFastForward', 'allowBypass']) {
-        if (!tTag || !cTag || typeof tTag[key] !== 'boolean' || typeof cTag[key] !== 'boolean') {
-            pushCheck(checks, 'ruleset root tag ' + key + ' strictness not weakened', false,
-                'ruleset invariants root-tag ' + key + ' must be a boolean on both sides; fail closed');
-            continue;
+    for (const [name, tTag] of trustedTags) {
+        const cTag = candidateTags.get(name);
+        for (const key of ['allowDeletion', 'allowNonFastForward', 'allowBypass']) {
+            const valid = !!cTag && typeof tTag[key] === 'boolean' && typeof cTag[key] === 'boolean';
+            const weakened = valid && tTag[key] === false && cTag[key] === true;
+            pushCheck(checks, 'ruleset root tag ' + name + ' ' + key + ' strictness not weakened',
+                valid && !weakened,
+                'candidate removed or weakened root-tag ' + name + '.' + key + '; fail closed');
         }
-        const weakened = tTag[key] === false && cTag[key] === true;
-        pushCheck(checks, 'ruleset root tag ' + key + ' strictness not weakened', !weakened,
-            'candidate weakened root-tag ' + key + ' from ' + tTag[key] + ' to '
-                + cTag[key] + '; fail closed');
+    }
+    for (const [name, cTag] of candidateTags) {
+        for (const key of ['allowDeletion', 'allowNonFastForward', 'allowBypass']) {
+            pushCheck(checks, 'ruleset root tag ' + name + ' ' + key + ' is fail-closed',
+                cTag[key] === false,
+                'candidate root-tag ' + name + '.' + key + ' must be false; fail closed');
+        }
     }
     return checks;
 }
@@ -1952,14 +2011,30 @@ function runHookContentChecks(candidateRoot) {
             continue;
         }
         const content = fs.readFileSync(file, 'utf8');
+        const preparedRootBound = hook !== 'pre-commit'
+            || (/preparedRootEpoch/.test(content)
+                && /preparedRootParent/.test(content)
+                && /preparedRootTree/.test(content)
+                && /git write-tree/.test(content)
+                && /prepared_parent.*current_parent/.test(content)
+                && /prepared_tree.*current_tree/.test(content));
+        const localGitEnvIsolated = /git rev-parse --local-env-vars/.test(content)
+            && /unset "\$name"/.test(content)
+            && /run_without_local_git_env node/.test(content);
         const ok = !isNoopStep(content)
             && /trustedGateRef/.test(content)
-            && /trustedGateEpoch/.test(content);
+            && /trustedGateEpoch/.test(content)
+            && /minimumTrustedVerifier/.test(content)
+            && localGitEnvIsolated
+            && preparedRootBound;
         checks.push({
             name: 'candidate ' + hook + ' keeps trusted-anchor semantics', kind: 'hooks-static',
-            expected: 'trustedGateRef + trustedGateEpoch routing with real commands', status: null, ok,
+            expected: 'trustedGateRef + trustedGateEpoch + minimumTrustedVerifier routing'
+                + ' + isolated trusted-contract Git environment'
+                + (hook === 'pre-commit' ? ' + exact prepared-root parent/tree binding' : ''), status: null, ok,
             diagnostic: ok ? '' : 'candidate ' + hook + ' was weakened (missing trustedGateRef /'
-                + ' trustedGateEpoch routing, or reduced to a no-op stub); fail closed',
+                + ' trustedGateEpoch routing / trusted-contract Git environment isolation / prepared-root'
+                + ' binding, or reduced to a no-op stub); fail closed',
         });
     }
     return checks;
@@ -2168,7 +2243,7 @@ async function runSelfProtection(repoRoot, candidateRoot, trustedPolicy, hasCont
             }, null, 2) + '\n', 'utf8');
         }
         git(['add', '-A'], repo);
-        git(['commit', '-q', '-m', 'malicious next gate'], repo);
+        git(['-c', 'core.hooksPath=/dev/null', 'commit', '-q', '-m', 'malicious next gate'], repo);
         const malicious = git(['rev-parse', 'HEAD'], repo);
         const candidateContract = path.join(candidateRoot, 'scripts', 'i18n', 'gate-contract.mjs');
         const result = run(['node', candidateContract, '--repo-root', repo, '--candidate-ref', malicious],
@@ -2179,6 +2254,40 @@ async function runSelfProtection(repoRoot, candidateRoot, trustedPolicy, hasCont
             kind: 'self-protection', expected: 'exit != 0', status: result.status, ok,
             diagnostic: ok ? '' : 'candidate contract accepted a no-op checker gate (exit 0);'
                 + ' the candidate contract cannot protect the next upgrade',
+        });
+
+        git(['reset', '-q', '--hard', 'HEAD~1'], repo, { stdio: 'ignore' });
+        const minimumPolicy = JSON.parse(fs.readFileSync(policyPath, 'utf8'));
+        minimumPolicy.minimumTrustedVerifier.contractVersion -= 1;
+        fs.writeFileSync(policyPath, JSON.stringify(minimumPolicy, null, 2) + '\n', 'utf8');
+        git(['add', '-A'], repo);
+        git(['-c', 'core.hooksPath=/dev/null', 'commit', '-q', '-m', 'lower minimum verifier baseline'], repo);
+        const minimumCandidate = git(['rev-parse', 'HEAD'], repo);
+        const minimumResult = run(['node', candidateContract, '--repo-root', repo,
+            '--candidate-ref', minimumCandidate], { cwd: repo });
+        results.push({
+            name: 'candidate contract must reject a minimumTrustedVerifier downgrade by itself',
+            kind: 'self-protection', expected: 'exit != 0', status: minimumResult.status,
+            ok: minimumResult.status !== 0,
+            diagnostic: minimumResult.status !== 0 ? ''
+                : 'candidate contract accepted minimumTrustedVerifier.contractVersion downgrade',
+        });
+
+        git(['reset', '-q', '--hard', 'HEAD~1'], repo, { stdio: 'ignore' });
+        const coverageDoc = loadYamlModule(repo).parse(fs.readFileSync(workflowFile, 'utf8'));
+        coverageDoc.on.push = { branches: ['master'] };
+        fs.writeFileSync(workflowFile, loadYamlModule(repo).stringify(coverageDoc), 'utf8');
+        git(['add', '-A'], repo);
+        git(['-c', 'core.hooksPath=/dev/null', 'commit', '-q', '-m', 'narrow quality gate push coverage'], repo);
+        const coverageCandidate = git(['rev-parse', 'HEAD'], repo);
+        const coverageResult = run(['node', candidateContract, '--repo-root', repo,
+            '--candidate-ref', coverageCandidate], { cwd: repo });
+        results.push({
+            name: 'candidate contract must reject branches-ignore to branches master downgrade by itself',
+            kind: 'self-protection', expected: 'exit != 0', status: coverageResult.status,
+            ok: coverageResult.status !== 0,
+            diagnostic: coverageResult.status !== 0 ? ''
+                : 'candidate contract accepted narrowed quality-gate push coverage',
         });
     } finally {
         rmrf(repo);
@@ -2320,6 +2429,40 @@ async function main() {
                     expected: '>= ' + trustedPolicy.contractVersion, status: null, ok: true, diagnostic: '',
                 });
             }
+            if (candidatePolicy.schemaVersion < trustedPolicy.schemaVersion) {
+                checks.push({
+                    name: 'candidate schemaVersion not lowered', kind: 'policy',
+                    expected: '>= ' + trustedPolicy.schemaVersion, status: null, ok: false,
+                    diagnostic: 'candidate schemaVersion ' + candidatePolicy.schemaVersion
+                        + ' < trusted ' + trustedPolicy.schemaVersion,
+                });
+            } else {
+                checks.push({
+                    name: 'candidate schemaVersion not lowered', kind: 'policy',
+                    expected: '>= ' + trustedPolicy.schemaVersion, status: null, ok: true, diagnostic: '',
+                });
+            }
+            const trustedMinimum = trustedPolicy.minimumTrustedVerifier;
+            const candidateMinimum = candidatePolicy.minimumTrustedVerifier;
+            for (const key of ['contractVersion', 'schemaVersion']) {
+                const ok = candidateMinimum[key] >= trustedMinimum[key];
+                checks.push({
+                    name: 'minimum trusted verifier ' + key + ' not lowered', kind: 'policy',
+                    expected: '>= ' + trustedMinimum[key], status: null, ok,
+                    diagnostic: ok ? '' : 'candidate minimumTrustedVerifier.' + key + ' '
+                        + candidateMinimum[key] + ' < trusted ' + trustedMinimum[key] + '; fail closed',
+                });
+            }
+            const removedVerifierFiles = trustedGate.policySetReduced(
+                trustedMinimum.requiredFiles, candidateMinimum.requiredFiles);
+            checks.push({
+                name: 'minimum trusted verifier required files not reduced', kind: 'policy',
+                expected: 'candidate keeps all trusted verifier files', status: null,
+                ok: removedVerifierFiles.length === 0,
+                diagnostic: removedVerifierFiles.length > 0
+                    ? 'candidate dropped minimumTrustedVerifier.requiredFiles: '
+                        + removedVerifierFiles.join(', ') : '',
+            });
             // 7.1 Epoch 不得变化：正常 advance 只能 same epoch；2 → 1 / 2 → 3 属于另一轮人工 root reset
             if (candidatePolicy.gateEpoch !== trustedPolicy.gateEpoch) {
                 checks.push({

--- a/scripts/i18n/gate-contract.mjs
+++ b/scripts/i18n/gate-contract.mjs
@@ -2012,12 +2012,14 @@ function runHookContentChecks(candidateRoot) {
         }
         const content = fs.readFileSync(file, 'utf8');
         const preparedRootBound = hook !== 'pre-commit'
-            || (/preparedRootEpoch/.test(content)
-                && /preparedRootParent/.test(content)
-                && /preparedRootTree/.test(content)
+            || (/firstAdmissionSourceEpoch/.test(content)
+                && /firstAdmissionTargetEpoch/.test(content)
+                && /firstAdmissionTrustedSource/.test(content)
+                && /firstAdmissionParent/.test(content)
+                && /firstAdmissionTree/.test(content)
                 && /git write-tree/.test(content)
-                && /prepared_parent.*current_parent/.test(content)
-                && /prepared_tree.*current_tree/.test(content));
+                && /admission_parent.*current_parent/.test(content)
+                && /admission_tree.*current_tree/.test(content));
         const localGitEnvIsolated = /git rev-parse --local-env-vars/.test(content)
             && /unset "\$name"/.test(content)
             && /run_without_local_git_env node/.test(content);
@@ -2036,6 +2038,24 @@ function runHookContentChecks(candidateRoot) {
                 + ' trustedGateEpoch routing / trusted-contract Git environment isolation / prepared-root'
                 + ' binding, or reduced to a no-op stub); fail closed',
         });
+    }
+    return checks;
+}
+
+function runFirstAdmissionBridgeContract(candidateRoot) {
+    const checks = [];
+    const specName = 'epoch-2-first-admission.json';
+    const trustedSpec = path.join(OWN_DIR, specName);
+    if (!fs.existsSync(trustedSpec)) {
+        return checks;
+    }
+    for (const rel of [specName, 'trust-gate.mjs']) {
+        const trustedFile = path.join(OWN_DIR, rel);
+        const candidateFile = path.join(candidateRoot, 'scripts', 'i18n', rel);
+        const identical = fs.existsSync(candidateFile)
+            && fs.readFileSync(candidateFile).equals(fs.readFileSync(trustedFile));
+        pushCheck(checks, 'Epoch 2 first-admission ' + rel + ' is frozen to the trusted bundle',
+            identical, identical ? '' : 'candidate changed or removed the one-time trusted bridge; fail closed');
     }
     return checks;
 }
@@ -2605,6 +2625,23 @@ async function main() {
         checks.push(...runGateSurfaceContract(candidateRoot, trustedPolicy));
         checks.push(...runRulesetInvariantsContract(candidateRoot));
         checks.push(...runHookContentChecks(candidateRoot));
+        const bridgeChecks = runFirstAdmissionBridgeContract(candidateRoot);
+        checks.push(...bridgeChecks);
+        if (bridgeChecks.some((check) => !check.ok)) {
+            for (const check of bridgeChecks.filter((entry) => !entry.ok)) {
+                diagnostics.push('FAIL: ' + check.name + ' — ' + check.diagnostic);
+            }
+            const payload = {
+                contractVersion: CONTRACT_VERSION,
+                trustedPolicy,
+                candidate: { mode: args.mode, ref: candidateRef, policyProposal: candidatePolicy || null },
+                requiredPaths: required,
+                checks, verdict: 'fail', diagnostics,
+            };
+            emitFailure(reportRoot, payload, args.mode === 'ref' ? candidateRef : 'index');
+            process.exitCode = 1;
+            return;
+        }
 
         const hasChecker = fs.existsSync(path.join(candidateRoot, 'scripts', 'i18n', 'check.mjs'));
         const hasHooks = fs.existsSync(path.join(candidateRoot, 'scripts', 'hooks'));

--- a/scripts/i18n/gate-contract.mjs
+++ b/scripts/i18n/gate-contract.mjs
@@ -17,7 +17,7 @@
  *   普通候选必须由 trusted predecessor 审核；root admission 是唯一显式人工例外
  *   （candidate == root 时运行 root 自身 gate + 全量 root self-protection suite，
  *   由 --force-self-protection 关闭归纳跳过）；
- * - candidate 可以提出新 policy，但旧 trusted contract 必须审核它：gateEpoch 不得改变、
+ * - candidate 可以提出新 policy，但当前 trusted contract 必须审核它：gateEpoch 不得改变、
  *   contractVersion 不得降低、i18nEnforcementStartCommit 不得向后移动或删除、
  *   required paths / protectedBranches / requiredWorkflowJobs / requiredPackageScripts /
  *   requiredExternalChecks 集合不得减少（允许新增）；
@@ -40,6 +40,11 @@
  *   needs 链 + publish 的 needs.quality-gate.result == 'success'），禁止 always() 绕过；
  * - gate-surface.json 清单契约：candidate manifest 只能被检查（不能决定检查范围），
  *   不得删除 trusted 条目，不得声明不存在的路径；
+ * - github-ruleset-invariants.json 契约：candidate 必须携带该清单，schemaVersion 只增不减，
+ *   requiredChecks 只增（trusted ⊆ candidate），requireStrict 只允许 false→true，
+ *   allowBypass / allowDeletion / allowNonFastForward 只允许 true→false；
+ * - 本 contract 自身就是 trusted verifier：启动时断言自身满足当前 verifier baseline
+ *   （contractVersion / schemaVersion / verifier 本体文件），旧 verifier → fail closed；
  * - 外部 checker：candidate scripts/sync-shared-snippets.ps1 内容守卫 + 黑盒行为
  *   （drift fixture 必须 exit != 0，合法同步 exit 0）；
  * - 自保护：构造「下一代恶意 gate」（no-op checker / hooks / guard / workflow 弱化 /
@@ -431,8 +436,9 @@ async function runCheckerScenarios(candidateRoot, hasChecker, skip) {
         return results;
     }
     if (!hasChecker) {
-        results.push({ name: 'checker-bundle', kind: 'report', expected: null, status: null, ok: true,
-            diagnostic: 'candidate has no scripts/i18n/check.mjs (predates the i18n gate); black-box scenarios skipped' });
+        results.push({ name: 'checker-bundle', kind: 'report', expected: null, status: null, ok: false,
+            diagnostic: 'candidate has no scripts/i18n/check.mjs (part of the current verifier'
+                + ' baseline; deletion must fail closed)' });
         return results;
     }
 
@@ -634,7 +640,7 @@ async function makeContractRepo(repoRoot, candidateRoot, trustedPolicy) {
                 fs.symlinkSync(repoNodeModules, path.join(repo, 'node_modules'));
             }
         } catch (ignored) {
-            // 链接失败不阻断：候选 predates workflow 时不需要 yaml
+            // 链接失败不阻断：yaml 解析走 NODE_PATH 兜底（等价 CI 的 npm ci）
         }
     }
     // C1：candidate gate bundle（无 policy）
@@ -735,8 +741,9 @@ async function runHookScenarios(repoRoot, candidateRoot, trustedPolicy, hasHooks
         return results;
     }
     if (!hasHooks) {
-        results.push({ name: 'hooks-bundle', kind: 'report', expected: null, status: null, ok: true,
-            diagnostic: 'candidate has no scripts/hooks; hook behavior scenarios skipped' });
+        results.push({ name: 'hooks-bundle', kind: 'report', expected: null, status: null, ok: false,
+            diagnostic: 'candidate has no scripts/hooks (part of the current verifier baseline;'
+                + ' deletion must fail closed)' });
         return results;
     }
     if (!hasBash()) {
@@ -942,7 +949,10 @@ const APPROVED_ACTIONS = {
 };
 /** Epoch 2 门禁的最低 package scripts 集合（policy.requiredPackageScripts 在此基础上只增不减）。 */
 const REQUIRED_SCRIPTS = ['test:i18n', 'i18n:check', 'i18n:generate-static', 'i18n:trust-gate',
-    'i18n:gate-contract', 'i18n:gate-parity', 'test:js', 'test:web-standards'];
+    'i18n:gate-contract', 'i18n:gate-parity', 'test:js', 'test:web-standards', 'doctor:github-gate'];
+
+/** github-ruleset-invariants.json 相对仓库根的路径（doctor 的期望不变量声明）。 */
+const RULESET_INVARIANTS_REL = path.posix.join('scripts', 'ci', 'github-ruleset-invariants.json');
 
 /** 可信 gate 执行必须来自物化的 trusted bundle，禁止直接运行候选工作树的 contract/guard。 */
 const TRUSTED_LOC = /\$GATE_DIR|\$RUNNER_TEMP|\bguard\/out\b|materialize-trusted-gate/;
@@ -1103,15 +1113,15 @@ function pushPackageCheck(checks, name, ok, diagnostic) {
  * github.sha^ 回退禁令 / FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 清理 /
  * Epoch 2 root tag 与 ROOT_ADMISSION 机制 / reusable input 优先级 / trusted helper 交叉验证 /
  * gate parity 步骤。
- * 候选缺失 workflow 文件（predates）时只报告不阻断。
+ * 候选缺失 workflow 文件 = 删除 baseline 文件 → fail closed（无 predates 报告路径）。
  */
 function runWorkflowContractChecks(repoRoot, candidateRoot) {
     const checks = [];
     const workflowFile = path.join(candidateRoot, ...WORKFLOW_REL.split('/'));
     if (!fs.existsSync(workflowFile)) {
-        checks.push({ name: 'candidate quality-gate.yml contract', kind: 'workflow', expected: null,
-            status: null, ok: true,
-            diagnostic: 'candidate predates .github/workflows/quality-gate.yml (report only)' });
+        pushCheck(checks, 'candidate quality-gate.yml contract', false,
+            'candidate has no .github/workflows/quality-gate.yml (part of the current verifier'
+                + ' baseline; deletion must fail closed)');
         return checks;
     }
     let doc;
@@ -1457,19 +1467,6 @@ function jobHasUsesAtJobLevel(job, re) {
 }
 
 /**
- * 候选是否曾引入过该路径（git log --diff-filter=A）。
- * 用于「文件缺失但历史已引入 → 删除 → fail closed」判定（predates 只报告）。
- */
-function wasIntroducedInHistory(repoRoot, historyRef, rel) {
-    try {
-        const introduced = git(['log', '--diff-filter=A', '--format=%H', historyRef, '--', rel], repoRoot);
-        return introduced.length > 0;
-    } catch (e) {
-        return true;
-    }
-}
-
-/**
  * 外围 workflow 语义契约（真实 YAML 解析）：
  * - shared-snippets-check.yml：冻结 name / 触发器 / check-shared-snippets job /
  *   真实 ./scripts/sync-shared-snippets.ps1 -Check 命令；删除 -Check / 改 true / echo /
@@ -1483,25 +1480,19 @@ function wasIntroducedInHistory(repoRoot, historyRef, rel) {
  *   needs.quality-gate.result == 'success'）；禁止 always() / 无 success 检查的 !cancelled()；
  * - nightly.yml：publish-plugins（uses publish-plugins.yml）→ build-jar（needs
  *   publish-plugins，即 quality gate 传递生效）→ release-nightly（needs 构建产物）。
- * 候选缺文件（predates）只报告不阻断；删除由 requiredPaths 统一 fail closed。
+ * 候选缺文件 = 删除 baseline 文件 → fail closed（无 predates 报告路径）。
  */
-function runExternalWorkflowContracts(repoRoot, candidateRoot, historyRef) {
+function runExternalWorkflowContracts(repoRoot, candidateRoot) {
     const checks = [];
     let yamlMod = null;
     let yamlLoaded = false;
     for (const rel of EXTERNAL_WORKFLOW_RELS) {
         const file = path.join(candidateRoot, ...rel.split('/'));
         if (!fs.existsSync(file)) {
-            // 候选 predates → 只报告；历史已引入却被删除 → fail closed
-            // （本轮起由语义契约 + parity predecessor diff + gate-surface 清单拦截；
-            // requiredPaths 条目由下一个 NORMAL successor 落地，见 gate-policy.json 注释）
-            const deleted = wasIntroducedInHistory(repoRoot, historyRef, rel);
-            checks.push({ name: rel + ' contract', kind: 'workflow', expected: null, status: null,
-                ok: !deleted,
-                diagnostic: deleted
-                    ? rel + ' was introduced in the candidate history but is missing from the'
-                        + ' candidate snapshot (deletion of a protected workflow must fail closed)'
-                    : 'candidate predates ' + rel + ' (report only)' });
+            checks.push({ name: rel + ' contract', kind: 'workflow', expected: 'present',
+                status: null, ok: false,
+                diagnostic: rel + ' is missing from the candidate snapshot (part of the current'
+                    + ' verifier baseline; deletion must fail closed)' });
             continue;
         }
         const spec = EXTERNAL_WORKFLOW_SPECS[rel];
@@ -1701,15 +1692,10 @@ function runGateSurfaceContract(candidateRoot, trustedPolicy) {
     const candidateFile = path.join(candidateRoot, ...SURFACE_REL.split('/'));
     const trustedFile = path.join(OWN_DIR, '..', 'ci', 'gate-surface.json');
     if (!fs.existsSync(candidateFile)) {
-        // 候选整体 predates gate surface（连 scripts/ci 都没有）→ 只报告；
-        // scripts/ci 存在但清单被删 → fail closed（删除由 requiredPaths + 本检查双重拦截）
-        const ciDir = path.join(candidateRoot, 'scripts', 'ci');
-        const predated = !fs.existsSync(ciDir);
-        pushCheck(checks, 'candidate gate-surface.json present', predated,
-            predated
-                ? 'candidate predates the gate surface manifest (report only)'
-                : 'candidate has no scripts/ci/gate-surface.json (deletion of the gate surface'
-                    + ' manifest must fail closed)');
+        // gate-surface.json 属于当前 verifier baseline：候选缺失 = 删除 → fail closed
+        pushCheck(checks, 'candidate gate-surface.json present', false,
+            'candidate has no scripts/ci/gate-surface.json (the gate surface manifest is part of'
+                + ' the current verifier baseline; deletion must fail closed)');
         return checks;
     }
     let candidateSurface = null;
@@ -1725,34 +1711,131 @@ function runGateSurfaceContract(candidateRoot, trustedPolicy) {
     pushCheck(checks, 'candidate gate-surface.json declares a non-empty path list',
         candidatePaths.length > 0,
         'candidate gate-surface.json must declare a non-empty paths array');
-    // trusted manifest 存在时（hooks / CI 已物化 scripts/ci）：候选不得减少
-    if (fs.existsSync(trustedFile)) {
-        let trustedSurface = null;
-        try {
-            trustedSurface = JSON.parse(fs.readFileSync(trustedFile, 'utf8'));
-        } catch (e) {
-            pushCheck(checks, 'trusted gate-surface.json parses as JSON', false,
-                'trusted gate-surface.json is invalid; fail closed: ' + e.message);
-            return checks;
-        }
-        const trustedPaths = Array.isArray(trustedSurface && trustedSurface.paths)
-            ? trustedSurface.paths.filter((p) => typeof p === 'string') : [];
-        const removed = trustedPaths.filter((p) => !candidatePaths.includes(p));
-        pushCheck(checks, 'candidate gate-surface.json keeps the trusted gate surface',
-            removed.length === 0,
-            'candidate dropped gate surface entries: ' + removed.join(', ')
-                + '; pre-commit / pre-push / contract / parity must share one surface');
-    } else {
-        pushCheck(checks, 'candidate gate-surface.json keeps the trusted gate surface',
-            true,
-            'trusted bundle predates scripts/ci/gate-surface.json (report only)');
+    // trusted manifest 缺失 → trusted verifier 低于 baseline → fail closed（无兼容路径）
+    if (!fs.existsSync(trustedFile)) {
+        pushCheck(checks, 'trusted verifier carries gate-surface.json', false,
+            'trusted verifier does not satisfy the current verifier baseline'
+                + ' (missing scripts/ci/gate-surface.json); fail closed');
+        return checks;
     }
+    let trustedSurface = null;
+    try {
+        trustedSurface = JSON.parse(fs.readFileSync(trustedFile, 'utf8'));
+    } catch (e) {
+        pushCheck(checks, 'trusted gate-surface.json parses as JSON', false,
+            'trusted gate-surface.json is invalid; fail closed: ' + e.message);
+        return checks;
+    }
+    const trustedPaths = Array.isArray(trustedSurface && trustedSurface.paths)
+        ? trustedSurface.paths.filter((p) => typeof p === 'string') : [];
+    const removed = trustedPaths.filter((p) => !candidatePaths.includes(p));
+    pushCheck(checks, 'candidate gate-surface.json keeps the trusted gate surface',
+        removed.length === 0,
+        'candidate dropped gate surface entries: ' + removed.join(', ')
+            + '; pre-commit / pre-push / contract / parity must share one surface');
     // phantom 声明禁令：候选 manifest 里声明的每个路径必须在同一候选快照中真实存在
     const phantom = candidatePaths.filter((p) => !fs.existsSync(path.join(candidateRoot, ...p.split('/'))));
     pushCheck(checks, 'candidate gate-surface.json declares only real paths',
         phantom.length === 0,
         'candidate gate-surface.json declares paths that do not exist in the candidate snapshot: '
             + phantom.join(', ') + '; the candidate manifest cannot enlarge what is checked');
+    return checks;
+}
+
+// ---------------------------------------------------------------------------
+// github-ruleset-invariants.json 契约（Ruleset 安全语义只增不减 + 自保护）
+// ---------------------------------------------------------------------------
+
+/**
+ * 候选 github-ruleset-invariants.json 审核：
+ * - 文件必须存在（当前 verifier baseline 组成）；
+ * - schemaVersion 必须是整数且 >= trusted（缺失 → fail closed）；
+ * - master.requiredChecks：trusted ⊆ candidate（只能增加）；
+ * - master.requireStrict 只允许 false→true；master / root-tag 的
+ *   allowBypass / allowDeletion / allowNonFastForward 只允许 true→false；
+ * - trusted 文件缺失 → trusted verifier 低于 baseline → fail closed。
+ */
+function runRulesetInvariantsContract(candidateRoot) {
+    const checks = [];
+    const candidateFile = path.join(candidateRoot, ...RULESET_INVARIANTS_REL.split('/'));
+    if (!fs.existsSync(candidateFile)) {
+        pushCheck(checks, 'candidate github-ruleset-invariants.json present', false,
+            'candidate has no scripts/ci/github-ruleset-invariants.json (part of the current'
+                + ' verifier baseline; deletion must fail closed)');
+        return checks;
+    }
+    let candidate;
+    try {
+        candidate = JSON.parse(fs.readFileSync(candidateFile, 'utf8'));
+    } catch (e) {
+        pushCheck(checks, 'candidate github-ruleset-invariants.json parses as JSON', false,
+            'candidate github-ruleset-invariants.json is invalid: ' + e.message);
+        return checks;
+    }
+    const cs = Number.isInteger(candidate.schemaVersion) ? candidate.schemaVersion : null;
+    if (cs === null) {
+        pushCheck(checks, 'candidate ruleset invariants schemaVersion present', false,
+            'candidate github-ruleset-invariants.json has no integer schemaVersion; fail closed');
+        return checks;
+    }
+    const trustedFile = path.join(OWN_DIR, '..', '..', ...RULESET_INVARIANTS_REL.split('/'));
+    if (!fs.existsSync(trustedFile)) {
+        pushCheck(checks, 'trusted verifier carries github-ruleset-invariants.json', false,
+            'trusted verifier does not satisfy the current verifier baseline; fail closed');
+        return checks;
+    }
+    let trusted;
+    try {
+        trusted = JSON.parse(fs.readFileSync(trustedFile, 'utf8'));
+    } catch (e) {
+        pushCheck(checks, 'trusted github-ruleset-invariants.json parses as JSON', false,
+            'trusted github-ruleset-invariants.json is invalid: ' + e.message);
+        return checks;
+    }
+    const ts = Number.isInteger(trusted.schemaVersion) ? trusted.schemaVersion : null;
+    pushCheck(checks, 'ruleset invariants schemaVersion not lowered',
+        ts !== null && cs >= ts,
+        'candidate ruleset invariants schemaVersion ' + cs + (ts === null
+            ? ' (trusted schemaVersion missing)' : ' < trusted ' + ts) + '; fail closed');
+
+    const tMaster = trusted.master && typeof trusted.master === 'object' ? trusted.master : null;
+    const cMaster = candidate.master && typeof candidate.master === 'object' ? candidate.master : null;
+    const tTag = trusted['i18n-gate-epoch-2-root'] && typeof trusted['i18n-gate-epoch-2-root'] === 'object'
+        ? trusted['i18n-gate-epoch-2-root'] : null;
+    const cTag = candidate['i18n-gate-epoch-2-root'] && typeof candidate['i18n-gate-epoch-2-root'] === 'object'
+        ? candidate['i18n-gate-epoch-2-root'] : null;
+    const tChecks = Array.isArray(tMaster && tMaster.requiredChecks)
+        ? tMaster.requiredChecks.filter((c) => typeof c === 'string') : [];
+    const cChecks = Array.isArray(cMaster && cMaster.requiredChecks)
+        ? cMaster.requiredChecks.filter((c) => typeof c === 'string') : [];
+    const removedChecks = tChecks.filter((c) => !cChecks.includes(c));
+    pushCheck(checks, 'ruleset required checks not reduced', removedChecks.length === 0,
+        'candidate dropped required status checks: ' + removedChecks.join(', '));
+    for (const [key, stricterIs] of [['requireStrict', true], ['allowBypass', false],
+        ['allowDeletion', false], ['allowNonFastForward', false]]) {
+        if (!tMaster || !cMaster || typeof tMaster[key] !== 'boolean' || typeof cMaster[key] !== 'boolean') {
+            pushCheck(checks, 'ruleset master.' + key + ' strictness not weakened', false,
+                'ruleset invariants master.' + key + ' must be a boolean on both sides; fail closed');
+            continue;
+        }
+        const weakened = stricterIs
+            ? (tMaster[key] === true && cMaster[key] === false)
+            : (tMaster[key] === false && cMaster[key] === true);
+        pushCheck(checks, 'ruleset master.' + key + ' strictness not weakened', !weakened,
+            'candidate weakened master.' + key + ' from ' + tMaster[key] + ' to '
+                + cMaster[key] + '; fail closed');
+    }
+    for (const key of ['allowDeletion', 'allowNonFastForward', 'allowBypass']) {
+        if (!tTag || !cTag || typeof tTag[key] !== 'boolean' || typeof cTag[key] !== 'boolean') {
+            pushCheck(checks, 'ruleset root tag ' + key + ' strictness not weakened', false,
+                'ruleset invariants root-tag ' + key + ' must be a boolean on both sides; fail closed');
+            continue;
+        }
+        const weakened = tTag[key] === false && cTag[key] === true;
+        pushCheck(checks, 'ruleset root tag ' + key + ' strictness not weakened', !weakened,
+            'candidate weakened root-tag ' + key + ' from ' + tTag[key] + ' to '
+                + cTag[key] + '; fail closed');
+    }
     return checks;
 }
 
@@ -1769,7 +1852,7 @@ function runGateSurfaceContract(candidateRoot, trustedPolicy) {
  *   requiredPaths 条目由下一个 NORMAL successor 落地）。
  * 与 trusted bundle 逐字节一致时归纳跳过（行为由信任链保证）。
  */
-async function runSyncScenarios(repoRoot, candidateRoot, historyRef, skip) {
+async function runSyncScenarios(repoRoot, candidateRoot, skip) {
     const results = [];
     if (skip) {
         results.push({ name: 'sync-shared-snippets.ps1 behavior (black-box)', kind: 'external-checker',
@@ -1780,14 +1863,10 @@ async function runSyncScenarios(repoRoot, candidateRoot, historyRef, skip) {
     }
     const scriptFile = path.join(candidateRoot, ...SYNC_REL.split('/'));
     if (!fs.existsSync(scriptFile)) {
-        const deleted = wasIntroducedInHistory(repoRoot, historyRef, SYNC_REL);
-        results.push({ name: 'sync-shared-snippets.ps1 content', kind: 'report', expected: null,
-            status: null, ok: !deleted,
-            diagnostic: deleted
-                ? 'scripts/sync-shared-snippets.ps1 was introduced in the candidate history but is'
-                    + ' missing from the candidate snapshot (deletion of the shared snippet checker'
-                    + ' must fail closed)'
-                : 'candidate predates scripts/sync-shared-snippets.ps1 (report only)' });
+        results.push({ name: 'sync-shared-snippets.ps1 content', kind: 'external-checker',
+            expected: 'present', status: null, ok: false,
+            diagnostic: 'scripts/sync-shared-snippets.ps1 is missing from the candidate snapshot'
+                + ' (part of the current verifier baseline; deletion must fail closed)' });
         return results;
     }
     const content = fs.readFileSync(scriptFile, 'utf8');
@@ -1857,17 +1936,19 @@ function runHookContentChecks(candidateRoot) {
     const checks = [];
     const hooksRoot = path.join(candidateRoot, 'scripts', 'hooks');
     if (!fs.existsSync(hooksRoot)) {
-        checks.push({ name: 'candidate hooks bundle', kind: 'hooks-static', expected: null,
-            status: null, ok: true,
-            diagnostic: 'candidate predates scripts/hooks (report only; required paths govern deletion)' });
+        checks.push({ name: 'candidate hooks bundle', kind: 'hooks-static', expected: 'present',
+            status: null, ok: false,
+            diagnostic: 'candidate has no scripts/hooks (part of the current verifier baseline;'
+                + ' deletion must fail closed)' });
         return checks;
     }
     for (const hook of ['pre-commit', 'pre-push']) {
         const file = path.join(hooksRoot, hook);
         if (!fs.existsSync(file)) {
             checks.push({ name: 'candidate hook constraint: missing ' + hook, kind: 'hooks-static',
-                expected: null, status: null, ok: true,
-                diagnostic: 'candidate lacks ' + hook + ' (report; required paths govern deletion)' });
+                expected: 'present', status: null, ok: false,
+                diagnostic: 'candidate lacks ' + hook + ' (part of the current verifier baseline;'
+                    + ' deletion must fail closed)' });
             continue;
         }
         const content = fs.readFileSync(file, 'utf8');
@@ -1889,9 +1970,9 @@ function runPackageContractChecks(candidateRoot, trustedPolicy) {
     const checks = [];
     const pkgFile = path.join(candidateRoot, ...PACKAGE_JSON_REL.split('/'));
     if (!fs.existsSync(pkgFile)) {
-        checks.push({ name: 'candidate package.json scripts contract', kind: 'package', expected: null,
-            status: null, ok: true,
-            diagnostic: 'candidate predates package.json (report only)' });
+        pushPackageCheck(checks, 'candidate package.json scripts contract', false,
+            'candidate has no package.json (part of the current verifier baseline; deletion must'
+                + ' fail closed)');
         return checks;
     }
     let pkg;
@@ -1934,9 +2015,9 @@ async function runSelfProtection(repoRoot, candidateRoot, trustedPolicy, hasCont
         return results;
     }
     if (!hasContract) {
-        results.push({ name: 'self-protection', kind: 'report', expected: null, status: null, ok: true,
-            diagnostic: 'candidate has no scripts/i18n/gate-contract.mjs; self-protection cannot run'
-                + ' (predates the contract architecture)' });
+        results.push({ name: 'self-protection', kind: 'report', expected: null, status: null, ok: false,
+            diagnostic: 'candidate has no scripts/i18n/gate-contract.mjs (part of the current'
+                + ' verifier baseline; deletion must fail closed)' });
         return results;
     }
     if (!hasBash()) {
@@ -2065,6 +2146,27 @@ async function runSelfProtection(repoRoot, candidateRoot, trustedPolicy, hasCont
             pol.contractVersion = 0;
             fs.writeFileSync(policyPath, JSON.stringify(pol, null, 2) + '\n', 'utf8');
         }
+        // 下一代恶意 gate 同时弱化 Ruleset 不变量声明（github-ruleset-invariants.json）：
+        // requireStrict=false / allowBypass=true / allowDeletion=true / allowNonFastForward=true /
+        // requiredChecks 清空 / root tag 放开 → 新 contract 必须拒绝
+        const rulesetPath = path.join(repo, 'scripts', 'ci', 'github-ruleset-invariants.json');
+        if (fs.existsSync(rulesetPath)) {
+            fs.writeFileSync(rulesetPath, JSON.stringify({
+                schemaVersion: 1,
+                master: {
+                    requiredChecks: [],
+                    requireStrict: false,
+                    allowBypass: true,
+                    allowDeletion: true,
+                    allowNonFastForward: true,
+                },
+                'i18n-gate-epoch-2-root': {
+                    allowDeletion: true,
+                    allowNonFastForward: true,
+                    allowBypass: true,
+                },
+            }, null, 2) + '\n', 'utf8');
+        }
         git(['add', '-A'], repo);
         git(['commit', '-q', '-m', 'malicious next gate'], repo);
         const malicious = git(['rev-parse', 'HEAD'], repo);
@@ -2145,6 +2247,15 @@ async function main() {
     if (!trustedPolicy) {
         fail('gate-contract must run from the trusted gate materialization'
             + ' (gate-policy.json missing next to gate-contract.mjs)');
+        return;
+    }
+    // 本 contract 自身就是 trusted verifier：它必须满足当前 verifier baseline。
+    // 低于最低能力（旧 verifier）→ fail closed，绝不 predates / fallback / legacy 兼容。
+    try {
+        trustedGate.assertSupportedTrustedVerifierDir(path.join(OWN_DIR, '..', '..'));
+    } catch (e) {
+        fail('trusted verifier does not satisfy the current Gate Epoch 2 verifier baseline;'
+            + ' fail closed: ' + e.message);
         return;
     }
 
@@ -2346,9 +2457,10 @@ async function main() {
 
         // 3.5 candidate quality-gate.yml + package.json 语义契约（真实 YAML 解析）
         checks.push(...runWorkflowContractChecks(repoRoot, candidateRoot));
-        checks.push(...runExternalWorkflowContracts(repoRoot, candidateRoot, historyRef));
+        checks.push(...runExternalWorkflowContracts(repoRoot, candidateRoot));
         checks.push(...runPackageContractChecks(candidateRoot, trustedPolicy));
         checks.push(...runGateSurfaceContract(candidateRoot, trustedPolicy));
+        checks.push(...runRulesetInvariantsContract(candidateRoot));
         checks.push(...runHookContentChecks(candidateRoot));
 
         const hasChecker = fs.existsSync(path.join(candidateRoot, 'scripts', 'i18n', 'check.mjs'));
@@ -2380,7 +2492,7 @@ async function main() {
             }
             return fs.readFileSync(candidateFile, 'utf8') === fs.readFileSync(trustedFile, 'utf8');
         })();
-        const syncScenarios = await runSyncScenarios(repoRoot, candidateRoot, historyRef, candidateSyncIdentical);
+        const syncScenarios = await runSyncScenarios(repoRoot, candidateRoot, candidateSyncIdentical);
         checks.push(...syncScenarios);
         const syncOk = syncScenarios.every((c) => c.ok);
 

--- a/scripts/i18n/gate-policy.json
+++ b/scripts/i18n/gate-policy.json
@@ -2,6 +2,19 @@
   "schemaVersion": 3,
   "gateEpoch": 2,
   "contractVersion": 4,
+  "minimumTrustedVerifier": {
+    "contractVersion": 4,
+    "schemaVersion": 3,
+    "requiredFiles": [
+      "scripts/ci/gate-surface.json",
+      "scripts/ci/gate-invariants.json",
+      "scripts/ci/gate-parity.mjs",
+      "scripts/ci/resolve-trusted-base.mjs",
+      "scripts/ci/materialize-trusted-gate.sh",
+      "scripts/ci/doctor-github-ruleset.mjs",
+      "scripts/i18n/trust-gate.mjs"
+    ]
+  },
   "i18nEnforcementStartCommit": "05f4ebed7ce00f0b923fe48ec2e0971610511547",
   "requiredPaths": [
     "scripts/i18n/check.mjs",
@@ -9,6 +22,7 @@
     "scripts/i18n/gate-policy.json",
     "scripts/i18n/lib/repository-snapshot.mjs",
     "scripts/i18n/lib/trusted-gate.mjs",
+    "scripts/i18n/trust-gate.mjs",
     "scripts/hooks/pre-commit",
     "scripts/hooks/pre-push",
     "scripts/hooks/pre-push-guard.sh",

--- a/scripts/i18n/gate-policy.json
+++ b/scripts/i18n/gate-policy.json
@@ -18,6 +18,7 @@
     "scripts/ci/gate-invariants.json",
     "scripts/ci/gate-surface.json",
     "scripts/ci/github-ruleset-invariants.json",
+    "scripts/ci/doctor-github-ruleset.mjs",
     ".github/workflows/quality-gate.yml",
     "package.json",
     "package-lock.json"
@@ -47,7 +48,8 @@
     "i18n:gate-contract",
     "i18n:gate-parity",
     "test:js",
-    "test:web-standards"
+    "test:web-standards",
+    "doctor:github-gate"
   ],
   "requiredExternalChecks": [
     "Shared Snippet Drift Check"

--- a/scripts/i18n/gate-policy.json
+++ b/scripts/i18n/gate-policy.json
@@ -23,6 +23,7 @@
     "scripts/i18n/lib/repository-snapshot.mjs",
     "scripts/i18n/lib/trusted-gate.mjs",
     "scripts/i18n/trust-gate.mjs",
+    "scripts/i18n/epoch-2-first-admission.json",
     "scripts/hooks/pre-commit",
     "scripts/hooks/pre-push",
     "scripts/hooks/pre-push-guard.sh",

--- a/scripts/i18n/lib/trusted-gate.mjs
+++ b/scripts/i18n/lib/trusted-gate.mjs
@@ -37,6 +37,25 @@ export const TRUSTED_EPOCH_KEY = 'pixiv.i18n.trustedGateEpoch';
 /** 当前唯一受支持的 Gate Epoch。epoch < 2 视为 obsolete；epoch > 2 视为 unsupported future。 */
 export const CURRENT_GATE_EPOCH = 2;
 
+/**
+ * 当前新标准 verifier 最低能力（与 Epoch 2 历史信任 root 分开）：
+ * Epoch 2 root（cb587e01，contract v3）只证明「属于 Epoch 2 历史」，
+ * 不等于「当前允许作为 verifier 的最老提交」。CURRENT_MIN_* 决定当前
+ * trusted verifier 必须具备的能力；低于此线 → fail closed，绝不兼容 / fallback / predates。
+ */
+export const CURRENT_MIN_CONTRACT_VERSION = 4;
+export const CURRENT_MIN_SCHEMA_VERSION = 3;
+
+/** 当前 verifier baseline 要求的 verifier 本体文件（缺任一 → verifier 无资格审核新标准候选）。 */
+export const REQUIRED_VERIFIER_FILES = [
+    path.posix.join('scripts', 'ci', 'gate-surface.json'),
+    path.posix.join('scripts', 'ci', 'gate-invariants.json'),
+    path.posix.join('scripts', 'ci', 'gate-parity.mjs'),
+    path.posix.join('scripts', 'ci', 'resolve-trusted-base.mjs'),
+    path.posix.join('scripts', 'ci', 'materialize-trusted-gate.sh'),
+    path.posix.join('scripts', 'ci', 'doctor-github-ruleset.mjs'),
+];
+
 /** Epoch 2 信任根 tag（仓库内容之外的不可自我修改锚点，由管理员人工创建并受 Ruleset 保护）。 */
 export const ROOT_TAG_NAME = 'i18n-gate-epoch-2-root';
 
@@ -416,6 +435,52 @@ export function loadPolicyFromRef(repoRoot, ref) {
     }
 }
 
+/**
+ * 校验物化后的 verifier 目录是否满足当前 verifier baseline（Gate Epoch 2 新标准）。
+ * 低于最低能力（contract / schema / 缺 verifier 本体文件）→ 抛错 fail closed；
+ * 兼容 / fallback / predates / legacy 分支一律不存在。
+ * @param {string} dir 物化后的 trusted verifier bundle 根目录
+ * @returns {Object} trusted policy（校验通过时）
+ */
+export function assertSupportedTrustedVerifierDir(dir) {
+    const policy = loadPolicyFromDir(dir);
+    const failures = [];
+    if (policy.gateEpoch !== CURRENT_GATE_EPOCH) {
+        failures.push('gateEpoch ' + policy.gateEpoch + ' != ' + CURRENT_GATE_EPOCH);
+    }
+    if (!Number.isInteger(policy.contractVersion)
+        || policy.contractVersion < CURRENT_MIN_CONTRACT_VERSION) {
+        failures.push('contractVersion ' + policy.contractVersion
+            + ' < current minimum ' + CURRENT_MIN_CONTRACT_VERSION
+            + ' (verifier rollback is refused)');
+    }
+    if (!Number.isInteger(policy.schemaVersion)
+        || policy.schemaVersion < CURRENT_MIN_SCHEMA_VERSION) {
+        failures.push('schemaVersion ' + policy.schemaVersion
+            + ' < current minimum ' + CURRENT_MIN_SCHEMA_VERSION);
+    }
+    for (const rel of REQUIRED_VERIFIER_FILES) {
+        if (!fs.existsSync(path.join(dir, ...rel.split('/')))) {
+            failures.push('missing ' + rel);
+        }
+    }
+    if (failures.length > 0) {
+        throw new Error('trusted verifier does not satisfy the current Gate Epoch 2 verifier'
+            + ' baseline (fail closed): ' + failures.join('; '));
+    }
+    return policy;
+}
+
+/** 校验 ref 处的 verifier 是否满足当前 verifier baseline（物化后检查，自动清理）。 */
+export function assertSupportedTrustedVerifierAt(repoRoot, sha) {
+    const materialized = snapshot.materializePaths(repoRoot, sha, GATE_PATHS);
+    try {
+        return assertSupportedTrustedVerifierDir(materialized.root);
+    } finally {
+        materialized.cleanup();
+    }
+}
+
 /** 从可信锚点物化完整 gate bundle（scripts/i18n + scripts/hooks）。 */
 export function materializeTrustedGate(repoRoot, trustedSha, outDir) {
     const materialized = snapshot.materializePaths(repoRoot, trustedSha, GATE_PATHS);
@@ -530,6 +595,9 @@ export default {
     TRUSTED_REF_KEY,
     TRUSTED_EPOCH_KEY,
     CURRENT_GATE_EPOCH,
+    CURRENT_MIN_CONTRACT_VERSION,
+    CURRENT_MIN_SCHEMA_VERSION,
+    REQUIRED_VERIFIER_FILES,
     ROOT_TAG_NAME,
     GATE_PATHS,
     POLICY_REL,
@@ -552,6 +620,8 @@ export default {
     validatePolicyStructure,
     loadPolicyFromDir,
     loadPolicyFromRef,
+    assertSupportedTrustedVerifierDir,
+    assertSupportedTrustedVerifierAt,
     materializeTrustedGate,
     hasPathInDir,
     checkRequiredPaths,

--- a/scripts/i18n/lib/trusted-gate.mjs
+++ b/scripts/i18n/lib/trusted-gate.mjs
@@ -28,36 +28,28 @@
 import { execFileSync, spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 import snapshot from './repository-snapshot.mjs';
 
 export const TRUSTED_REF_KEY = 'pixiv.i18n.trustedGateRef';
 export const TRUSTED_EPOCH_KEY = 'pixiv.i18n.trustedGateEpoch';
+export const PREPARED_ROOT_EPOCH_KEY = 'pixiv.i18n.preparedRootEpoch';
+export const PREPARED_ROOT_PARENT_KEY = 'pixiv.i18n.preparedRootParent';
+export const PREPARED_ROOT_TREE_KEY = 'pixiv.i18n.preparedRootTree';
 
 /** 当前唯一受支持的 Gate Epoch。epoch < 2 视为 obsolete；epoch > 2 视为 unsupported future。 */
 export const CURRENT_GATE_EPOCH = 2;
 
-/**
- * 当前新标准 verifier 最低能力（与 Epoch 2 历史信任 root 分开）：
- * Epoch 2 root（cb587e01，contract v3）只证明「属于 Epoch 2 历史」，
- * 不等于「当前允许作为 verifier 的最老提交」。CURRENT_MIN_* 决定当前
- * trusted verifier 必须具备的能力；低于此线 → fail closed，绝不兼容 / fallback / predates。
- */
-export const CURRENT_MIN_CONTRACT_VERSION = 4;
-export const CURRENT_MIN_SCHEMA_VERSION = 3;
-
-/** 当前 verifier baseline 要求的 verifier 本体文件（缺任一 → verifier 无资格审核新标准候选）。 */
-export const REQUIRED_VERIFIER_FILES = [
-    path.posix.join('scripts', 'ci', 'gate-surface.json'),
-    path.posix.join('scripts', 'ci', 'gate-invariants.json'),
-    path.posix.join('scripts', 'ci', 'gate-parity.mjs'),
-    path.posix.join('scripts', 'ci', 'resolve-trusted-base.mjs'),
-    path.posix.join('scripts', 'ci', 'materialize-trusted-gate.sh'),
-    path.posix.join('scripts', 'ci', 'doctor-github-ruleset.mjs'),
-];
-
 /** Epoch 2 信任根 tag（仓库内容之外的不可自我修改锚点，由管理员人工创建并受 Ruleset 保护）。 */
 export const ROOT_TAG_NAME = 'i18n-gate-epoch-2-root';
+
+export function rootTagNameForEpoch(epoch) {
+    if (!Number.isInteger(Number(epoch)) || Number(epoch) < 2) {
+        throw new Error('invalid Gate Epoch: ' + epoch);
+    }
+    return 'i18n-gate-epoch-' + Number(epoch) + '-root';
+}
 
 /** hooks 与 contract 从可信锚点物化的路径范围。 */
 export const GATE_PATHS = [
@@ -85,6 +77,8 @@ export const WORKFLOW_REL = path.posix.join('.github', 'workflows', 'quality-gat
 
 /** package.json 相对仓库根的路径。 */
 export const PACKAGE_JSON_REL = path.posix.join('package.json');
+
+const OWN_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 
 const REF_RE = /^refs\/heads\/[A-Za-z0-9._/-]+$/;
 
@@ -120,6 +114,19 @@ function validateJobIdList(list) {
         }
         seen.add(entry);
     }
+}
+
+function validateMinimumTrustedVerifier(minimum) {
+    if (!minimum || typeof minimum !== 'object' || Array.isArray(minimum)) {
+        throw new Error('gate-policy.json: minimumTrustedVerifier must be an object');
+    }
+    if (!Number.isInteger(minimum.contractVersion) || minimum.contractVersion < 1) {
+        throw new Error('gate-policy.json: minimumTrustedVerifier.contractVersion must be an integer >= 1');
+    }
+    if (!Number.isInteger(minimum.schemaVersion) || minimum.schemaVersion < 1) {
+        throw new Error('gate-policy.json: minimumTrustedVerifier.schemaVersion must be an integer >= 1');
+    }
+    validatePathList('minimumTrustedVerifier.requiredFiles', minimum.requiredFiles);
 }
 
 /**
@@ -170,17 +177,20 @@ export function getTrustedEpoch(repoRoot) {
  * 写本地 Epoch 2 trust anchor（epoch + ref 一起写，只写 local 配置）并回读验证。
  * 这是 root adoption / advance 的唯一写入路径。
  */
-export function setTrustedAnchor(repoRoot, sha) {
+export function setTrustedAnchor(repoRoot, sha, epoch = CURRENT_GATE_EPOCH) {
     if (!SHA_RE.test(sha)) {
         throw new Error('refusing to trust a non-commit value: ' + sha);
     }
-    git(['config', '--local', TRUSTED_EPOCH_KEY, String(CURRENT_GATE_EPOCH)], repoRoot);
+    if (!Number.isInteger(Number(epoch)) || Number(epoch) < 2) {
+        throw new Error('refusing to trust an invalid Gate Epoch: ' + epoch);
+    }
+    git(['config', '--local', TRUSTED_EPOCH_KEY, String(Number(epoch))], repoRoot);
     git(['config', '--local', TRUSTED_REF_KEY, sha], repoRoot);
     const actualRef = getTrustedRef(repoRoot);
     const actualEpoch = getTrustedEpoch(repoRoot);
-    if (actualRef !== sha || actualEpoch !== String(CURRENT_GATE_EPOCH)) {
+    if (actualRef !== sha || actualEpoch !== String(Number(epoch))) {
         throw new Error('trusted gate anchor verification failed: expected epoch '
-            + CURRENT_GATE_EPOCH + ' + ref ' + sha + ', got epoch ' + actualEpoch + ' + ref ' + actualRef);
+            + epoch + ' + ref ' + sha + ', got epoch ' + actualEpoch + ' + ref ' + actualRef);
     }
 }
 
@@ -188,14 +198,15 @@ export function setTrustedAnchor(repoRoot, sha) {
  * 解析本地 Epoch 2 root tag（refs/tags/i18n-gate-epoch-2-root^{commit}）。
  * tag 不存在 / 不是 commit / 不是完整 SHA → 返回 null（fail closed 由调用方处理）。
  */
-export function resolveRootTag(repoRoot) {
-    return resolveCommit(repoRoot, 'refs/tags/' + ROOT_TAG_NAME);
+export function resolveRootTag(repoRoot, epoch = CURRENT_GATE_EPOCH) {
+    return resolveCommit(repoRoot, 'refs/tags/' + rootTagNameForEpoch(epoch));
 }
 
 /** 本地仓库中是否存在 Epoch 2 root tag。 */
-export function hasRootTag(repoRoot) {
+export function hasRootTag(repoRoot, epoch = CURRENT_GATE_EPOCH) {
     try {
-        git(['rev-parse', '--verify', '--quiet', 'refs/tags/' + ROOT_TAG_NAME + '^{commit}'], repoRoot);
+        git(['rev-parse', '--verify', '--quiet',
+            'refs/tags/' + rootTagNameForEpoch(epoch) + '^{commit}'], repoRoot);
         return true;
     } catch (e) {
         return false;
@@ -213,10 +224,10 @@ export function describeTrustedEpoch(repoRoot) {
     if (epoch === null) {
         return 'uninitialized';
     }
-    if (epoch < String(CURRENT_GATE_EPOCH)) {
+    if (Number(epoch) < CURRENT_GATE_EPOCH) {
         return 'obsolete';
     }
-    if (epoch > String(CURRENT_GATE_EPOCH)) {
+    if (Number(epoch) > CURRENT_GATE_EPOCH) {
         return 'unsupported future';
     }
     return 'current';
@@ -267,7 +278,7 @@ export function isWorktreeClean(repoRoot) {
 }
 
 /** 校验 policy 结构。非法时抛出带原因的 Error。 */
-export function validatePolicyStructure(policy) {
+export function validatePolicyStructure(policy, expectedEpoch = CURRENT_GATE_EPOCH) {
     if (!policy || typeof policy !== 'object' || Array.isArray(policy)) {
         throw new Error('gate-policy.json: root must be a JSON object');
     }
@@ -275,12 +286,17 @@ export function validatePolicyStructure(policy) {
         throw new Error('gate-policy.json: schemaVersion must be an integer >= 1');
     }
     // Epoch 单一标准：只支持 CURRENT_GATE_EPOCH；epoch < 2 是 obsolete，epoch > 2 是 unsupported
-    if (policy.gateEpoch !== CURRENT_GATE_EPOCH) {
-        throw new Error('gate-policy.json: gateEpoch must be exactly ' + CURRENT_GATE_EPOCH
+    if (policy.gateEpoch !== expectedEpoch) {
+        throw new Error('gate-policy.json: gateEpoch must be exactly ' + expectedEpoch
             + ' (obsolete / unsupported future epochs fail closed; got ' + policy.gateEpoch + ')');
     }
     if (!Number.isInteger(policy.contractVersion) || policy.contractVersion < 1) {
         throw new Error('gate-policy.json: contractVersion must be an integer >= 1');
+    }
+    validateMinimumTrustedVerifier(policy.minimumTrustedVerifier);
+    if (policy.contractVersion < policy.minimumTrustedVerifier.contractVersion
+        || policy.schemaVersion < policy.minimumTrustedVerifier.schemaVersion) {
+        throw new Error('gate-policy.json: verifier policy is below minimumTrustedVerifier');
     }
     if (!SHA_RE.test(policy.i18nEnforcementStartCommit || '')) {
         throw new Error('gate-policy.json: i18nEnforcementStartCommit must be a full 40-char lowercase hex commit sha');
@@ -405,7 +421,7 @@ export function policySetReduced(trustedList, candidateList) {
 }
 
 /** 从给定目录读取并校验 gate-policy.json（trusted 物化或候选快照）。 */
-export function loadPolicyFromDir(dir) {
+export function loadPolicyFromDir(dir, expectedEpoch = CURRENT_GATE_EPOCH) {
     const file = path.join(dir, POLICY_REL);
     if (!fs.existsSync(file)) {
         return null;
@@ -416,7 +432,7 @@ export function loadPolicyFromDir(dir) {
     } catch (e) {
         throw new Error('gate-policy.json: cannot parse: ' + e.message);
     }
-    validatePolicyStructure(policy);
+    validatePolicyStructure(policy, expectedEpoch);
     return policy;
 }
 
@@ -442,30 +458,38 @@ export function loadPolicyFromRef(repoRoot, ref) {
  * @param {string} dir 物化后的 trusted verifier bundle 根目录
  * @returns {Object} trusted policy（校验通过时）
  */
-export function assertSupportedTrustedVerifierDir(dir) {
-    const policy = loadPolicyFromDir(dir);
+export function assertSupportedTrustedVerifierDir(dir, expectedEpoch = CURRENT_GATE_EPOCH,
+    declaredMinimum = null) {
+    const minimum = declaredMinimum || loadPolicyFromDir(OWN_ROOT).minimumTrustedVerifier;
+    const policyFile = path.join(dir, ...POLICY_REL.split('/'));
+    let policy;
+    try {
+        policy = JSON.parse(fs.readFileSync(policyFile, 'utf8'));
+    } catch (e) {
+        throw new Error('cannot read trusted verifier gate-policy.json: ' + e.message);
+    }
     const failures = [];
-    if (policy.gateEpoch !== CURRENT_GATE_EPOCH) {
-        failures.push('gateEpoch ' + policy.gateEpoch + ' != ' + CURRENT_GATE_EPOCH);
+    if (policy.gateEpoch !== expectedEpoch) {
+        failures.push('gateEpoch ' + policy.gateEpoch + ' != ' + expectedEpoch);
     }
     if (!Number.isInteger(policy.contractVersion)
-        || policy.contractVersion < CURRENT_MIN_CONTRACT_VERSION) {
+        || policy.contractVersion < minimum.contractVersion) {
         failures.push('contractVersion ' + policy.contractVersion
-            + ' < current minimum ' + CURRENT_MIN_CONTRACT_VERSION
+            + ' < declared minimum ' + minimum.contractVersion
             + ' (verifier rollback is refused)');
     }
     if (!Number.isInteger(policy.schemaVersion)
-        || policy.schemaVersion < CURRENT_MIN_SCHEMA_VERSION) {
+        || policy.schemaVersion < minimum.schemaVersion) {
         failures.push('schemaVersion ' + policy.schemaVersion
-            + ' < current minimum ' + CURRENT_MIN_SCHEMA_VERSION);
+            + ' < declared minimum ' + minimum.schemaVersion);
     }
-    for (const rel of REQUIRED_VERIFIER_FILES) {
+    for (const rel of minimum.requiredFiles) {
         if (!fs.existsSync(path.join(dir, ...rel.split('/')))) {
             failures.push('missing ' + rel);
         }
     }
     if (failures.length > 0) {
-        throw new Error('trusted verifier does not satisfy the current Gate Epoch 2 verifier'
+        throw new Error('trusted verifier does not satisfy the current Gate Epoch ' + expectedEpoch + ' verifier'
             + ' baseline (fail closed): ' + failures.join('; '));
     }
     return policy;
@@ -594,11 +618,12 @@ export function runI18nTestSuite(repoRoot, excludeFile) {
 export default {
     TRUSTED_REF_KEY,
     TRUSTED_EPOCH_KEY,
+    PREPARED_ROOT_EPOCH_KEY,
+    PREPARED_ROOT_PARENT_KEY,
+    PREPARED_ROOT_TREE_KEY,
     CURRENT_GATE_EPOCH,
-    CURRENT_MIN_CONTRACT_VERSION,
-    CURRENT_MIN_SCHEMA_VERSION,
-    REQUIRED_VERIFIER_FILES,
     ROOT_TAG_NAME,
+    rootTagNameForEpoch,
     GATE_PATHS,
     POLICY_REL,
     CONTRACT_REL,

--- a/scripts/i18n/lib/trusted-gate.mjs
+++ b/scripts/i18n/lib/trusted-gate.mjs
@@ -41,6 +41,7 @@ export const FIRST_ADMISSION_TARGET_EPOCH_KEY = 'pixiv.i18n.firstAdmissionTarget
 export const FIRST_ADMISSION_TRUSTED_SOURCE_KEY = 'pixiv.i18n.firstAdmissionTrustedSource';
 export const FIRST_ADMISSION_PARENT_KEY = 'pixiv.i18n.firstAdmissionParent';
 export const FIRST_ADMISSION_TREE_KEY = 'pixiv.i18n.firstAdmissionTree';
+export const FIRST_ADMISSION_CANDIDATE_KEY = 'pixiv.i18n.firstAdmissionCandidate';
 
 /** 当前唯一受支持的 Gate Epoch。epoch < 2 视为 obsolete；epoch > 2 视为 unsupported future。 */
 export const CURRENT_GATE_EPOCH = 2;
@@ -627,6 +628,7 @@ export default {
     FIRST_ADMISSION_TRUSTED_SOURCE_KEY,
     FIRST_ADMISSION_PARENT_KEY,
     FIRST_ADMISSION_TREE_KEY,
+    FIRST_ADMISSION_CANDIDATE_KEY,
     CURRENT_GATE_EPOCH,
     ROOT_TAG_NAME,
     rootTagNameForEpoch,

--- a/scripts/i18n/lib/trusted-gate.mjs
+++ b/scripts/i18n/lib/trusted-gate.mjs
@@ -17,6 +17,8 @@
  *     自己可信，root 由人工 review + 全量自动检查 + root admission 门禁共同建立；
  *   - 之后只能 --advance，advance 由「当前 Epoch 2 trusted contract 审核候选」完成，
  *     候选不能自我批准；Epoch 1 及更早 anchor 不迁移、不兼容、无自动升级权。
+ * - Epoch 2 → 3 first admission 另由 Epoch 2 trusted bundle 中的一次性 bridge 审核；
+ *   ticket 存在共享 Git config，精确绑定 source/target epoch、trusted source、parent 与 tree。
  *
  * 门禁事实来源只允许：
  * - trusted ref 中的 gate-policy.json（gateEpoch / required paths / contract version /
@@ -34,9 +36,11 @@ import snapshot from './repository-snapshot.mjs';
 
 export const TRUSTED_REF_KEY = 'pixiv.i18n.trustedGateRef';
 export const TRUSTED_EPOCH_KEY = 'pixiv.i18n.trustedGateEpoch';
-export const PREPARED_ROOT_EPOCH_KEY = 'pixiv.i18n.preparedRootEpoch';
-export const PREPARED_ROOT_PARENT_KEY = 'pixiv.i18n.preparedRootParent';
-export const PREPARED_ROOT_TREE_KEY = 'pixiv.i18n.preparedRootTree';
+export const FIRST_ADMISSION_SOURCE_EPOCH_KEY = 'pixiv.i18n.firstAdmissionSourceEpoch';
+export const FIRST_ADMISSION_TARGET_EPOCH_KEY = 'pixiv.i18n.firstAdmissionTargetEpoch';
+export const FIRST_ADMISSION_TRUSTED_SOURCE_KEY = 'pixiv.i18n.firstAdmissionTrustedSource';
+export const FIRST_ADMISSION_PARENT_KEY = 'pixiv.i18n.firstAdmissionParent';
+export const FIRST_ADMISSION_TREE_KEY = 'pixiv.i18n.firstAdmissionTree';
 
 /** 当前唯一受支持的 Gate Epoch。epoch < 2 视为 obsolete；epoch > 2 视为 unsupported future。 */
 export const CURRENT_GATE_EPOCH = 2;
@@ -618,9 +622,11 @@ export function runI18nTestSuite(repoRoot, excludeFile) {
 export default {
     TRUSTED_REF_KEY,
     TRUSTED_EPOCH_KEY,
-    PREPARED_ROOT_EPOCH_KEY,
-    PREPARED_ROOT_PARENT_KEY,
-    PREPARED_ROOT_TREE_KEY,
+    FIRST_ADMISSION_SOURCE_EPOCH_KEY,
+    FIRST_ADMISSION_TARGET_EPOCH_KEY,
+    FIRST_ADMISSION_TRUSTED_SOURCE_KEY,
+    FIRST_ADMISSION_PARENT_KEY,
+    FIRST_ADMISSION_TREE_KEY,
     CURRENT_GATE_EPOCH,
     ROOT_TAG_NAME,
     rootTagNameForEpoch,

--- a/scripts/i18n/test/doctor-github-ruleset.test.mjs
+++ b/scripts/i18n/test/doctor-github-ruleset.test.mjs
@@ -1,0 +1,213 @@
+'use strict';
+/**
+ * GitHub Ruleset doctor 单元测试（不依赖真实 GitHub）：
+ * - list endpoint 只给摘要 → doctor 必须逐个 follow detail endpoint 再检查；
+ * - detail 正确解析 rules[].parameters.required_status_checks（context）与
+ *   strict_required_status_checks_policy；
+ * - strict=false / permanent always bypass / required check 缺失 / tag 未保护 → exit 1；
+ * - 无 token / 403 / 404 / detail 不可读 → CANNOT VERIFY / exit 2。
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { runDoctor, loadInvariants } from '../../ci/doctor-github-ruleset.mjs';
+
+const SCRIPTS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CLI = path.join(SCRIPTS_DIR, '..', 'ci', 'doctor-github-ruleset.mjs');
+const REPO = 'test/repo';
+const invariants = loadInvariants();
+const REQUIRED = invariants.master.requiredChecks;
+
+function validMasterDetail() {
+    return {
+        id: 101,
+        name: 'master-protection',
+        enforcement: 'active',
+        target: 'branch',
+        conditions: { ref_name: { include: ['refs/heads/master'] } },
+        rules: [
+            {
+                type: 'required_status_checks',
+                parameters: {
+                    strict_required_status_checks_policy: true,
+                    required_status_checks: REQUIRED.map((context) => ({ context })),
+                },
+            },
+            { type: 'deletion', parameters: {} },
+            { type: 'non_fast_forward', parameters: {} },
+        ],
+        bypass_actors: [],
+    };
+}
+
+function validTagDetail() {
+    return {
+        id: 202,
+        name: 'epoch2-root-protection',
+        enforcement: 'active',
+        target: 'tag',
+        conditions: { ref_name: { include: ['refs/tags/i18n-gate-epoch-2-root'] } },
+        rules: [
+            { type: 'deletion', parameters: {} },
+            { type: 'non_fast_forward', parameters: {} },
+        ],
+        bypass_actors: [],
+    };
+}
+
+/** 摘要只含 id / name / target / enforcement；真实 API 的摘要 conditions 为 null（必须用 detail 分类）。 */
+function summaryOf(detail) {
+    return {
+        id: detail.id,
+        name: detail.name,
+        target: detail.target,
+        enforcement: detail.enforcement,
+        conditions: null,
+    };
+}
+
+function makeFetch(listSummaries, detailsById) {
+    const calls = [];
+    const fetchJson = async (url) => {
+        calls.push(url);
+        if (/\/rulesets\?per_page=100$/.test(url)) {
+            return { status: 200, body: listSummaries };
+        }
+        const m = /\/rulesets\/(\d+)$/.exec(url);
+        if (m) {
+            const detail = detailsById[Number(m[1])];
+            if (detail) {
+                return { status: 200, body: detail };
+            }
+            return { status: 404, body: null };
+        }
+        return { status: 404, body: null };
+    };
+    return { fetchJson, calls };
+}
+
+async function doctorWith(masterDetail, tagDetail, overrides = {}) {
+    const master = masterDetail === null ? null : (masterDetail || validMasterDetail());
+    const tag = tagDetail === null ? null : (tagDetail || validTagDetail());
+    const summaries = [];
+    const details = {};
+    if (master) {
+        summaries.push(summaryOf(master));
+        details[master.id] = master;
+    }
+    if (tag) {
+        summaries.push(summaryOf(tag));
+        details[tag.id] = tag;
+    }
+    const { fetchJson, calls } = makeFetch(summaries, details);
+    const result = await runDoctor({
+        fetchJson,
+        token: 'test-token',
+        repo: REPO,
+        invariants,
+        ...overrides,
+    });
+    return { result, calls };
+}
+
+test('doctor：list endpoint 摘要 → 必须 follow detail endpoint（摘要数据不可信）', async () => {
+    // 摘要故意携带错误 enforcement 且 conditions=null（列表对象不可作为检查依据）：
+    // detail 完全正确 → 必须 exit 0，证明分类与检查全部来自 detail
+    const master = validMasterDetail();
+    const tag = validTagDetail();
+    const summaries = [
+        { ...summaryOf(master), enforcement: 'disabled' },
+        { ...summaryOf(tag), enforcement: 'disabled' },
+    ];
+    const { fetchJson, calls } = makeFetch(summaries, { [master.id]: master, [tag.id]: tag });
+    const result = await runDoctor({ fetchJson, token: 't', repo: REPO, invariants });
+    assert.equal(result.exitCode, 0, JSON.stringify(result.problems));
+    assert.ok(calls.some((u) => /\/rulesets\/101$/.test(u)), '必须请求 master detail endpoint');
+    assert.ok(calls.some((u) => /\/rulesets\/202$/.test(u)), '必须请求 tag detail endpoint');
+    assert.ok(calls.filter((u) => /\/rulesets\/\d+$/.test(u)).length >= 2,
+        'list 之后必须逐个 follow detail（用 detail 的 conditions 分类）');
+});
+
+test('doctor：master + root tag detail 完全正确 → success (exit 0)', async () => {
+    const { result } = await doctorWith(validMasterDetail(), validTagDetail());
+    assert.equal(result.exitCode, 0, JSON.stringify(result.problems));
+});
+
+test('doctor：strict_required_status_checks_policy=false → violation (exit 1)', async () => {
+    const master = validMasterDetail();
+    master.rules[0].parameters.strict_required_status_checks_policy = false;
+    const { result } = await doctorWith(master, validTagDetail());
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.problems.some((p) => /strict_required_status_checks_policy disabled/.test(p)));
+});
+
+test('doctor：permanent always bypass actor → violation (exit 1)', async () => {
+    const master = validMasterDetail();
+    master.bypass_actors = [
+        { actor_type: 'RepositoryRole', actor_id: 4, bypass_mode: 'always' },
+        { actor_type: 'OrganizationAdmin', actor_id: 1, bypass_mode: 'pull_request' },
+    ];
+    const { result } = await doctorWith(master, validTagDetail());
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.problems.some((p) => /permanent always-bypass actors: RepositoryRole:4/.test(p)));
+});
+
+test('doctor：required check 缺失 → violation (exit 1)', async () => {
+    const master = validMasterDetail();
+    master.rules[0].parameters.required_status_checks = master.rules[0].parameters.required_status_checks
+        .filter((c) => c.context !== REQUIRED[0]);
+    const { result } = await doctorWith(master, validTagDetail());
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.problems.some((p) => /misses required check/.test(p)));
+});
+
+test('doctor：tag deletion 未保护 → violation (exit 1)', async () => {
+    const tag = validTagDetail();
+    tag.rules = tag.rules.filter((r) => r.type !== 'deletion');
+    const { result } = await doctorWith(validMasterDetail(), tag);
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.problems.some((p) => /does not block deletion/.test(p)));
+});
+
+test('doctor：tag non-fast-forward 未保护 → violation (exit 1)', async () => {
+    const tag = validTagDetail();
+    tag.rules = tag.rules.filter((r) => r.type !== 'non_fast_forward');
+    const { result } = await doctorWith(validMasterDetail(), tag);
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.problems.some((p) => /does not block non-fast-forward/.test(p)));
+});
+
+test('doctor：无 token → CANNOT VERIFY (exit 2)，不是 pass', () => {
+    const env = { ...process.env };
+    delete env.GITHUB_TOKEN;
+    delete env.GH_TOKEN;
+    const run = spawnSync('node', [CLI, '--repo', REPO], { encoding: 'utf8', env });
+    assert.equal(run.status, 2);
+    assert.match(run.stdout + run.stderr, /CANNOT VERIFY/);
+});
+
+test('doctor：list 403 → CANNOT VERIFY (exit 2)', async () => {
+    const fetchJson = async () => ({ status: 403, body: null });
+    const result = await runDoctor({ fetchJson, token: 't', repo: REPO, invariants });
+    assert.equal(result.exitCode, 2);
+    assert.match(result.cannotVerify, /access denied/);
+});
+
+test('doctor：list 404 → CANNOT VERIFY (exit 2)', async () => {
+    const fetchJson = async () => ({ status: 404, body: null });
+    const result = await runDoctor({ fetchJson, token: 't', repo: REPO, invariants });
+    assert.equal(result.exitCode, 2);
+    assert.match(result.cannotVerify, /no rulesets endpoint/);
+});
+
+test('doctor：detail 404 → CANNOT VERIFY (exit 2)', async () => {
+    const master = validMasterDetail();
+    const { fetchJson, calls } = makeFetch([summaryOf(master)], {});
+    const result = await runDoctor({ fetchJson, token: 't', repo: REPO, invariants });
+    assert.equal(result.exitCode, 2);
+    assert.match(result.cannotVerify, /cannot read ruleset detail/);
+    assert.ok(calls.some((u) => /\/rulesets\/101$/.test(u)), 'detail 不可读也必须先请求 detail');
+});

--- a/scripts/i18n/test/doctor-github-ruleset.test.mjs
+++ b/scripts/i18n/test/doctor-github-ruleset.test.mjs
@@ -4,12 +4,13 @@
  * - list endpoint 只给摘要 → doctor 必须逐个 follow detail endpoint 再检查；
  * - detail 正确解析 rules[].parameters.required_status_checks（context）与
  *   strict_required_status_checks_policy；
- * - strict=false / permanent always bypass / required check 缺失 / tag 未保护 → exit 1；
+ * - strict=false / 任意 bypass / required check 缺失 / tag 未保护 → exit 1；
  * - 无 token / 403 / 404 / detail 不可读 → CANNOT VERIFY / exit 2。
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -20,6 +21,17 @@ const CLI = path.join(SCRIPTS_DIR, '..', 'ci', 'doctor-github-ruleset.mjs');
 const REPO = 'test/repo';
 const invariants = loadInvariants();
 const REQUIRED = invariants.master.requiredChecks;
+
+test('doctor：required contexts 与当前 trusted predecessor 声明一致', () => {
+    assert.deepEqual(REQUIRED, [
+        'Quality Gate / java-tests', 'Quality Gate / javascript-tests',
+        'Quality Gate / signature-guard', 'Quality Gate / trusted-gate-contract',
+        'Quality Gate / i18n-check', 'Shared Snippet Drift Check / check-shared-snippets',
+    ]);
+    const policy = JSON.parse(fs.readFileSync(path.join(SCRIPTS_DIR, 'gate-policy.json'), 'utf8'));
+    assert.equal(policy.requiredExternalCheckDefinitions[0].requiredContext,
+        'Shared Snippet Drift Check / check-shared-snippets');
+});
 
 function validMasterDetail() {
     return {
@@ -136,6 +148,35 @@ test('doctor：master + root tag detail 完全正确 → success (exit 0)', asyn
     assert.equal(result.exitCode, 0, JSON.stringify(result.problems));
 });
 
+test('doctor：声明多个 Epoch root 时逐个要求受保护 ruleset', async () => {
+    const nextInvariants = structuredClone(invariants);
+    nextInvariants['i18n-gate-epoch-3-root'] = structuredClone(
+        nextInvariants['i18n-gate-epoch-2-root']);
+    const master = validMasterDetail();
+    const epoch2 = validTagDetail();
+    const epoch3 = {
+        ...validTagDetail(),
+        id: 203,
+        name: 'epoch3-root-protection',
+        conditions: { ref_name: { include: ['refs/tags/i18n-gate-epoch-3-root'] } },
+    };
+    const completeFetch = makeFetch(
+        [summaryOf(master), summaryOf(epoch2), summaryOf(epoch3)],
+        { [master.id]: master, [epoch2.id]: epoch2, [epoch3.id]: epoch3 });
+    const complete = await runDoctor({
+        fetchJson: completeFetch.fetchJson, token: 't', repo: REPO, invariants: nextInvariants,
+    });
+    assert.equal(complete.exitCode, 0, JSON.stringify(complete.problems));
+
+    const missingFetch = makeFetch(
+        [summaryOf(master), summaryOf(epoch2)], { [master.id]: master, [epoch2.id]: epoch2 });
+    const missing = await runDoctor({
+        fetchJson: missingFetch.fetchJson, token: 't', repo: REPO, invariants: nextInvariants,
+    });
+    assert.equal(missing.exitCode, 1);
+    assert.ok(missing.problems.some((p) => /refs\/tags\/i18n-gate-epoch-3-root/.test(p)));
+});
+
 test('doctor：strict_required_status_checks_policy=false → violation (exit 1)', async () => {
     const master = validMasterDetail();
     master.rules[0].parameters.strict_required_status_checks_policy = false;
@@ -144,7 +185,7 @@ test('doctor：strict_required_status_checks_policy=false → violation (exit 1)
     assert.ok(result.problems.some((p) => /strict_required_status_checks_policy disabled/.test(p)));
 });
 
-test('doctor：permanent always bypass actor → violation (exit 1)', async () => {
+test('doctor：allowBypass=false 时任意 bypass actor → violation (exit 1)', async () => {
     const master = validMasterDetail();
     master.bypass_actors = [
         { actor_type: 'RepositoryRole', actor_id: 4, bypass_mode: 'always' },
@@ -152,7 +193,27 @@ test('doctor：permanent always bypass actor → violation (exit 1)', async () =
     ];
     const { result } = await doctorWith(master, validTagDetail());
     assert.equal(result.exitCode, 1);
-    assert.ok(result.problems.some((p) => /permanent always-bypass actors: RepositoryRole:4/.test(p)));
+    assert.ok(result.problems.some((p) => /allowBypass=false/.test(p)));
+});
+
+test('doctor：只有 bypass_mode=pull_request 也必须拒绝', async () => {
+    const master = validMasterDetail();
+    master.bypass_actors = [
+        { actor_type: 'OrganizationAdmin', actor_id: 1, bypass_mode: 'pull_request' },
+    ];
+    const { result } = await doctorWith(master, validTagDetail());
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.problems.some((p) => /OrganizationAdmin:1:pull_request/.test(p)));
+});
+
+test('doctor：root tag 的 pull_request bypass 同样拒绝', async () => {
+    const tag = validTagDetail();
+    tag.bypass_actors = [
+        { actor_type: 'OrganizationAdmin', actor_id: 1, bypass_mode: 'pull_request' },
+    ];
+    const { result } = await doctorWith(validMasterDetail(), tag);
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.problems.some((p) => /root tag.*allowBypass=false/.test(p)));
 });
 
 test('doctor：required check 缺失 → violation (exit 1)', async () => {

--- a/scripts/i18n/test/gate-contract.test.mjs
+++ b/scripts/i18n/test/gate-contract.test.mjs
@@ -217,6 +217,48 @@ test('gate-contract：candidate contract 被改为 exit(0) → 自保护拒绝�
     }
 });
 
+test('gate-contract：candidate 删除 prepared-root parent/tree 精确绑定 → 拒绝', () => {
+    const root = makeCandidateRepo();
+    const trusted = makeTrustedCopy(root);
+    try {
+        const hookFile = path.join(root, 'scripts', 'hooks', 'pre-commit');
+        const hook = fs.readFileSync(hookFile, 'utf8').replace(
+            '    && [ "$prepared_parent" = "$current_parent" ] && [ "$prepared_tree" = "$current_tree" ]; then',
+            '    ; then');
+        fs.writeFileSync(hookFile, hook, 'utf8');
+        commitBypass(root, 'weaken prepared root binding');
+        const sha = git(['rev-parse', 'HEAD'], root).stdout.trim();
+        const run = runContract(trusted, root, ['--repo-root', root, '--candidate-ref', sha]);
+        assert.notEqual(run.status, 0, 'prepared-root 失去 parent/tree 精确绑定必须拒绝');
+        assert.match(run.stdout + run.stderr, /prepared-root binding|candidate pre-commit was weakened/);
+    } finally {
+        cleanRepo(root);
+        fs.rmSync(trusted, { recursive: true, force: true });
+    }
+});
+
+test('gate-contract：candidate 删除 trusted contract 的 Git 环境隔离 → 拒绝', () => {
+    const root = makeCandidateRepo();
+    const trusted = makeTrustedCopy(root);
+    try {
+        for (const hook of ['pre-commit', 'pre-push']) {
+            const hookFile = path.join(root, 'scripts', 'hooks', hook);
+            const original = fs.readFileSync(hookFile, 'utf8');
+            fs.writeFileSync(hookFile,
+                original.replace('git rev-parse --local-env-vars', 'printf GIT_DIR'), 'utf8');
+            commitBypass(root, 'remove trusted contract Git environment isolation from ' + hook);
+            const sha = git(['rev-parse', 'HEAD'], root).stdout.trim();
+            const run = runContract(trusted, root, ['--repo-root', root, '--candidate-ref', sha]);
+            assert.notEqual(run.status, 0, hook + ' 删除 Git 环境隔离必须拒绝');
+            assert.match(run.stdout + run.stderr, /Git environment isolation|candidate .* was weakened/);
+            git(['reset', '-q', '--hard', 'HEAD~1'], root);
+        }
+    } finally {
+        cleanRepo(root);
+        fs.rmSync(trusted, { recursive: true, force: true });
+    }
+});
+
 test('gate-contract：required path 删除（check.mjs / pre-push / gate-contract.mjs）→ fail closed', () => {
     const root = makeCandidateRepo();
     const trusted = makeTrustedCopy(root);
@@ -273,6 +315,35 @@ test('gate-contract：candidate policy 弱化（contractVersion 降低 / require
         run = runContract(trusted, root, ['--repo-root', root, '--candidate-ref', sha]);
         assert.notEqual(run.status, 0, 'enforcement start 后移必须拒绝');
         assert.match(run.stdout + run.stderr, /enforcement/);
+    } finally {
+        cleanRepo(root);
+        fs.rmSync(trusted, { recursive: true, force: true });
+    }
+});
+
+test('gate-contract：minimumTrustedVerifier 三个维度降低（candidate 自身版本不变）→ 拒绝', () => {
+    const root = makeCandidateRepo();
+    const trusted = makeTrustedCopy(root);
+    try {
+        const policyPath = path.join(root, 'scripts', 'i18n', 'gate-policy.json');
+        for (const [name, mutate] of [
+            ['contractVersion 4→3', (minimum) => { minimum.contractVersion = 3; }],
+            ['schemaVersion 3→2', (minimum) => { minimum.schemaVersion = 2; }],
+            ['requiredFiles 删除 doctor', (minimum) => {
+                minimum.requiredFiles = minimum.requiredFiles
+                    .filter((rel) => rel !== 'scripts/ci/doctor-github-ruleset.mjs');
+            }],
+        ]) {
+            const policy = JSON.parse(fs.readFileSync(policyPath, 'utf8'));
+            mutate(policy.minimumTrustedVerifier);
+            fs.writeFileSync(policyPath, JSON.stringify(policy, null, 2) + '\n', 'utf8');
+            commitBypass(root, 'lower minimum verifier baseline: ' + name);
+            const sha = git(['rev-parse', 'HEAD'], root).stdout.trim();
+            const run = runContract(trusted, root, ['--repo-root', root, '--candidate-ref', sha]);
+            assert.notEqual(run.status, 0, 'minimum verifier baseline 降低必须拒绝: ' + name);
+            assert.match(run.stdout + run.stderr, /minimum trusted verifier|minimumTrustedVerifier/);
+            git(['reset', '-q', '--hard', 'HEAD~1'], root);
+        }
     } finally {
         cleanRepo(root);
         fs.rmSync(trusted, { recursive: true, force: true });

--- a/scripts/i18n/test/gate-contract.test.mjs
+++ b/scripts/i18n/test/gate-contract.test.mjs
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'node:url';
 
 import { runAcceptCore } from '../accept.mjs';
 import { runGenerate } from '../generate-static.mjs';
+import { copyGateSurfaceFiles } from './lib/surface-fixture.mjs';
 
 const SCRIPTS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const REPO_ROOT = path.resolve(SCRIPTS_DIR, '..', '..');
@@ -70,6 +71,14 @@ function makeCandidateRepo() {
     fs.rmSync(path.join(dir, 'scripts', 'i18n', 'test'), { recursive: true, force: true });
     fs.rmSync(path.join(dir, 'scripts', 'i18n', 'gate-policy.json'), { force: true });
     fs.cpSync(path.join(REPO_ROOT, 'scripts', 'hooks'), path.join(dir, 'scripts', 'hooks'), { recursive: true });
+    // 当前 verifier baseline：fixture 必须携带完整 gate bundle（scripts/ci + workflow + package）
+    fs.cpSync(path.join(REPO_ROOT, 'scripts', 'ci'), path.join(dir, 'scripts', 'ci'), { recursive: true });
+    fs.mkdirSync(path.join(dir, '.github', 'workflows'), { recursive: true });
+    fs.copyFileSync(path.join(REPO_ROOT, '.github', 'workflows', 'quality-gate.yml'),
+        path.join(dir, '.github', 'workflows', 'quality-gate.yml'));
+    copyGateSurfaceFiles(REPO_ROOT, dir);
+    fs.copyFileSync(path.join(REPO_ROOT, 'package.json'), path.join(dir, 'package.json'));
+    fs.copyFileSync(path.join(REPO_ROOT, 'package-lock.json'), path.join(dir, 'package-lock.json'));
     const i18nDir = path.join(dir, APP_I18N);
     fs.mkdirSync(path.join(i18nDir, 'web'), { recursive: true });
     fs.writeFileSync(path.join(i18nDir, 'locales.json'), CATALOG, 'utf8');
@@ -98,12 +107,19 @@ function makeCandidateRepo() {
     return dir;
 }
 
-/** trusted copy：真实 scripts/i18n + scripts/hooks，policy 的 enforcement start 指向夹具。 */
+/** trusted copy：真实 scripts/i18n + hooks + scripts/ci + workflow + package，policy 的 enforcement start 指向夹具。 */
 function makeTrustedCopy(repoRoot) {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv contract trusted-'));
     fs.cpSync(path.join(REPO_ROOT, 'scripts', 'i18n'), path.join(dir, 'scripts', 'i18n'), { recursive: true });
     fs.rmSync(path.join(dir, 'scripts', 'i18n', 'test'), { recursive: true, force: true });
     fs.cpSync(path.join(REPO_ROOT, 'scripts', 'hooks'), path.join(dir, 'scripts', 'hooks'), { recursive: true });
+    // 当前 verifier baseline：trusted verifier 必须携带完整 gate bundle（scripts/ci + workflow + package）
+    fs.cpSync(path.join(REPO_ROOT, 'scripts', 'ci'), path.join(dir, 'scripts', 'ci'), { recursive: true });
+    fs.mkdirSync(path.join(dir, '.github', 'workflows'), { recursive: true });
+    fs.copyFileSync(path.join(REPO_ROOT, '.github', 'workflows', 'quality-gate.yml'),
+        path.join(dir, '.github', 'workflows', 'quality-gate.yml'));
+    copyGateSurfaceFiles(REPO_ROOT, dir);
+    fs.copyFileSync(path.join(REPO_ROOT, 'package.json'), path.join(dir, 'package.json'));
     const policy = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'scripts', 'i18n', 'gate-policy.json'), 'utf8'));
     const start = git(['rev-parse', 'HEAD~1'], repoRoot).stdout.trim();
     policy.i18nEnforcementStartCommit = start;

--- a/scripts/i18n/test/gate-contract.test.mjs
+++ b/scripts/i18n/test/gate-contract.test.mjs
@@ -217,20 +217,45 @@ test('gate-contract：candidate contract 被改为 exit(0) → 自保护拒绝�
     }
 });
 
-test('gate-contract：candidate 删除 prepared-root parent/tree 精确绑定 → 拒绝', () => {
+test('gate-contract：candidate 删除 first-admission source/parent/tree 精确绑定 → 拒绝', () => {
     const root = makeCandidateRepo();
     const trusted = makeTrustedCopy(root);
     try {
         const hookFile = path.join(root, 'scripts', 'hooks', 'pre-commit');
         const hook = fs.readFileSync(hookFile, 'utf8').replace(
-            '    && [ "$prepared_parent" = "$current_parent" ] && [ "$prepared_tree" = "$current_tree" ]; then',
+            '    && [ "$admission_parent" = "$trusted" ] && [ "$admission_parent" = "$current_parent" ] \\\n'
+                + '    && [ "$admission_tree" = "$current_tree" ]; then',
             '    ; then');
         fs.writeFileSync(hookFile, hook, 'utf8');
-        commitBypass(root, 'weaken prepared root binding');
+        assert.notEqual(hook, fs.readFileSync(path.join(trusted, 'scripts', 'hooks', 'pre-commit'), 'utf8'),
+            '测试前提：必须成功删除 first-admission 精确绑定');
+        commitBypass(root, 'weaken first admission binding');
         const sha = git(['rev-parse', 'HEAD'], root).stdout.trim();
         const run = runContract(trusted, root, ['--repo-root', root, '--candidate-ref', sha]);
-        assert.notEqual(run.status, 0, 'prepared-root 失去 parent/tree 精确绑定必须拒绝');
+        assert.notEqual(run.status, 0, 'first-admission 失去 source/parent/tree 精确绑定必须拒绝');
         assert.match(run.stdout + run.stderr, /prepared-root binding|candidate pre-commit was weakened/);
+    } finally {
+        cleanRepo(root);
+        fs.rmSync(trusted, { recursive: true, force: true });
+    }
+});
+
+test('gate-contract：candidate 修改 first-admission bridge spec 或 launcher → 拒绝', () => {
+    const root = makeCandidateRepo();
+    const trusted = makeTrustedCopy(root);
+    try {
+        for (const rel of ['scripts/i18n/epoch-2-first-admission.json',
+            'scripts/i18n/trust-gate.mjs']) {
+            const file = path.join(root, ...rel.split('/'));
+            fs.appendFileSync(file, '\n', 'utf8');
+        }
+        commitBypass(root, 'weaken first admission bridge');
+        const sha = git(['rev-parse', 'HEAD'], root).stdout.trim();
+        const run = runContract(trusted, root, ['--repo-root', root, '--candidate-ref', sha]);
+        assert.notEqual(run.status, 0, 'bridge spec/launcher 被修改时 trusted contract 必须拒绝');
+        assert.match(run.stdout + run.stderr,
+            /first-admission epoch-2-first-admission\.json is frozen/);
+        assert.match(run.stdout + run.stderr, /first-admission trust-gate\.mjs is frozen/);
     } finally {
         cleanRepo(root);
         fs.rmSync(trusted, { recursive: true, force: true });

--- a/scripts/i18n/test/gate-monotonicity.test.mjs
+++ b/scripts/i18n/test/gate-monotonicity.test.mjs
@@ -446,6 +446,93 @@ const MUTATIONS = [
                 'if (false) {'), 'utf8');
         },
     },
+    {
+        name: 'github-ruleset-invariants 删除 required check',
+        mutate: async (root) => {
+            const file = path.join(root, 'scripts', 'ci', 'github-ruleset-invariants.json');
+            const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+            doc.master.requiredChecks = doc.master.requiredChecks.slice(1);
+            fs.writeFileSync(file, JSON.stringify(doc, null, 2) + '\n', 'utf8');
+        },
+    },
+    {
+        name: 'github-ruleset-invariants requireStrict true → false',
+        mutate: async (root) => {
+            const file = path.join(root, 'scripts', 'ci', 'github-ruleset-invariants.json');
+            const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+            doc.master.requireStrict = false;
+            fs.writeFileSync(file, JSON.stringify(doc, null, 2) + '\n', 'utf8');
+        },
+    },
+    {
+        name: 'github-ruleset-invariants allowBypass false → true',
+        mutate: async (root) => {
+            const file = path.join(root, 'scripts', 'ci', 'github-ruleset-invariants.json');
+            const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+            doc.master.allowBypass = true;
+            fs.writeFileSync(file, JSON.stringify(doc, null, 2) + '\n', 'utf8');
+        },
+    },
+    {
+        name: 'github-ruleset-invariants allowDeletion false → true',
+        mutate: async (root) => {
+            const file = path.join(root, 'scripts', 'ci', 'github-ruleset-invariants.json');
+            const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+            doc.master.allowDeletion = true;
+            fs.writeFileSync(file, JSON.stringify(doc, null, 2) + '\n', 'utf8');
+        },
+    },
+    {
+        name: 'github-ruleset-invariants allowNonFastForward false → true',
+        mutate: async (root) => {
+            const file = path.join(root, 'scripts', 'ci', 'github-ruleset-invariants.json');
+            const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+            doc.master.allowNonFastForward = true;
+            fs.writeFileSync(file, JSON.stringify(doc, null, 2) + '\n', 'utf8');
+        },
+    },
+    {
+        name: 'github-ruleset-invariants root tag allowBypass false → true',
+        mutate: async (root) => {
+            const file = path.join(root, 'scripts', 'ci', 'github-ruleset-invariants.json');
+            const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+            doc['i18n-gate-epoch-2-root'].allowBypass = true;
+            fs.writeFileSync(file, JSON.stringify(doc, null, 2) + '\n', 'utf8');
+        },
+    },
+    {
+        name: 'github-ruleset-invariants schemaVersion 降低',
+        mutate: async (root) => {
+            const file = path.join(root, 'scripts', 'ci', 'github-ruleset-invariants.json');
+            const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+            doc.schemaVersion = 0;
+            fs.writeFileSync(file, JSON.stringify(doc, null, 2) + '\n', 'utf8');
+        },
+    },
+    {
+        name: 'doctor-github-ruleset.mjs 删除',
+        mutate: async (root) => {
+            fs.rmSync(path.join(root, 'scripts', 'ci', 'doctor-github-ruleset.mjs'));
+        },
+    },
+    {
+        name: '删除 doctor:github-gate package script',
+        mutate: async (root) => {
+            const pkgPath = path.join(root, 'package.json');
+            const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+            delete pkg.scripts['doctor:github-gate'];
+            fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf8');
+        },
+    },
+    {
+        name: 'doctor:github-gate = true',
+        mutate: async (root) => {
+            const pkgPath = path.join(root, 'package.json');
+            const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+            pkg.scripts['doctor:github-gate'] = 'true';
+            fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf8');
+        },
+    },
 ];
 
 for (const mutation of MUTATIONS) {

--- a/scripts/i18n/test/gate-monotonicity.test.mjs
+++ b/scripts/i18n/test/gate-monotonicity.test.mjs
@@ -369,8 +369,10 @@ const MUTATIONS = [
         mutate: async (root) => {
             const file = path.join(root, 'scripts', 'ci', 'resolve-trusted-base.mjs');
             const source = fs.readFileSync(file, 'utf8').replace(
-                "if (args.gitRef === 'refs/heads/' + args.defaultBranch\n            && SHA_RE.test(args.before || '')",
-                "if (SHA_RE.test(args.before || '')");
+                "if ((args.gitRef === 'refs/heads/' + args.defaultBranch\n"
+                    + "                || (!args.gitRef && SHA_RE.test(args.before || '') && args.before !== ZERO))\n"
+                    + "            && SHA_RE.test(args.before || '') && args.before !== ZERO)",
+                "if (SHA_RE.test(args.before || '') && args.before !== ZERO)");
             fs.writeFileSync(file, source, 'utf8');
         },
     },

--- a/scripts/i18n/test/gate-monotonicity.test.mjs
+++ b/scripts/i18n/test/gate-monotonicity.test.mjs
@@ -1,7 +1,7 @@
 'use strict';
 /**
  * Gate Monotonicity 审计测试（Epoch 2 门禁不可减少）：
- * 程序化构造 21 种 downgrade mutation，全部必须被 gate-parity 拒绝。
+ * 程序化构造 downgrade mutation 矩阵，全部必须被 gate-parity 拒绝。
  * 不是「当前 workflow 看起来正确」，而是「候选试图降低要求时一定失败」。
  */
 import { test } from 'node:test';
@@ -330,6 +330,14 @@ const MUTATIONS = [
         },
     },
     {
+        name: 'push branches-ignore [gh-pages] → branches [master]（缩小分支覆盖）',
+        mutate: async (root) => {
+            const doc = await readWorkflow(root);
+            doc.on.push = { branches: ['master'] };
+            await writeWorkflow(root, doc);
+        },
+    },
+    {
         name: '删除 package script（i18n:gate-parity → 真值删除）',
         mutate: async (root) => {
             const pkgPath = path.join(root, 'package.json');
@@ -345,6 +353,35 @@ const MUTATIONS = [
             const policy = JSON.parse(fs.readFileSync(policyPath, 'utf8'));
             policy.contractVersion = 1;
             fs.writeFileSync(policyPath, JSON.stringify(policy, null, 2) + '\n', 'utf8');
+        },
+    },
+    {
+        name: 'minimumTrustedVerifier contractVersion 4 → 3',
+        mutate: async (root) => {
+            const policyPath = path.join(root, 'scripts', 'i18n', 'gate-policy.json');
+            const policy = JSON.parse(fs.readFileSync(policyPath, 'utf8'));
+            policy.minimumTrustedVerifier.contractVersion = 3;
+            fs.writeFileSync(policyPath, JSON.stringify(policy, null, 2) + '\n', 'utf8');
+        },
+    },
+    {
+        name: 'feature push 重新信任 event.before',
+        mutate: async (root) => {
+            const file = path.join(root, 'scripts', 'ci', 'resolve-trusted-base.mjs');
+            const source = fs.readFileSync(file, 'utf8').replace(
+                "if (args.gitRef === 'refs/heads/' + args.defaultBranch\n            && SHA_RE.test(args.before || '')",
+                "if (SHA_RE.test(args.before || '')");
+            fs.writeFileSync(file, source, 'utf8');
+        },
+    },
+    {
+        name: 'doctor 只拒绝 bypass_mode=always',
+        mutate: async (root) => {
+            const file = path.join(root, 'scripts', 'ci', 'doctor-github-ruleset.mjs');
+            const source = fs.readFileSync(file, 'utf8').replaceAll(
+                'bypassActors.length > 0',
+                "bypassActors.some((a) => a && a.bypass_mode === 'always')");
+            fs.writeFileSync(file, source, 'utf8');
         },
     },
     {
@@ -497,6 +534,28 @@ const MUTATIONS = [
             const file = path.join(root, 'scripts', 'ci', 'github-ruleset-invariants.json');
             const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
             doc['i18n-gate-epoch-2-root'].allowBypass = true;
+            fs.writeFileSync(file, JSON.stringify(doc, null, 2) + '\n', 'utf8');
+        },
+    },
+    {
+        name: 'github-ruleset-invariants 删除既有 verifier root tag',
+        mutate: async (root) => {
+            const file = path.join(root, 'scripts', 'ci', 'github-ruleset-invariants.json');
+            const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+            delete doc['i18n-gate-epoch-2-root'];
+            fs.writeFileSync(file, JSON.stringify(doc, null, 2) + '\n', 'utf8');
+        },
+    },
+    {
+        name: 'github-ruleset-invariants 新 verifier root tag 允许 bypass',
+        mutate: async (root) => {
+            const file = path.join(root, 'scripts', 'ci', 'github-ruleset-invariants.json');
+            const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+            doc['i18n-gate-epoch-3-root'] = {
+                allowDeletion: false,
+                allowNonFastForward: false,
+                allowBypass: true,
+            };
             fs.writeFileSync(file, JSON.stringify(doc, null, 2) + '\n', 'utf8');
         },
     },

--- a/scripts/i18n/test/hooks-hardening.test.mjs
+++ b/scripts/i18n/test/hooks-hardening.test.mjs
@@ -22,6 +22,7 @@ import { fileURLToPath } from 'node:url';
 import { runGenerate } from '../generate-static.mjs';
 import { runAcceptCore, validateCliPolicy } from '../accept.mjs';
 import { runDoctor } from '../doctor-hooks.mjs';
+import { copyGateSurfaceFiles } from './lib/surface-fixture.mjs';
 import staleLock from '../lib/stale-lock.mjs';
 
 const SCRIPTS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -81,10 +82,28 @@ function makeGitRepo(base = os.tmpdir()) {
     git(['config', 'user.email', 't@example.com'], dir);
     git(['config', 'user.name', 'test'], dir);
     git(['config', 'core.autocrlf', 'false'], dir);
+    fs.writeFileSync(path.join(dir, '.gitignore'), 'build/\nnode_modules/\n', 'utf8');
+    try {
+        if (process.platform === 'win32') {
+            fs.symlinkSync(path.join(REPO_ROOT, 'node_modules'), path.join(dir, 'node_modules'), 'junction');
+        } else {
+            fs.symlinkSync(path.join(REPO_ROOT, 'node_modules'), path.join(dir, 'node_modules'));
+        }
+    } catch (e) {
+        // node_modules 不可链接时静默跳过：contract 需要 yaml 的场景会因 NODE_PATH 兜底
+    }
     fs.cpSync(path.join(REPO_ROOT, 'scripts', 'i18n'), path.join(dir, 'scripts', 'i18n'), { recursive: true });
     fs.rmSync(path.join(dir, 'scripts', 'i18n', 'test'), { recursive: true, force: true });
     fs.rmSync(path.join(dir, 'scripts', 'i18n', 'gate-policy.json'), { force: true });
     fs.cpSync(path.join(REPO_ROOT, 'scripts', 'hooks'), path.join(dir, 'scripts', 'hooks'), { recursive: true });
+    // 当前 verifier baseline：anchor 必须携带完整 gate bundle（scripts/ci + workflow + package）
+    fs.cpSync(path.join(REPO_ROOT, 'scripts', 'ci'), path.join(dir, 'scripts', 'ci'), { recursive: true });
+    fs.mkdirSync(path.join(dir, '.github', 'workflows'), { recursive: true });
+    fs.copyFileSync(path.join(REPO_ROOT, '.github', 'workflows', 'quality-gate.yml'),
+        path.join(dir, '.github', 'workflows', 'quality-gate.yml'));
+    copyGateSurfaceFiles(REPO_ROOT, dir);
+    fs.copyFileSync(path.join(REPO_ROOT, 'package.json'), path.join(dir, 'package.json'));
+    fs.copyFileSync(path.join(REPO_ROOT, 'package-lock.json'), path.join(dir, 'package-lock.json'));
     const i18nDir = path.join(dir, APP_I18N);
     fs.mkdirSync(path.join(i18nDir, 'web'), { recursive: true });
     fs.writeFileSync(path.join(i18nDir, 'locales.json'), CATALOG, 'utf8');
@@ -645,7 +664,12 @@ test('pre-push：remote SHA 不在本地 object database → 回退目标 remote
         // pre-push 先从真实远端 fetch 对象到临时 namespace 再准确计算基线（9.4）：
         // 本地提交不在远端 tip 之后 → protected master 拒绝盲推；不得漏检或崩溃。
         const remoteTipBefore = git(['ls-remote', remote], root).stdout.trim();
-        writeBundles(root, GOOD_ZH, GOOD_EN);
+        fs.writeFileSync(path.join(root, APP_I18N, 'web', 'common.properties'),
+            GOOD_ZH + 'status3=状态三\n', 'utf8');
+        fs.writeFileSync(path.join(root, APP_I18N, 'web', 'common_en.properties'),
+            GOOD_EN + 'status3=Status three\n', 'utf8');
+        runGenerate(root);
+        assert.equal(runAcceptCore(root, { locale: 'en-US' }).ok, true);
         commitAll(root, 'local good');
         const push = git(['push', 'origin', 'master'], root, { allowFailure: true });
         assert.notEqual(push.status, 0,

--- a/scripts/i18n/test/hooks.test.mjs
+++ b/scripts/i18n/test/hooks.test.mjs
@@ -178,30 +178,6 @@ function bootstrapRepo(root) {
     git(['commit', '-q', '-m', 'i18n baseline'], root);
 }
 
-/**
- * 持久泄漏快照目录计数：只统计存在超过 30 秒的目录。
- * 并行测试进程的临时快照目录生命周期只有毫秒级，持续存在的目录才代表真正的泄漏
- * （crash / 未清理路径），这样断言不依赖并发时序。
- */
-function snapshotLeakCount() {
-    const cutoff = Date.now() - 30 * 1000;
-    return fs.readdirSync(os.tmpdir(), { withFileTypes: true })
-        .filter((e) => e.isDirectory() && e.name.startsWith('pixivdownload-i18n-snapshot-'))
-        .filter((e) => fs.statSync(path.join(os.tmpdir(), e.name)).mtimeMs < cutoff)
-        .length;
-}
-
-/** 测试文件以独立进程并行执行，共享系统临时目录；检查器进程在 finally 中清理，等待并发进程清理完毕。
- * 注意：gate contract / trust-gate 等长耗时检查进程可能持续 30-60s，等待窗口必须覆盖它们。 */
-function waitForLeakCount(target) {
-    for (let i = 0; i < 240; i += 1) {
-        if (snapshotLeakCount() <= target) {
-            return;
-        }
-        execFileSync('bash', ['-c', 'sleep 0.5'], { stdio: 'ignore' });
-    }
-}
-
 function cleanRepo(root) {
     if (!root) {
         return;
@@ -225,7 +201,8 @@ test('pre-commit：暂存坏英文、工作树修好但不 add → 必须失败'
         test.skip('bash 不可用');
         return;
     }
-    const before = snapshotLeakCount();
+    const isolatedTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv precommit snapshot '));
+    const snapshotEnv = { ...process.env, TEMP: isolatedTemp, TMP: isolatedTemp, TMPDIR: isolatedTemp };
     const root = makeGitRepo();
     try {
         // 工作树与 index 都改为坏英文，然后 git add（index 坏）
@@ -235,7 +212,7 @@ test('pre-commit：暂存坏英文、工作树修好但不 add → 必须失败'
         // 工作树修好，但不 git add
         writeBundles(root, GOOD_ZH, GOOD_EN);
 
-        const result = bash(['scripts/hooks/pre-commit'], root);
+        const result = bash(['scripts/hooks/pre-commit'], root, { env: snapshotEnv });
         assert.notEqual(result.status, 0, 'index 中是坏翻译，pre-commit 必须失败');
         assert.match(result.stdout + result.stderr, /I18N CHECK FAILED|FAILED/);
 
@@ -245,13 +222,13 @@ test('pre-commit：暂存坏英文、工作树修好但不 add → 必须失败'
 
         // 重新暂存修复后通过
         git(['add', '-A'], root);
-        const ok = bash(['scripts/hooks/pre-commit'], root);
+        const ok = bash(['scripts/hooks/pre-commit'], root, { env: snapshotEnv });
         assert.equal(ok.status, 0, 'index 修复后 pre-commit 必须通过: ' + ok.stdout + ok.stderr);
+        assert.equal(fs.readdirSync(isolatedTemp).length, 0, '本用例的临时快照必须全部清理');
     } finally {
         cleanRepo(root);
+        fs.rmSync(isolatedTemp, { recursive: true, force: true });
     }
-    waitForLeakCount(before);
-    assert.equal(snapshotLeakCount(), before, '临时快照必须全部清理');
 });
 
 test('pre-commit：trusted anchor 缺失 → fail closed 并提示 adopt-root', () => {
@@ -271,7 +248,7 @@ test('pre-commit：trusted anchor 缺失 → fail closed 并提示 adopt-root', 
         const result = bash(['scripts/hooks/pre-commit'], root);
         assert.notEqual(result.status, 0, 'anchor 缺失必须 fail closed');
         assert.match(result.stdout + result.stderr, /obsolete or uninitialized epoch/);
-        assert.match(result.stdout + result.stderr, /i18n:trust-gate -- --adopt-root --ref HEAD --epoch 2/);
+        assert.match(result.stdout + result.stderr, /explicit current root adoption command/);
     } finally {
         cleanRepo(root);
     }
@@ -303,10 +280,41 @@ test('pre-commit：epoch1 / 缺失 epoch 的旧 anchor → OBSOLETE GATE EPOCH f
         git(['config', '--local', 'pixiv.i18n.trustedGateEpoch', '3'], root);
         result = bash(['scripts/hooks/pre-commit'], root);
         assert.notEqual(result.status, 0, 'epoch 3 必须 fail closed');
-        assert.match(result.stdout + result.stderr, /obsolete or uninitialized epoch/);
+        assert.match(result.stdout + result.stderr, /does not match trusted anchor policy epoch/);
         // 恢复 epoch 2 后 hooks 正常（fixture 其余状态合法）
         git(['config', '--local', 'pixiv.i18n.trustedGateEpoch', '2'], root);
         assert.equal(anchor.length, 40);
+    } finally {
+        cleanRepo(root);
+    }
+});
+
+test('pre-commit：下一 Epoch root 票据必须同时绑定候选 epoch、HEAD parent 与 staged tree', () => {
+    if (!hasBash()) {
+        test.skip('bash 不可用');
+        return;
+    }
+    const root = makeGitRepo();
+    try {
+        const policyFile = path.join(root, 'scripts', 'i18n', 'gate-policy.json');
+        const policy = JSON.parse(fs.readFileSync(policyFile, 'utf8'));
+        policy.gateEpoch = 3;
+        fs.writeFileSync(policyFile, JSON.stringify(policy, null, 2) + '\n', 'utf8');
+        git(['add', 'scripts/i18n/gate-policy.json'], root);
+        const parent = git(['rev-parse', 'HEAD'], root).stdout.trim();
+        const tree = git(['write-tree'], root).stdout.trim();
+        git(['config', '--local', 'pixiv.i18n.preparedRootEpoch', '3'], root);
+        git(['config', '--local', 'pixiv.i18n.preparedRootParent', parent], root);
+        git(['config', '--local', 'pixiv.i18n.preparedRootTree', tree], root);
+
+        const exact = bash(['scripts/hooks/pre-commit'], root);
+        assert.equal(exact.status, 0, exact.stdout + exact.stderr);
+        assert.match(exact.stdout + exact.stderr, /exact prepared Gate Epoch 3 root candidate/);
+
+        git(['config', '--local', 'pixiv.i18n.preparedRootTree', '0'.repeat(40)], root);
+        const mismatched = bash(['scripts/hooks/pre-commit'], root);
+        assert.notEqual(mismatched.status, 0, 'tree 不匹配时不得使用 root preparation 例外');
+        assert.match(mismatched.stdout + mismatched.stderr, /GATE CONTRACT FAILED|gateEpoch/);
     } finally {
         cleanRepo(root);
     }
@@ -425,7 +433,7 @@ test('pre-commit：git rm scripts/i18n/gate-contract.mjs（gate contract 删除�
     }
 });
 
-test('pre-commit：合法 gate 升级（暂存合法增强的 checker）→ trusted contract 通过', () => {
+test('pre-commit：真实 git commit 的合法 gate 升级 → trusted contract 通过且不污染外层仓库', () => {
     if (!hasBash()) {
         test.skip('bash 不可用');
         return;
@@ -439,9 +447,11 @@ test('pre-commit：合法 gate 升级（暂存合法增强的 checker）→ trus
         fs.writeFileSync(path.join(root, 'pixivdownload-app', 'src', 'main', 'resources', 'static', 'js', 'x.js'),
             'var x = 1;\n', 'utf8');
         git(['add', '-A'], root);
-        const result = bash(['scripts/hooks/pre-commit'], root);
+        const result = git(['commit', '-q', '-m', 'legal gate upgrade'], root, { allowFailure: true });
         assert.equal(result.status, 0, '合法 gate 升级必须通过 trusted contract: ' + result.stdout + result.stderr);
-        assert.match(result.stdout, /GATE CONTRACT OK|gate contract/);
+        assert.match(result.stdout + result.stderr, /GATE CONTRACT OK|gate contract/);
+        assert.equal(git(['config', '--local', '--get', 'core.bare'], root).stdout.trim(), 'false');
+        assert.equal(git(['config', '--local', '--get', 'user.name'], root).stdout.trim(), 'test');
     } finally {
         cleanRepo(root);
     }
@@ -680,36 +690,38 @@ test('pre-push 签名守卫：待推送 commit 含标记 → 失败并指出 SHA
 
 test('check --snapshot index/ref 不读取工作树；异常退出也不残留临时目录', () => {
     const root = makeGitRepo();
+    const isolatedTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv snapshot isolation '));
+    const snapshotEnv = { ...process.env, TEMP: isolatedTemp, TMP: isolatedTemp, TMPDIR: isolatedTemp };
     try {
         // index 快照检查通过（已提交内容合法）
         const indexOk = spawnSync('node',
             [path.join(root, 'scripts', 'i18n', 'check.mjs'), '--snapshot', 'index'],
-            { cwd: root, encoding: 'utf8' });
+            { cwd: root, encoding: 'utf8', env: snapshotEnv });
         assert.equal(indexOk.status, 0, indexOk.stdout + indexOk.stderr);
 
         // 工作树改坏：index 快照检查仍然通过（不读工作树）
         writeBundles(root, GOOD_ZH, BAD_EN);
         const indexStill = spawnSync('node',
             [path.join(root, 'scripts', 'i18n', 'check.mjs'), '--snapshot', 'index'],
-            { cwd: root, encoding: 'utf8' });
+            { cwd: root, encoding: 'utf8', env: snapshotEnv });
         assert.equal(indexStill.status, 0, 'index 快照必须不读取工作树');
 
         // ref 快照检查（HEAD）同样不读工作树
         const refOk = spawnSync('node',
             [path.join(root, 'scripts', 'i18n', 'check.mjs'), '--snapshot', 'ref', '--ref', 'HEAD'],
-            { cwd: root, encoding: 'utf8' });
+            { cwd: root, encoding: 'utf8', env: snapshotEnv });
         assert.equal(refOk.status, 0, refOk.stdout + refOk.stderr);
 
         // 非法 ref → 失败但不残留临时目录
         const badRef = spawnSync('node',
             [path.join(root, 'scripts', 'i18n', 'check.mjs'), '--snapshot', 'ref', '--ref', 'deadbeef'],
-            { cwd: root, encoding: 'utf8' });
+            { cwd: root, encoding: 'utf8', env: snapshotEnv });
         assert.notEqual(badRef.status, 0);
+        assert.equal(fs.readdirSync(isolatedTemp).length, 0, '本用例的临时快照目录必须全部清理');
     } finally {
         cleanRepo(root);
+        cleanRepo(isolatedTemp);
     }
-    waitForLeakCount(0);
-    assert.equal(snapshotLeakCount(), 0, '临时快照目录必须全部清理');
 });
 
 test('pre-push：candidate tip checker = exit(0) + 非法翻译 → 必须失败（不再自批准）', () => {

--- a/scripts/i18n/test/hooks.test.mjs
+++ b/scripts/i18n/test/hooks.test.mjs
@@ -77,8 +77,9 @@ function hasBash() {
  * - C2：引入 gate-policy.json（i18nEnforcementStartCommit = C1），作为本地 trusted anchor。
  * 之后启用 core.hooksPath 并写入 pixiv.i18n.trustedGateRef = C2。
  * 这样后续每个历史 commit 都满足 i18n 门禁，pre-push 的逐 commit 检查只在故意注入的坏提交上失败。
- * fullGate=true 时 C1 还包含 scripts/ci、.github/workflows/quality-gate.yml 与 package.json
- * （候选 gate 完整 bundle；用于 workflow/package scripts 弱化场景）。
+ * C1 始终包含完整 gate bundle：scripts/ci、.github/workflows/quality-gate.yml 与 package.json
+ * （当前 verifier baseline 要求 trusted anchor 携带 gate-surface / gate-invariants / parity /
+ *  resolver / materialize / doctor；旧 fixture 直接升级到当前标准，不做 predates 兼容）。
  */
 function makeGitRepo(base = os.tmpdir(), opts = {}) {
     const dir = path.join(base, 'pixiv test repo ' + Date.now() + '-' + Math.random().toString(36).slice(2));
@@ -98,7 +99,7 @@ function makeGitRepo(base = os.tmpdir(), opts = {}) {
             fs.symlinkSync(path.join(REPO_ROOT, 'node_modules'), path.join(dir, 'node_modules'));
         }
     } catch (e) {
-        // node_modules 不可链接时静默跳过：候选 predates workflow 的场景不需要 yaml
+        // node_modules 不可链接时静默跳过：yaml 解析由 NODE_PATH 兜底
     }
 
     // 复制真实检查器与 hooks（hooks 经 core.hooksPath 生效）；测试目录不需要且含签名标记字样
@@ -107,7 +108,7 @@ function makeGitRepo(base = os.tmpdir(), opts = {}) {
     // C1 不带 gate-policy.json（与真实 enforcement start 05f4ebed 同构：policy 在后续提交引入）
     fs.rmSync(path.join(dir, 'scripts', 'i18n', 'gate-policy.json'), { force: true });
     fs.cpSync(path.join(REPO_ROOT, 'scripts', 'hooks'), path.join(dir, 'scripts', 'hooks'), { recursive: true });
-    if (opts.fullGate) {
+    if (opts.fullGate !== false) {
         fs.cpSync(path.join(REPO_ROOT, 'scripts', 'ci'), path.join(dir, 'scripts', 'ci'), { recursive: true });
         fs.mkdirSync(path.join(dir, '.github', 'workflows'), { recursive: true });
         fs.copyFileSync(path.join(REPO_ROOT, '.github', 'workflows', 'quality-gate.yml'),
@@ -1004,11 +1005,18 @@ function makeEnforcementRepo() {
     git(['add', '-A'], dir);
     git(['commit', '-q', '-m', 'B: no i18n checker'], dir);
 
-    // C：enforcement start —— 完整 i18n gate bundle（无 policy）
+    // C：enforcement start —— 完整 i18n gate bundle（无 policy）+ 当前 verifier baseline 文件
     fs.cpSync(path.join(REPO_ROOT, 'scripts', 'i18n'), path.join(dir, 'scripts', 'i18n'), { recursive: true });
     fs.rmSync(path.join(dir, 'scripts', 'i18n', 'test'), { recursive: true, force: true });
     fs.rmSync(path.join(dir, 'scripts', 'i18n', 'gate-policy.json'), { force: true });
     fs.cpSync(path.join(REPO_ROOT, 'scripts', 'hooks'), path.join(dir, 'scripts', 'hooks'), { recursive: true });
+    fs.cpSync(path.join(REPO_ROOT, 'scripts', 'ci'), path.join(dir, 'scripts', 'ci'), { recursive: true });
+    fs.mkdirSync(path.join(dir, '.github', 'workflows'), { recursive: true });
+    fs.copyFileSync(path.join(REPO_ROOT, '.github', 'workflows', 'quality-gate.yml'),
+        path.join(dir, '.github', 'workflows', 'quality-gate.yml'));
+    copyGateSurfaceFiles(REPO_ROOT, dir);
+    fs.copyFileSync(path.join(REPO_ROOT, 'package.json'), path.join(dir, 'package.json'));
+    fs.copyFileSync(path.join(REPO_ROOT, 'package-lock.json'), path.join(dir, 'package-lock.json'));
     const i18nDir = path.join(dir, APP_I18N);
     fs.mkdirSync(path.join(i18nDir, 'web'), { recursive: true });
     fs.writeFileSync(path.join(i18nDir, 'locales.json'), CATALOG, 'utf8');

--- a/scripts/i18n/test/hooks.test.mjs
+++ b/scripts/i18n/test/hooks.test.mjs
@@ -289,7 +289,7 @@ test('pre-commit：epoch1 / 缺失 epoch 的旧 anchor → OBSOLETE GATE EPOCH f
     }
 });
 
-test('pre-commit：下一 Epoch root 票据必须同时绑定候选 epoch、HEAD parent 与 staged tree', () => {
+test('pre-commit：first-admission 票据必须绑定双 epoch、trusted source、HEAD parent 与 staged tree', () => {
     if (!hasBash()) {
         test.skip('bash 不可用');
         return;
@@ -303,15 +303,17 @@ test('pre-commit：下一 Epoch root 票据必须同时绑定候选 epoch、HEAD
         git(['add', 'scripts/i18n/gate-policy.json'], root);
         const parent = git(['rev-parse', 'HEAD'], root).stdout.trim();
         const tree = git(['write-tree'], root).stdout.trim();
-        git(['config', '--local', 'pixiv.i18n.preparedRootEpoch', '3'], root);
-        git(['config', '--local', 'pixiv.i18n.preparedRootParent', parent], root);
-        git(['config', '--local', 'pixiv.i18n.preparedRootTree', tree], root);
+        git(['config', '--local', 'pixiv.i18n.firstAdmissionSourceEpoch', '2'], root);
+        git(['config', '--local', 'pixiv.i18n.firstAdmissionTargetEpoch', '3'], root);
+        git(['config', '--local', 'pixiv.i18n.firstAdmissionTrustedSource', parent], root);
+        git(['config', '--local', 'pixiv.i18n.firstAdmissionParent', parent], root);
+        git(['config', '--local', 'pixiv.i18n.firstAdmissionTree', tree], root);
 
         const exact = bash(['scripts/hooks/pre-commit'], root);
         assert.equal(exact.status, 0, exact.stdout + exact.stderr);
-        assert.match(exact.stdout + exact.stderr, /exact prepared Gate Epoch 3 root candidate/);
+        assert.match(exact.stdout + exact.stderr, /exact trusted first-admission Gate Epoch 3 root candidate/);
 
-        git(['config', '--local', 'pixiv.i18n.preparedRootTree', '0'.repeat(40)], root);
+        git(['config', '--local', 'pixiv.i18n.firstAdmissionTree', '0'.repeat(40)], root);
         const mismatched = bash(['scripts/hooks/pre-commit'], root);
         assert.notEqual(mismatched.status, 0, 'tree 不匹配时不得使用 root preparation 例外');
         assert.match(mismatched.stdout + mismatched.stderr, /GATE CONTRACT FAILED|gateEpoch/);

--- a/scripts/i18n/test/quality-gate-root-admission.test.mjs
+++ b/scripts/i18n/test/quality-gate-root-admission.test.mjs
@@ -501,6 +501,14 @@ test('feature push：前一恶意 verifier M 即使已在远端，也不能审�
         assert.equal(JSON.parse(run.stdout).base, protectedBase,
             'feature push 必须回到受保护 master fork base，不能使用 event.before=M');
 
+        const bridged = spawnSync('node', [RESOLVER, '--repo-root', root,
+            '--event-name', 'push', '--candidate', candidate,
+            '--before', '0000000000000000000000000000000000000000',
+            '--default-branch', 'master', '--mode'], { cwd: root, encoding: 'utf8' });
+        assert.equal(bridged.status, 0, bridged.stdout + bridged.stderr);
+        assert.equal(JSON.parse(bridged.stdout).base, protectedBase,
+            'contract v4 无 --ref 调用必须通过归一化 before 得到同一 protected fork base');
+
         const proposed = runResolver(root, ['--event-name', 'push', '--candidate', candidate,
             '--before', malicious, '--input-base', malicious, '--default-branch', 'master',
             '--ref', 'refs/heads/feature', '--mode']);

--- a/scripts/i18n/test/quality-gate-root-admission.test.mjs
+++ b/scripts/i18n/test/quality-gate-root-admission.test.mjs
@@ -91,6 +91,10 @@ function makeRepo() {
         JSON.stringify(policy, null, 2) + '\n', 'utf8');
     git(['add', '-A'], dir);
     git(['commit', '-q', '-m', 'add gate policy'], dir); // C2
+    const remote = path.join(dir, '.git', 'test-origin.git');
+    git(['init', '-q', '--bare', remote], dir);
+    git(['remote', 'add', 'origin', remote], dir);
+    git(['-c', 'core.hooksPath=/dev/null', 'push', '-q', '-u', 'origin', 'master'], dir);
     git(['config', '--local', 'core.hooksPath', 'scripts/hooks'], dir);
     git(['config', '--local', 'pixiv.i18n.trustedGateEpoch', '2'], dir);
     git(['config', '--local', 'pixiv.i18n.trustedGateRef', git(['rev-parse', 'HEAD'], dir).stdout.trim()], dir);
@@ -103,7 +107,11 @@ function commitBypass(root, message) {
 }
 
 function runResolver(root, args) {
-    return spawnSync('node', [RESOLVER, '--repo-root', root, ...args],
+    const resolvedArgs = [...args];
+    if (resolvedArgs.includes('push') && !resolvedArgs.includes('--ref')) {
+        resolvedArgs.push('--ref', 'refs/heads/master');
+    }
+    return spawnSync('node', [RESOLVER, '--repo-root', root, ...resolvedArgs],
         { cwd: root, encoding: 'utf8' });
 }
 
@@ -356,6 +364,7 @@ test('trusted base provenance DAG matrix：root <= base < candidate；sibling / 
         fs.writeFileSync(path.join(jsDir, 'x.js'), 'var x = 1;\n', 'utf8');
         commitBypass(root, 'A (legal ancestor)');
         const a = git(['rev-parse', 'HEAD'], root).stdout.trim();
+        git(['-c', 'core.hooksPath=/dev/null', 'push', '-q', 'origin', 'master'], root);
         fs.writeFileSync(path.join(jsDir, 'x.js'), 'var x = 2;\n', 'utf8');
         commitBypass(root, 'C (candidate)');
         const c = git(['rev-parse', 'HEAD'], root).stdout.trim();
@@ -436,6 +445,7 @@ test('push 新分支（before 全零）：fork base = merge-base(candidate, prot
         // 无远端：新分支无法确定 fork base → fail closed
         const noRemote = makeRepo();
         try {
+            git(['remote', 'remove', 'origin'], noRemote);
             git(['tag', 'i18n-gate-epoch-2-root', git(['rev-parse', 'HEAD'], noRemote).stdout.trim()], noRemote);
             fs.mkdirSync(path.join(noRemote, 'pixivdownload-app', 'src', 'main', 'resources', 'static', 'js'), { recursive: true });
             fs.writeFileSync(path.join(noRemote, 'pixivdownload-app', 'src', 'main', 'resources', 'static', 'js', 'f.js'),
@@ -443,7 +453,7 @@ test('push 新分支（before 全零）：fork base = merge-base(candidate, prot
             commitBypass(noRemote, 'feature commit');
             const feat = git(['rev-parse', 'HEAD'], noRemote).stdout.trim();
             const fail = runResolver(noRemote, ['--event-name', 'push', '--candidate', feat, '--before', zero,
-                '--default-branch', 'master', '--mode']);
+                '--default-branch', 'master', '--ref', 'refs/heads/feature', '--mode']);
             assert.notEqual(fail.status, 0, '无远端的新分支 push 必须 fail closed');
             assert.match(fail.stderr, /fork base|protected default/);
         } finally {
@@ -451,11 +461,6 @@ test('push 新分支（before 全零）：fork base = merge-base(candidate, prot
         }
 
         // 有远端：新 feature 分支 fork base = merge-base(candidate, origin/master)
-        const remote = path.join(os.tmpdir(), 'pixiv bare remote ' + Date.now() + '-' + Math.random().toString(36).slice(2));
-        fs.mkdirSync(remote);
-        git(['init', '-q', '--bare', remote], root);
-        git(['remote', 'add', 'origin', remote], root);
-        git(['-c', 'core.hooksPath=/dev/null', 'push', '-q', 'origin', 'master'], root);
         git(['checkout', '-q', '-b', 'feature', c2], root);
         fs.mkdirSync(path.join(root, 'pixivdownload-app', 'src', 'main', 'resources', 'static', 'js'), { recursive: true });
         fs.writeFileSync(path.join(root, 'pixivdownload-app', 'src', 'main', 'resources', 'static', 'js', 'f.js'),
@@ -463,15 +468,44 @@ test('push 新分支（before 全零）：fork base = merge-base(candidate, prot
         commitBypass(root, 'feature commit');
         const featTip = git(['rev-parse', 'HEAD'], root).stdout.trim();
         const fork = runResolver(root, ['--event-name', 'push', '--candidate', featTip, '--before', zero,
-            '--default-branch', 'master', '--mode']);
+            '--default-branch', 'master', '--ref', 'refs/heads/feature', '--mode']);
         assert.equal(fork.status, 0, fork.stdout + fork.stderr);
         assert.equal(JSON.parse(fork.stdout).base, c2,
             '新分支 trusted base 必须是 merge-base(candidate, protected default branch)，'
                 + '而不是 default branch 当前 tip');
         assert.equal(JSON.parse(fork.stdout).mode, 'NORMAL');
 
-        fs.rmSync(remote, { recursive: true, force: true });
         git(['tag', '-d', 'i18n-gate-epoch-2-root'], root, { allowFailure: true });
+    } finally {
+        cleanRepo(root);
+    }
+});
+
+test('feature push：前一恶意 verifier M 即使已在远端，也不能审核下一提交 C', () => {
+    const root = makeRepo();
+    try {
+        const protectedBase = git(['rev-parse', 'HEAD'], root).stdout.trim();
+        git(['tag', 'i18n-gate-epoch-2-root', protectedBase], root);
+        git(['checkout', '-q', '-b', 'feature', protectedBase], root);
+        fs.writeFileSync(path.join(root, 'malicious-verifier.txt'), 'previous CI failed\n', 'utf8');
+        commitBypass(root, 'M malicious verifier');
+        const malicious = git(['rev-parse', 'HEAD'], root).stdout.trim();
+        fs.writeFileSync(path.join(root, 'candidate.txt'), 'next candidate\n', 'utf8');
+        commitBypass(root, 'C candidate');
+        const candidate = git(['rev-parse', 'HEAD'], root).stdout.trim();
+
+        const run = runResolver(root, ['--event-name', 'push', '--candidate', candidate,
+            '--before', malicious, '--default-branch', 'master',
+            '--ref', 'refs/heads/feature', '--mode']);
+        assert.equal(run.status, 0, run.stdout + run.stderr);
+        assert.equal(JSON.parse(run.stdout).base, protectedBase,
+            'feature push 必须回到受保护 master fork base，不能使用 event.before=M');
+
+        const proposed = runResolver(root, ['--event-name', 'push', '--candidate', candidate,
+            '--before', malicious, '--input-base', malicious, '--default-branch', 'master',
+            '--ref', 'refs/heads/feature', '--mode']);
+        assert.notEqual(proposed.status, 0, '显式 proposed M 也必须拒绝');
+        assert.match(proposed.stderr, /protected default branch history|protected predecessor/);
     } finally {
         cleanRepo(root);
     }

--- a/scripts/i18n/test/quality-gate-workflow.test.mjs
+++ b/scripts/i18n/test/quality-gate-workflow.test.mjs
@@ -234,6 +234,21 @@ test('workflow：trusted materialization —— checkout-index --stdin < paths-f
 // 17.2 / 17.3 / 17.4 workflow + package 契约
 // ---------------------------------------------------------------------------
 
+test('workflow：feature push 以归一化 before 调用 contract v4 trusted resolver', () => {
+    const doc = readWorkflow(REPO_ROOT);
+    for (const jobId of ['signature-guard', 'trusted-gate-contract', 'i18n-check']) {
+        const step = doc.jobs[jobId].steps.find((candidate) =>
+            typeof candidate.run === 'string' && /resolve-trusted-base\.mjs/.test(candidate.run));
+        assert.ok(step, jobId + ' 必须调用 trusted resolver');
+        assert.match(step.run, /helper_before="\$\{\{ github\.event\.before \}\}"/);
+        assert.match(step.run,
+            /GITHUB_REF" != "refs\/heads\/\$helper_default_branch"[\s\S]*helper_before="\$zero"/);
+        assert.match(step.run, /--before "\$helper_before"/);
+        assert.doesNotMatch(step.run, /--candidate "\$GITHUB_SHA" --ref "\$GITHUB_REF"/,
+            jobId + ' 不得向 contract v4 trusted resolver 传递新增参数');
+    }
+});
+
 test('workflow 契约：合法 workflow + package scripts + action 版本 → 通过', () => {
     const root = makeFullCandidateRepo();
     const trusted = makeTrustedCopy(root);

--- a/scripts/i18n/test/quality-gate-workflow.test.mjs
+++ b/scripts/i18n/test/quality-gate-workflow.test.mjs
@@ -814,3 +814,75 @@ test('nightly 契约：删除 publish-plugins job → 拒绝（nightly 产物不
         fs.rmSync(trusted, { recursive: true, force: true });
     }
 });
+
+// ---------------------------------------------------------------------------
+// Ruleset invariant 契约（github-ruleset-invariants.json 安全语义只增不减）
+// ---------------------------------------------------------------------------
+
+function mutateRulesetInvariants(root, mutate) {
+    const file = path.join(root, 'scripts', 'ci', 'github-ruleset-invariants.json');
+    const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+    mutate(doc);
+    fs.writeFileSync(file, JSON.stringify(doc, null, 2) + '\n', 'utf8');
+}
+
+test('ruleset 契约：恶意候选（requireStrict=false / allowBypass=true / allowDeletion=true / allowNonFastForward=true / requiredChecks=[]）→ 拒绝', () => {
+    const root = makeFullCandidateRepo();
+    const trusted = makeTrustedCopy(root);
+    try {
+        mutateRulesetInvariants(root, (doc) => {
+            doc.master = {
+                requiredChecks: [],
+                requireStrict: false,
+                allowBypass: true,
+                allowDeletion: true,
+                allowNonFastForward: true,
+            };
+            doc['i18n-gate-epoch-2-root'] = {
+                allowDeletion: true,
+                allowNonFastForward: true,
+                allowBypass: true,
+            };
+        });
+        commitBypass(root, 'weaken ruleset invariants');
+        const sha = git(['rev-parse', 'HEAD'], root).stdout.trim();
+        const run = runContract(trusted, root, ['--repo-root', root, '--candidate-ref', sha]);
+        assert.notEqual(run.status, 0, '弱化 ruleset 不变量必须被 contract 拒绝');
+        assert.match(run.stdout + run.stderr, /requireStrict|allowBypass|required checks not reduced/);
+    } finally {
+        cleanRepo(root);
+        fs.rmSync(trusted, { recursive: true, force: true });
+    }
+});
+
+test('ruleset 契约：删除 github-ruleset-invariants.json → 拒绝', () => {
+    const root = makeFullCandidateRepo();
+    const trusted = makeTrustedCopy(root);
+    try {
+        fs.rmSync(path.join(root, 'scripts', 'ci', 'github-ruleset-invariants.json'));
+        commitBypass(root, 'delete ruleset invariants');
+        const sha = git(['rev-parse', 'HEAD'], root).stdout.trim();
+        const run = runContract(trusted, root, ['--repo-root', root, '--candidate-ref', sha]);
+        assert.notEqual(run.status, 0, '删除 ruleset 不变量文件必须被拒绝');
+        assert.match(run.stdout + run.stderr, /github-ruleset-invariants\.json/);
+    } finally {
+        cleanRepo(root);
+        fs.rmSync(trusted, { recursive: true, force: true });
+    }
+});
+
+test('ruleset 契约：schemaVersion 降低 → 拒绝', () => {
+    const root = makeFullCandidateRepo();
+    const trusted = makeTrustedCopy(root);
+    try {
+        mutateRulesetInvariants(root, (doc) => { doc.schemaVersion = 0; });
+        commitBypass(root, 'lower ruleset schemaVersion');
+        const sha = git(['rev-parse', 'HEAD'], root).stdout.trim();
+        const run = runContract(trusted, root, ['--repo-root', root, '--candidate-ref', sha]);
+        assert.notEqual(run.status, 0, 'schemaVersion 降低必须被拒绝');
+        assert.match(run.stdout + run.stderr, /schemaVersion/);
+    } finally {
+        cleanRepo(root);
+        fs.rmSync(trusted, { recursive: true, force: true });
+    }
+});

--- a/scripts/i18n/test/quality-gate-workflow.test.mjs
+++ b/scripts/i18n/test/quality-gate-workflow.test.mjs
@@ -536,6 +536,50 @@ test('workflow 契约：if false; then npm run test:js; fi → 拒绝（条件�
 // Epoch 2 机制：input 优先级 / root tag / 物化交叉验证
 // ---------------------------------------------------------------------------
 
+test('workflow 契约：push branches-ignore [gh-pages] → branches [master] → 拒绝', () => {
+    const root = makeFullCandidateRepo();
+    const trusted = makeTrustedCopy(root);
+    try {
+        const doc = readWorkflow(root);
+        doc.on.push = { branches: ['master'] };
+        writeWorkflow(root, doc);
+        commitBypass(root, 'narrow push coverage');
+        const sha = git(['rev-parse', 'HEAD'], root).stdout.trim();
+        const run = runContract(trusted, root, ['--repo-root', root, '--candidate-ref', sha]);
+        assert.notEqual(run.status, 0, 'Quality Gate push 覆盖缩回 master-only 必须拒绝');
+        assert.match(run.stdout + run.stderr, /push coverage|branches allow-list|excluded branches/);
+    } finally {
+        cleanRepo(root);
+        fs.rmSync(trusted, { recursive: true, force: true });
+    }
+});
+
+test('workflow 契约：minimumTrustedVerifier 只在 ROOT_ADMISSION 分支执行 → 拒绝', () => {
+    const root = makeFullCandidateRepo();
+    const trusted = makeTrustedCopy(root);
+    try {
+        const doc = readWorkflow(root);
+        const baseStep = doc.jobs['signature-guard'].steps.find((s) =>
+            /minimum_json=.*minimumTrustedVerifier/.test(s.run || ''));
+        assert.ok(baseStep, '测试前提：必须存在 minimumTrustedVerifier bootstrap');
+        const original = baseStep.run;
+        baseStep.run = baseStep.run
+            .replace(/([^\n]*ROOT ADMISSION MODE:[^\n]*\n)\s*fi\n(\s*# Candidate policy proposes)/,
+                '$1$2')
+            .replace(/(\s*done <<< "\$minimum_files"\n)/, '$1fi\n');
+        assert.notEqual(baseStep.run, original, '测试前提：必须成功把 baseline 移入 ROOT_ADMISSION');
+        writeWorkflow(root, doc);
+        commitBypass(root, 'restrict minimum verifier baseline to root admission');
+        const sha = git(['rev-parse', 'HEAD'], root).stdout.trim();
+        const run = runContract(trusted, root, ['--repo-root', root, '--candidate-ref', sha]);
+        assert.notEqual(run.status, 0, 'NORMAL candidate 跳过 minimumTrustedVerifier 必须拒绝');
+        assert.match(run.stdout + run.stderr, /minimumTrustedVerifier applies|NORMAL.*baseline/);
+    } finally {
+        cleanRepo(root);
+        fs.rmSync(trusted, { recursive: true, force: true });
+    }
+});
+
 test('workflow 契约：删除 inputs.trusted_base_sha 优先级（reusable 语义）→ 拒绝', () => {
     const root = makeFullCandidateRepo();
     const trusted = makeTrustedCopy(root);

--- a/scripts/i18n/test/trust-gate.test.mjs
+++ b/scripts/i18n/test/trust-gate.test.mjs
@@ -131,6 +131,39 @@ function runCli(root, args, env = {}) {
     return spawnSync('node', [CLI, ...args], { cwd: root, encoding: 'utf8', env: merged, timeout: 600000 });
 }
 
+function runRepoCli(root, args, env = {}) {
+    const merged = { ...process.env, ...env };
+    if (env.clearCI) {
+        delete merged.CI;
+        delete merged.clearCI;
+    }
+    return spawnSync('node', [path.join(root, 'scripts', 'i18n', 'trust-gate.mjs'), ...args],
+        { cwd: root, encoding: 'utf8', env: merged, timeout: 600000 });
+}
+
+function rewriteFixtureForNextEpoch(root) {
+    const roots = [path.join(root, 'scripts'), path.join(root, '.github', 'workflows')];
+    for (const start of roots) {
+        const pending = [start];
+        while (pending.length > 0) {
+            const current = pending.pop();
+            for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+                const file = path.join(current, entry.name);
+                if (entry.isDirectory()) {
+                    pending.push(file);
+                    continue;
+                }
+                let content = fs.readFileSync(file, 'utf8');
+                content = content
+                    .replaceAll('i18n-gate-epoch-2-root', 'i18n-gate-epoch-3-root')
+                    .replace('export const CURRENT_GATE_EPOCH = 2;', 'export const CURRENT_GATE_EPOCH = 3;')
+                    .replaceAll('"gateEpoch": 2', '"gateEpoch": 3');
+                fs.writeFileSync(file, content, 'utf8');
+            }
+        }
+    }
+}
+
 function cleanRepo(root) {
     if (!root) {
         return;
@@ -167,7 +200,7 @@ test('trust-gate：adopt-root 写入 epoch 2 + ref；--show 输出 SHA 与 contr
         const adopt = runCli(root, ['--adopt-root', '--ref', 'HEAD', '--epoch', '2'], { clearCI: true });
         assert.equal(adopt.status, 0, adopt.stdout + adopt.stderr);
         assert.match(adopt.stdout + adopt.stderr, /ROOT ADMISSION/);
-        assert.match(adopt.stdout + adopt.stderr, /Epoch 2 root adopted/);
+        assert.match(adopt.stdout + adopt.stderr, /Gate Epoch 2 root adopted/);
         const configured = git(['config', '--local', '--get', 'pixiv.i18n.trustedGateRef'], root).stdout.trim();
         assert.equal(configured, head, 'adopt-root 必须写入当前 HEAD 的完整 SHA');
         assert.equal(git(['config', '--local', '--get', 'pixiv.i18n.trustedGateEpoch'], root).stdout.trim(), '2');
@@ -196,9 +229,12 @@ test('trust-gate：adopt-root 只写 local 配置（不写 global）', () => {
     }
 });
 
-test('trust-gate：CI 环境禁止 adopt-root / advance', () => {
+test('trust-gate：CI 环境禁止 prepare-root / adopt-root / advance', () => {
     const root = makeRepo();
     try {
+        const prepare = runCli(root, ['--prepare-root', '--epoch', '2'], { CI: 'true' });
+        assert.notEqual(prepare.status, 0, 'CI=true 必须拒绝 prepare-root');
+        assert.match(prepare.stderr, /forbidden in CI/);
         const adopt = runCli(root, ['--adopt-root', '--ref', 'HEAD', '--epoch', '2'], { CI: 'true' });
         assert.notEqual(adopt.status, 0, 'CI=true 必须拒绝 adopt-root');
         assert.match(adopt.stderr, /forbidden in CI/);
@@ -247,6 +283,41 @@ test('trust-gate：adopt-root 脏工作树 / 已存在 anchor 拒绝', () => {
         const again = runCli(root, ['--adopt-root', '--ref', 'HEAD', '--epoch', '2'], { clearCI: true });
         assert.notEqual(again.status, 0, '已有 anchor 必须拒绝再次 adopt-root');
         assert.match(again.stderr, /already exists/);
+    } finally {
+        cleanRepo(root);
+    }
+});
+
+test('trust-gate：prepare-root 精确绑定 staged tree + parent，提交后才允许采用下一 Epoch root', () => {
+    if (!hasBash()) {
+        test.skip('bash 不可用');
+        return;
+    }
+    const root = makeRepo(true);
+    try {
+        const previousRoot = git(['rev-parse', 'HEAD'], root).stdout.trim();
+        git(['tag', 'i18n-gate-epoch-2-root', previousRoot], root);
+        rewriteFixtureForNextEpoch(root);
+        git(['add', '-A'], root);
+
+        const prepare = runRepoCli(root, ['--prepare-root', '--epoch', '3'], { clearCI: true });
+        assert.equal(prepare.status, 0, prepare.stdout + prepare.stderr);
+        assert.match(prepare.stdout + prepare.stderr, /Gate Epoch 3 root prepared/);
+        const preparedTree = git(['config', '--local', '--get', 'pixiv.i18n.preparedRootTree'], root)
+            .stdout.trim();
+        assert.equal(preparedTree, git(['write-tree'], root).stdout.trim());
+
+        const commit = git(['commit', '-q', '-m', 'epoch 3 root'], root);
+        assert.equal(commit.status, 0, commit.stdout + commit.stderr);
+        const adopt = runRepoCli(root,
+            ['--adopt-root', '--ref', 'HEAD', '--epoch', '3'], { clearCI: true });
+        assert.equal(adopt.status, 0, adopt.stdout + adopt.stderr);
+        assert.equal(git(['config', '--local', '--get', 'pixiv.i18n.trustedGateEpoch'], root)
+            .stdout.trim(), '3');
+        assert.equal(git(['config', '--local', '--get', 'pixiv.i18n.trustedGateRef'], root)
+            .stdout.trim(), git(['rev-parse', 'HEAD'], root).stdout.trim());
+        assert.notEqual(git(['config', '--local', '--get', 'pixiv.i18n.preparedRootTree'], root,
+            { allowFailure: true }).status, 0, 'adopt-root 成功后必须清除 preparation ticket');
     } finally {
         cleanRepo(root);
     }

--- a/scripts/i18n/test/trust-gate.test.mjs
+++ b/scripts/i18n/test/trust-gate.test.mjs
@@ -11,7 +11,7 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -145,6 +145,47 @@ function runRepoCli(root, args, env = {}) {
     }
     return spawnSync('node', [path.join(root, 'scripts', 'i18n', 'trust-gate.mjs'), ...args],
         { cwd: root, encoding: 'utf8', env: merged, timeout: 600000 });
+}
+
+function runRepoCliWithStdoutAction(root, args, marker, action, env = {}) {
+    const merged = { ...process.env, ...env };
+    if (env.clearCI) {
+        delete merged.CI;
+        delete merged.clearCI;
+    }
+    return new Promise((resolve, reject) => {
+        const child = spawn('node', [path.join(root, 'scripts', 'i18n', 'trust-gate.mjs'), ...args],
+            { cwd: root, env: merged });
+        let stdout = '';
+        let stderr = '';
+        let actionRun = false;
+        let actionError = null;
+        const timer = setTimeout(() => child.kill(), 600000);
+        child.stdout.on('data', (chunk) => {
+            stdout += chunk.toString();
+            if (!actionRun && stdout.includes(marker)) {
+                actionRun = true;
+                try {
+                    action();
+                } catch (e) {
+                    actionError = e;
+                    child.kill();
+                }
+            }
+        });
+        child.stderr.on('data', (chunk) => {
+            stderr += chunk.toString();
+        });
+        child.once('error', reject);
+        child.once('close', (status) => {
+            clearTimeout(timer);
+            if (actionError) {
+                reject(actionError);
+                return;
+            }
+            resolve({ status: status === null ? 1 : status, stdout, stderr, actionRun });
+        });
+    });
 }
 
 function runTrustedCli(root, trustedSource, args, env = {}) {
@@ -492,6 +533,63 @@ test('trust-gate：trusted bridge 以实时 master tip 准备 tree、唯一封�
             { allowFailure: true }).status, 0, 'adopt-root 成功后必须清除 preparation ticket');
         assert.notEqual(git(['config', '--local', '--get', 'pixiv.i18n.firstAdmissionCandidate'], root,
             { allowFailure: true }).status, 0, 'adopt-root 成功后必须清除 candidate seal');
+    } finally {
+        cleanRepo(root);
+    }
+});
+
+test('trust-gate：adopt-root 在 ROOT_ADMISSION 后按 commit-point 重验 live master', async () => {
+    if (!hasBash()) {
+        test.skip('bash 不可用');
+        return;
+    }
+    const root = makeRepo(true);
+    try {
+        const previousRoot = git(['rev-parse', 'HEAD'], root).stdout.trim();
+        git(['tag', 'i18n-gate-epoch-2-root', previousRoot], root);
+        rewriteFixtureForNextEpoch(root);
+        git(['add', '-A'], root);
+        const prepare = runTrustedCli(root, previousRoot,
+            ['--prepare-root', '--epoch', '3'], { clearCI: true });
+        assert.equal(prepare.status, 0, prepare.stdout + prepare.stderr);
+        const commit = git(['commit', '-q', '-m', 'epoch 3 root'], root);
+        assert.equal(commit.status, 0, commit.stdout + commit.stderr);
+        const seal = runTrustedCli(root, previousRoot,
+            ['--seal-root', '--ref', 'HEAD'], { clearCI: true });
+        assert.equal(seal.status, 0, seal.stdout + seal.stderr);
+        const candidateSha = git(['rev-parse', 'HEAD'], root).stdout.trim();
+        const ticketKeys = [
+            trustedGate.FIRST_ADMISSION_SOURCE_EPOCH_KEY,
+            trustedGate.FIRST_ADMISSION_TARGET_EPOCH_KEY,
+            trustedGate.FIRST_ADMISSION_TRUSTED_SOURCE_KEY,
+            trustedGate.FIRST_ADMISSION_PARENT_KEY,
+            trustedGate.FIRST_ADMISSION_TREE_KEY,
+            trustedGate.FIRST_ADMISSION_CANDIDATE_KEY,
+        ];
+        const ticketBefore = ticketKeys.map((key) =>
+            git(['config', '--local', '--get', key], root).stdout.trim());
+        const originDir = git(['remote', 'get-url', 'origin'], root).stdout.trim();
+        const advancedMaster = git(['--git-dir', originDir,
+            '-c', 'user.name=test', '-c', 'user.email=t@example.com',
+            'commit-tree', previousRoot + '^{tree}', '-p', previousRoot], root,
+            { input: 'advance protected master\n' }).stdout.trim();
+
+        const adopt = await runRepoCliWithStdoutAction(root,
+            ['--adopt-root', '--ref', 'HEAD', '--epoch', '3'],
+            'running the full i18n test suite', () => setLiveMaster(root, advancedMaster),
+            { clearCI: true });
+        assert.equal(adopt.actionRun, true, '必须在 ROOT_ADMISSION suite 运行期间推进 live master');
+        assert.notEqual(adopt.status, 0, 'commit-point 必须拒绝 suite 期间发生的 live master 变化');
+        assert.match(adopt.stdout + adopt.stderr, /commit-point revalidation failed.*live protected master tip/s);
+        assert.equal(git(['config', '--local', '--get', 'pixiv.i18n.trustedGateEpoch'], root)
+            .stdout.trim(), '2', '失败后必须保留 Epoch 2');
+        assert.equal(git(['config', '--local', '--get', 'pixiv.i18n.trustedGateRef'], root)
+            .stdout.trim(), previousRoot, '失败后必须保留 Epoch 2 trusted source');
+        assert.deepEqual(ticketKeys.map((key) =>
+            git(['config', '--local', '--get', key], root).stdout.trim()), ticketBefore,
+        '失败后必须保留完整 first-admission ticket 与 candidate seal');
+        assert.notEqual(git(['config', '--local', '--get', 'pixiv.i18n.trustedGateRef'], root)
+            .stdout.trim(), candidateSha, '失败后不得建立 Epoch 3 anchor');
     } finally {
         cleanRepo(root);
     }

--- a/scripts/i18n/test/trust-gate.test.mjs
+++ b/scripts/i18n/test/trust-gate.test.mjs
@@ -111,6 +111,7 @@ function makeRepo(withAnchor = false, anchorEpoch = '2') {
         const anchor = git(['rev-parse', 'HEAD'], dir).stdout.trim();
         git(['config', '--local', 'pixiv.i18n.trustedGateEpoch', anchorEpoch], dir);
         git(['config', '--local', 'pixiv.i18n.trustedGateRef', anchor], dir);
+        git(['update-ref', 'refs/remotes/origin/master', anchor], dir);
     }
     return dir;
 }
@@ -142,6 +143,14 @@ function runRepoCli(root, args, env = {}) {
 }
 
 function rewriteFixtureForNextEpoch(root) {
+    const contextReplacements = new Map([
+        ['Quality Gate / java-tests', 'java-tests'],
+        ['Quality Gate / javascript-tests', 'javascript-tests'],
+        ['Quality Gate / signature-guard', 'signature-guard'],
+        ['Quality Gate / trusted-gate-contract', 'trusted-gate-contract'],
+        ['Quality Gate / i18n-check', 'i18n-check'],
+        ['Shared Snippet Drift Check / check-shared-snippets', 'check-shared-snippets'],
+    ]);
     const roots = [path.join(root, 'scripts'), path.join(root, '.github', 'workflows')];
     for (const start of roots) {
         const pending = [start];
@@ -153,11 +162,33 @@ function rewriteFixtureForNextEpoch(root) {
                     pending.push(file);
                     continue;
                 }
+                if (file.endsWith(path.join('scripts', 'i18n', 'epoch-2-first-admission.json'))) {
+                    fs.rmSync(file);
+                    continue;
+                }
+                if (file.endsWith(path.join('scripts', 'ci', 'github-ruleset-invariants.json'))) {
+                    const rules = JSON.parse(fs.readFileSync(file, 'utf8'));
+                    rules.master.requiredChecks = [...contextReplacements.values()];
+                    rules['i18n-gate-epoch-3-root'] = { ...rules['i18n-gate-epoch-2-root'] };
+                    fs.writeFileSync(file, JSON.stringify(rules, null, 2) + '\n', 'utf8');
+                    continue;
+                }
                 let content = fs.readFileSync(file, 'utf8');
                 content = content
                     .replaceAll('i18n-gate-epoch-2-root', 'i18n-gate-epoch-3-root')
                     .replace('export const CURRENT_GATE_EPOCH = 2;', 'export const CURRENT_GATE_EPOCH = 3;')
                     .replaceAll('"gateEpoch": 2', '"gateEpoch": 3');
+                for (const [oldValue, newValue] of contextReplacements) {
+                    content = content.replaceAll(oldValue, newValue);
+                }
+                if (file.endsWith(path.join('scripts', 'i18n', 'gate-policy.json'))) {
+                    const policy = JSON.parse(content);
+                    policy.requiredPaths = policy.requiredPaths
+                        .filter((entryPath) => entryPath !== 'scripts/i18n/epoch-2-first-admission.json');
+                    policy.minimumTrustedVerifier.requiredFiles = policy.minimumTrustedVerifier.requiredFiles
+                        .filter((entryPath) => entryPath !== 'scripts/i18n/epoch-2-first-admission.json');
+                    content = JSON.stringify(policy, null, 2) + '\n';
+                }
                 fs.writeFileSync(file, content, 'utf8');
             }
         }
@@ -300,15 +331,64 @@ test('trust-gate：prepare-root 精确绑定 staged tree + parent，提交后才
         rewriteFixtureForNextEpoch(root);
         git(['add', '-A'], root);
 
+        git(['update-ref', '-d', 'refs/remotes/origin/master'], root);
+        const unprotected = runRepoCli(root, ['--prepare-root', '--epoch', '3'], { clearCI: true });
+        assert.notEqual(unprotected.status, 0, '不在受保护 master 历史中的 source 必须拒绝');
+        assert.match(unprotected.stdout + unprotected.stderr, /not in protected origin\/master history/);
+        assert.notEqual(git(['config', '--local', '--get', 'pixiv.i18n.firstAdmissionTree'], root,
+            { allowFailure: true }).status, 0, '失败 bridge 不得部分写 ticket');
+        git(['update-ref', 'refs/remotes/origin/master', previousRoot], root);
+
+        const policyFile = path.join(root, 'scripts', 'i18n', 'gate-policy.json');
+        const badPolicy = JSON.parse(fs.readFileSync(policyFile, 'utf8'));
+        badPolicy.requiredExternalCheckDefinitions[0].requiredContext =
+            'Shared Snippet Drift Check / check-shared-snippets';
+        fs.writeFileSync(policyFile, JSON.stringify(badPolicy, null, 2) + '\n', 'utf8');
+        git(['add', 'scripts/i18n/gate-policy.json'], root);
+        const dualContext = runRepoCli(root, ['--prepare-root', '--epoch', '3'], { clearCI: true });
+        assert.notEqual(dualContext.status, 0, '旧 context 或双 context 必须拒绝');
+        assert.match(dualContext.stdout + dualContext.stderr, /requiredExternalCheckDefinitions|required context/);
+        badPolicy.requiredExternalCheckDefinitions[0].requiredContext = 'check-shared-snippets';
+        fs.writeFileSync(policyFile, JSON.stringify(badPolicy, null, 2) + '\n', 'utf8');
+        git(['add', 'scripts/i18n/gate-policy.json'], root);
+
+        fs.writeFileSync(path.join(root, 'unrelated.txt'), 'not part of the root transition\n', 'utf8');
+        git(['add', 'unrelated.txt'], root);
+        const expanded = runRepoCli(root, ['--prepare-root', '--epoch', '3'], { clearCI: true });
+        assert.notEqual(expanded.status, 0, 'first admission 不得夹带无关改动');
+        assert.match(expanded.stdout + expanded.stderr, /out-of-scope or non-mechanical change/);
+        git(['rm', '-q', '-f', 'unrelated.txt'], root);
+
         const prepare = runRepoCli(root, ['--prepare-root', '--epoch', '3'], { clearCI: true });
         assert.equal(prepare.status, 0, prepare.stdout + prepare.stderr);
         assert.match(prepare.stdout + prepare.stderr, /Gate Epoch 3 root prepared/);
-        const preparedTree = git(['config', '--local', '--get', 'pixiv.i18n.preparedRootTree'], root)
+        const preparedTree = git(['config', '--local', '--get', 'pixiv.i18n.firstAdmissionTree'], root)
             .stdout.trim();
         assert.equal(preparedTree, git(['write-tree'], root).stdout.trim());
+        assert.equal(git(['config', '--local', '--get', 'pixiv.i18n.firstAdmissionSourceEpoch'], root)
+            .stdout.trim(), '2');
+        assert.equal(git(['config', '--local', '--get', 'pixiv.i18n.firstAdmissionTargetEpoch'], root)
+            .stdout.trim(), '3');
+        assert.equal(git(['config', '--local', '--get', 'pixiv.i18n.firstAdmissionTrustedSource'], root)
+            .stdout.trim(), previousRoot);
 
+        git(['config', '--local', 'pixiv.i18n.firstAdmissionTrustedSource', '0'.repeat(40)], root);
+        const refusedCommit = git(['commit', '-q', '-m', 'mismatched epoch 3 root'], root,
+            { allowFailure: true });
+        assert.notEqual(refusedCommit.status, 0, 'ticket trusted source 不匹配时 pre-commit 必须拒绝');
+        git(['config', '--local', 'pixiv.i18n.firstAdmissionTrustedSource', previousRoot], root);
         const commit = git(['commit', '-q', '-m', 'epoch 3 root'], root);
         assert.equal(commit.status, 0, commit.stdout + commit.stderr);
+
+        git(['config', '--local', 'pixiv.i18n.firstAdmissionParent', '0'.repeat(40)], root);
+        const refusedAdopt = runRepoCli(root,
+            ['--adopt-root', '--ref', 'HEAD', '--epoch', '3'], { clearCI: true });
+        assert.notEqual(refusedAdopt.status, 0, 'ticket parent 不匹配时 adoption 必须拒绝');
+        assert.equal(git(['config', '--local', '--get', 'pixiv.i18n.trustedGateRef'], root)
+            .stdout.trim(), previousRoot, '失败 adoption 不得推进 anchor');
+        assert.equal(git(['config', '--local', '--get', 'pixiv.i18n.firstAdmissionParent'], root)
+            .stdout.trim(), '0'.repeat(40), '失败 adoption 不得消费或改写 ticket');
+        git(['config', '--local', 'pixiv.i18n.firstAdmissionParent', previousRoot], root);
         const adopt = runRepoCli(root,
             ['--adopt-root', '--ref', 'HEAD', '--epoch', '3'], { clearCI: true });
         assert.equal(adopt.status, 0, adopt.stdout + adopt.stderr);
@@ -316,7 +396,7 @@ test('trust-gate：prepare-root 精确绑定 staged tree + parent，提交后才
             .stdout.trim(), '3');
         assert.equal(git(['config', '--local', '--get', 'pixiv.i18n.trustedGateRef'], root)
             .stdout.trim(), git(['rev-parse', 'HEAD'], root).stdout.trim());
-        assert.notEqual(git(['config', '--local', '--get', 'pixiv.i18n.preparedRootTree'], root,
+        assert.notEqual(git(['config', '--local', '--get', 'pixiv.i18n.firstAdmissionTree'], root,
             { allowFailure: true }).status, 0, 'adopt-root 成功后必须清除 preparation ticket');
     } finally {
         cleanRepo(root);

--- a/scripts/i18n/test/trust-gate.test.mjs
+++ b/scripts/i18n/test/trust-gate.test.mjs
@@ -19,6 +19,7 @@ import { fileURLToPath } from 'node:url';
 
 import { runAcceptCore } from '../accept.mjs';
 import { runGenerate } from '../generate-static.mjs';
+import trustedGate from '../lib/trusted-gate.mjs';
 import { copyGateSurfaceFiles } from './lib/surface-fixture.mjs';
 
 const SCRIPTS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -106,12 +107,16 @@ function makeRepo(withAnchor = false, anchorEpoch = '2') {
         JSON.stringify(policy, null, 2) + '\n', 'utf8');
     git(['add', '-A'], dir);
     git(['commit', '-q', '-m', 'add gate policy'], dir); // C2
+    const anchor = git(['rev-parse', 'HEAD'], dir).stdout.trim();
+    const originDir = path.join(dir, '.git', 'test-origin.git');
+    git(['init', '--bare', '-q', originDir], dir);
+    git(['remote', 'add', 'origin', originDir], dir);
+    git(['push', '-q', 'origin', 'HEAD:refs/heads/master'], dir);
+    git(['update-ref', 'refs/remotes/origin/master', anchor], dir);
     git(['config', '--local', 'core.hooksPath', 'scripts/hooks'], dir);
     if (withAnchor) {
-        const anchor = git(['rev-parse', 'HEAD'], dir).stdout.trim();
         git(['config', '--local', 'pixiv.i18n.trustedGateEpoch', anchorEpoch], dir);
         git(['config', '--local', 'pixiv.i18n.trustedGateRef', anchor], dir);
-        git(['update-ref', 'refs/remotes/origin/master', anchor], dir);
     }
     return dir;
 }
@@ -140,6 +145,39 @@ function runRepoCli(root, args, env = {}) {
     }
     return spawnSync('node', [path.join(root, 'scripts', 'i18n', 'trust-gate.mjs'), ...args],
         { cwd: root, encoding: 'utf8', env: merged, timeout: 600000 });
+}
+
+function runTrustedCli(root, trustedSource, args, env = {}) {
+    const bundle = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv trusted first admission '));
+    try {
+        const paths = git(['ls-tree', '-r', '--name-only', trustedSource, '--',
+            ...trustedGate.GATE_PATHS], root).stdout.trim().split(/\r?\n/).filter(Boolean);
+        for (const rel of paths) {
+            const target = path.join(bundle, ...rel.split('/'));
+            fs.mkdirSync(path.dirname(target), { recursive: true });
+            const shown = spawnSync('git', ['show', trustedSource + ':' + rel], {
+                cwd: root, encoding: null, maxBuffer: 64 * 1024 * 1024,
+            });
+            assert.equal(shown.status, 0, shown.stderr && shown.stderr.toString('utf8'));
+            fs.writeFileSync(target, shown.stdout);
+        }
+        const merged = { ...process.env, ...env };
+        if (env.clearCI) {
+            delete merged.CI;
+            delete merged.clearCI;
+        }
+        return spawnSync('node', [path.join(bundle, 'scripts', 'i18n', 'trust-gate.mjs'),
+            ...args, '--trusted-source', trustedSource], {
+            cwd: root, encoding: 'utf8', env: merged, timeout: 600000,
+        });
+    } finally {
+        fs.rmSync(bundle, { recursive: true, force: true });
+    }
+}
+
+function setLiveMaster(root, sha) {
+    const originDir = git(['remote', 'get-url', 'origin'], root).stdout.trim();
+    git(['--git-dir', originDir, 'update-ref', 'refs/heads/master', sha], root);
 }
 
 function rewriteFixtureForNextEpoch(root) {
@@ -260,12 +298,17 @@ test('trust-gate：adopt-root 只写 local 配置（不写 global）', () => {
     }
 });
 
-test('trust-gate：CI 环境禁止 prepare-root / adopt-root / advance', () => {
+test('trust-gate：CI 环境禁止 prepare-root / seal-root / adopt-root / advance', () => {
     const root = makeRepo();
     try {
-        const prepare = runCli(root, ['--prepare-root', '--epoch', '2'], { CI: 'true' });
+        const prepare = runCli(root,
+            ['--prepare-root', '--epoch', '2', '--trusted-source', '0'.repeat(40)], { CI: 'true' });
         assert.notEqual(prepare.status, 0, 'CI=true 必须拒绝 prepare-root');
         assert.match(prepare.stderr, /forbidden in CI/);
+        const seal = runCli(root, ['--seal-root', '--ref', 'HEAD', '--trusted-source', '0'.repeat(40)],
+            { CI: 'true' });
+        assert.notEqual(seal.status, 0, 'CI=true 必须拒绝 seal-root');
+        assert.match(seal.stderr, /forbidden in CI/);
         const adopt = runCli(root, ['--adopt-root', '--ref', 'HEAD', '--epoch', '2'], { CI: 'true' });
         assert.notEqual(adopt.status, 0, 'CI=true 必须拒绝 adopt-root');
         assert.match(adopt.stderr, /forbidden in CI/);
@@ -319,7 +362,7 @@ test('trust-gate：adopt-root 脏工作树 / 已存在 anchor 拒绝', () => {
     }
 });
 
-test('trust-gate：prepare-root 精确绑定 staged tree + parent，提交后才允许采用下一 Epoch root', () => {
+test('trust-gate：trusted bridge 以实时 master tip 准备 tree、唯一封存 candidate SHA 后才允许采用', () => {
     if (!hasBash()) {
         test.skip('bash 不可用');
         return;
@@ -331,13 +374,21 @@ test('trust-gate：prepare-root 精确绑定 staged tree + parent，提交后才
         rewriteFixtureForNextEpoch(root);
         git(['add', '-A'], root);
 
-        git(['update-ref', '-d', 'refs/remotes/origin/master'], root);
-        const unprotected = runRepoCli(root, ['--prepare-root', '--epoch', '3'], { clearCI: true });
-        assert.notEqual(unprotected.status, 0, '不在受保护 master 历史中的 source 必须拒绝');
-        assert.match(unprotected.stdout + unprotected.stderr, /not in protected origin\/master history/);
+        const staleMaster = git(['rev-parse', previousRoot + '^'], root).stdout.trim();
+        setLiveMaster(root, staleMaster);
+        const unprotected = runTrustedCli(root, previousRoot,
+            ['--prepare-root', '--epoch', '3'], { clearCI: true });
+        assert.notEqual(unprotected.status, 0, 'source 不等于实时 protected master tip 时必须拒绝');
+        assert.match(unprotected.stdout + unprotected.stderr, /local and live protected master tip/);
         assert.notEqual(git(['config', '--local', '--get', 'pixiv.i18n.firstAdmissionTree'], root,
             { allowFailure: true }).status, 0, '失败 bridge 不得部分写 ticket');
-        git(['update-ref', 'refs/remotes/origin/master', previousRoot], root);
+        setLiveMaster(root, previousRoot);
+
+        const candidateLauncher = runRepoCli(root,
+            ['--prepare-root', '--epoch', '3', '--trusted-source', previousRoot], { clearCI: true });
+        assert.notEqual(candidateLauncher.status, 0, 'candidate CLI 不得代理 first-admission bridge');
+        assert.match(candidateLauncher.stdout + candidateLauncher.stderr,
+            /external materialized trusted bundle/);
 
         const policyFile = path.join(root, 'scripts', 'i18n', 'gate-policy.json');
         const badPolicy = JSON.parse(fs.readFileSync(policyFile, 'utf8'));
@@ -345,7 +396,8 @@ test('trust-gate：prepare-root 精确绑定 staged tree + parent，提交后才
             'Shared Snippet Drift Check / check-shared-snippets';
         fs.writeFileSync(policyFile, JSON.stringify(badPolicy, null, 2) + '\n', 'utf8');
         git(['add', 'scripts/i18n/gate-policy.json'], root);
-        const dualContext = runRepoCli(root, ['--prepare-root', '--epoch', '3'], { clearCI: true });
+        const dualContext = runTrustedCli(root, previousRoot,
+            ['--prepare-root', '--epoch', '3'], { clearCI: true });
         assert.notEqual(dualContext.status, 0, '旧 context 或双 context 必须拒绝');
         assert.match(dualContext.stdout + dualContext.stderr, /requiredExternalCheckDefinitions|required context/);
         badPolicy.requiredExternalCheckDefinitions[0].requiredContext = 'check-shared-snippets';
@@ -354,14 +406,16 @@ test('trust-gate：prepare-root 精确绑定 staged tree + parent，提交后才
 
         fs.writeFileSync(path.join(root, 'unrelated.txt'), 'not part of the root transition\n', 'utf8');
         git(['add', 'unrelated.txt'], root);
-        const expanded = runRepoCli(root, ['--prepare-root', '--epoch', '3'], { clearCI: true });
+        const expanded = runTrustedCli(root, previousRoot,
+            ['--prepare-root', '--epoch', '3'], { clearCI: true });
         assert.notEqual(expanded.status, 0, 'first admission 不得夹带无关改动');
         assert.match(expanded.stdout + expanded.stderr, /out-of-scope or non-mechanical change/);
         git(['rm', '-q', '-f', 'unrelated.txt'], root);
 
-        const prepare = runRepoCli(root, ['--prepare-root', '--epoch', '3'], { clearCI: true });
+        const prepare = runTrustedCli(root, previousRoot,
+            ['--prepare-root', '--epoch', '3'], { clearCI: true });
         assert.equal(prepare.status, 0, prepare.stdout + prepare.stderr);
-        assert.match(prepare.stdout + prepare.stderr, /Gate Epoch 3 root prepared/);
+        assert.match(prepare.stdout + prepare.stderr, /Gate Epoch 3 root tree prepared/);
         const preparedTree = git(['config', '--local', '--get', 'pixiv.i18n.firstAdmissionTree'], root)
             .stdout.trim();
         assert.equal(preparedTree, git(['write-tree'], root).stdout.trim());
@@ -371,6 +425,8 @@ test('trust-gate：prepare-root 精确绑定 staged tree + parent，提交后才
             .stdout.trim(), '3');
         assert.equal(git(['config', '--local', '--get', 'pixiv.i18n.firstAdmissionTrustedSource'], root)
             .stdout.trim(), previousRoot);
+        assert.notEqual(git(['config', '--local', '--get', 'pixiv.i18n.firstAdmissionCandidate'], root,
+            { allowFailure: true }).status, 0, 'prepare 阶段不得猜测最终 candidate SHA');
 
         git(['config', '--local', 'pixiv.i18n.firstAdmissionTrustedSource', '0'.repeat(40)], root);
         const refusedCommit = git(['commit', '-q', '-m', 'mismatched epoch 3 root'], root,
@@ -379,6 +435,42 @@ test('trust-gate：prepare-root 精确绑定 staged tree + parent，提交后才
         git(['config', '--local', 'pixiv.i18n.firstAdmissionTrustedSource', previousRoot], root);
         const commit = git(['commit', '-q', '-m', 'epoch 3 root'], root);
         assert.equal(commit.status, 0, commit.stdout + commit.stderr);
+
+        const unsealedAdopt = runRepoCli(root,
+            ['--adopt-root', '--ref', 'HEAD', '--epoch', '3'], { clearCI: true });
+        assert.notEqual(unsealedAdopt.status, 0, '未由 trusted bridge seal 的 commit 不得 adoption');
+        assert.match(unsealedAdopt.stdout + unsealedAdopt.stderr, /sealed candidate SHA/);
+
+        const candidateSeal = runRepoCli(root,
+            ['--seal-root', '--ref', 'HEAD', '--trusted-source', previousRoot], { clearCI: true });
+        assert.notEqual(candidateSeal.status, 0, 'candidate CLI 不得自行 seal candidate SHA');
+        assert.match(candidateSeal.stdout + candidateSeal.stderr,
+            /external materialized trusted bundle/);
+
+        const seal = runTrustedCli(root, previousRoot,
+            ['--seal-root', '--ref', 'HEAD'], { clearCI: true });
+        assert.equal(seal.status, 0, seal.stdout + seal.stderr);
+        const candidateSha = git(['rev-parse', 'HEAD'], root).stdout.trim();
+        assert.equal(git(['config', '--local', '--get', 'pixiv.i18n.firstAdmissionCandidate'], root)
+            .stdout.trim(), candidateSha, 'trusted bridge 必须封存唯一 candidate SHA');
+        const reseal = runTrustedCli(root, previousRoot,
+            ['--seal-root', '--ref', 'HEAD'], { clearCI: true });
+        assert.notEqual(reseal.status, 0, '同一 ticket 不得再次 seal');
+
+        setLiveMaster(root, staleMaster);
+        const movedMasterAdopt = runRepoCli(root,
+            ['--adopt-root', '--ref', 'HEAD', '--epoch', '3'], { clearCI: true });
+        assert.notEqual(movedMasterAdopt.status, 0, 'adopt 时必须再次确认实时 protected master tip');
+        assert.match(movedMasterAdopt.stdout + movedMasterAdopt.stderr, /live protected master tip/);
+        assert.equal(git(['config', '--local', '--get', 'pixiv.i18n.trustedGateRef'], root)
+            .stdout.trim(), previousRoot, '实时 tip 校验失败不得推进 anchor');
+        setLiveMaster(root, previousRoot);
+
+        git(['config', '--local', 'pixiv.i18n.firstAdmissionCandidate', '0'.repeat(40)], root);
+        const refusedCandidate = runRepoCli(root,
+            ['--adopt-root', '--ref', 'HEAD', '--epoch', '3'], { clearCI: true });
+        assert.notEqual(refusedCandidate.status, 0, 'sealed candidate SHA 不匹配时 adoption 必须拒绝');
+        git(['config', '--local', 'pixiv.i18n.firstAdmissionCandidate', candidateSha], root);
 
         git(['config', '--local', 'pixiv.i18n.firstAdmissionParent', '0'.repeat(40)], root);
         const refusedAdopt = runRepoCli(root,
@@ -398,6 +490,8 @@ test('trust-gate：prepare-root 精确绑定 staged tree + parent，提交后才
             .stdout.trim(), git(['rev-parse', 'HEAD'], root).stdout.trim());
         assert.notEqual(git(['config', '--local', '--get', 'pixiv.i18n.firstAdmissionTree'], root,
             { allowFailure: true }).status, 0, 'adopt-root 成功后必须清除 preparation ticket');
+        assert.notEqual(git(['config', '--local', '--get', 'pixiv.i18n.firstAdmissionCandidate'], root,
+            { allowFailure: true }).status, 0, 'adopt-root 成功后必须清除 candidate seal');
     } finally {
         cleanRepo(root);
     }

--- a/scripts/i18n/test/verifier-rollback.test.mjs
+++ b/scripts/i18n/test/verifier-rollback.test.mjs
@@ -21,6 +21,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import trustedGate from '../lib/trusted-gate.mjs';
+
 const SCRIPTS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const REPO_ROOT = path.resolve(SCRIPTS_DIR, '..', '..');
 const RESOLVER = path.join(REPO_ROOT, 'scripts', 'ci', 'resolve-trusted-base.mjs');
@@ -32,6 +34,14 @@ const VERIFIER_FILES = [
     'scripts/ci/resolve-trusted-base.mjs',
     'scripts/ci/materialize-trusted-gate.sh',
     'scripts/ci/doctor-github-ruleset.mjs',
+    'scripts/i18n/trust-gate.mjs',
+];
+const VERIFIER_CORE_FILES = [
+    'scripts/i18n/check.mjs',
+    'scripts/i18n/gate-contract.mjs',
+    'scripts/i18n/lib/trusted-gate.mjs',
+    'scripts/i18n/lib/repository-snapshot.mjs',
+    'scripts/hooks/pre-push-guard.sh',
 ];
 
 function git(args, cwd, opts = {}) {
@@ -85,7 +95,7 @@ function makeDagRepo({ v4Contract = 4, withSurface = true } = {}) {
     };
     fs.writeFileSync(path.join(dir, 'scripts', 'i18n', 'gate-policy.json'),
         JSON.stringify(policy, null, 2) + '\n', 'utf8');
-    for (const rel of VERIFIER_FILES) {
+    for (const rel of [...VERIFIER_CORE_FILES, ...VERIFIER_FILES]) {
         if (!withSurface && rel === 'scripts/ci/gate-surface.json') {
             continue;
         }
@@ -96,7 +106,20 @@ function makeDagRepo({ v4Contract = 4, withSurface = true } = {}) {
     git(['commit', '-q', '-m', 'V4 verifier'], dir);
     const v4 = git(['rev-parse', 'HEAD'], dir).stdout.trim();
 
-    // C：candidate
+    // origin/master 模拟受保护默认分支：只有已经进入该历史的 verifier 才能审核 candidate。
+    const remote = path.join(dir, '.git', 'test-origin.git');
+    git(['init', '-q', '--bare', remote], dir);
+    git(['remote', 'add', 'origin', remote], dir);
+    git(['push', '-q', '-u', 'origin', 'master'], dir);
+
+    // C：candidate 首次声明单调 baseline；V4 只需满足其实际 capability，不要求预知新字段。
+    policy.minimumTrustedVerifier = {
+        contractVersion: 4,
+        schemaVersion: 3,
+        requiredFiles: VERIFIER_FILES,
+    };
+    fs.writeFileSync(path.join(dir, 'scripts', 'i18n', 'gate-policy.json'),
+        JSON.stringify(policy, null, 2) + '\n', 'utf8');
     fs.writeFileSync(path.join(dir, 'feature.txt'), 'feature\n', 'utf8');
     git(['add', '-A'], dir);
     git(['commit', '-q', '-m', 'C candidate'], dir);
@@ -106,7 +129,8 @@ function makeDagRepo({ v4Contract = 4, withSurface = true } = {}) {
 }
 
 function runResolver(root, args) {
-    return spawnSync('node', [RESOLVER, '--repo-root', root, ...args],
+    const resolvedArgs = args.includes('--default-branch') ? args : [...args, '--default-branch', 'master'];
+    return spawnSync('node', [RESOLVER, '--repo-root', root, ...resolvedArgs],
         { cwd: root, encoding: 'utf8' });
 }
 
@@ -154,7 +178,8 @@ test('verifier rollback Case B：旧 verifier 是祖先（base = R(v3)，root <=
         const viaInput = runResolver(dir, ['--event-name', 'workflow_dispatch', '--candidate', c,
             '--input-base', r0, '--default-branch', 'master', '--mode']);
         assert.notEqual(viaInput.status, 0, '显式 trusted_base_sha = 旧 verifier 必须 FAIL');
-        assert.match(viaInput.stderr, /contractVersion 3 < current minimum 4|verifier rollback is refused/);
+        assert.match(viaInput.stderr,
+            /contractVersion 3 < current minimum 4|verifier rollback is refused|protected predecessor/);
     } finally {
         cleanRepo(dir);
     }
@@ -213,6 +238,23 @@ test('verifier rollback Case F：contractVersion 降到 3 → FAIL（capability�
             '--pr-base', v4, '--mode']);
         assert.notEqual(run.status, 0, 'contractVersion 3 的 verifier 必须 FAIL');
         assert.match(run.stderr, /contractVersion 3 < current minimum 4|verifier rollback is refused/);
+    } finally {
+        cleanRepo(dir);
+    }
+});
+
+test('verifier baseline 首次声明：执行中 policy 审核 V4 实际能力，不要求 predecessor 预知新字段', () => {
+    const { dir, v4 } = makeDagRepo();
+    const output = path.join(dir, 'build', 'materialized-verifier');
+    try {
+        assert.doesNotThrow(() => trustedGate.assertSupportedTrustedVerifierAt(dir, v4));
+        const run = spawnSync('bash', ['scripts/ci/materialize-trusted-gate.sh',
+            '--repo-root', '.', '--base', v4, '--output', 'build/materialized-verifier',
+            '--index', 'build/materialize-index', '--paths-file', 'build/materialize-paths',
+            '--paths', 'scripts/i18n scripts/hooks scripts/ci'],
+        { cwd: dir, encoding: 'utf8' });
+        assert.equal(run.status, 0, run.stdout + run.stderr);
+        assert.ok(fs.existsSync(path.join(output, 'scripts', 'ci', 'gate-parity.mjs')));
     } finally {
         cleanRepo(dir);
     }

--- a/scripts/i18n/test/verifier-rollback.test.mjs
+++ b/scripts/i18n/test/verifier-rollback.test.mjs
@@ -1,0 +1,219 @@
+'use strict';
+/**
+ * Verifier rollback 禁止测试（Gate Epoch 2 新标准）：
+ * trusted base 必须同时满足 ancestry（root <= base < candidate）与当前 verifier capability
+ * （contractVersion >= 4 / schemaVersion >= 3 / verifier 本体文件齐全）。
+ * 旧 verifier（contract v3 root 等）即使满足 root <= base < candidate 也必须 FAIL CLOSED。
+ *
+ * DAG 矩阵：
+ * - Case A：R(v3) ─ V4 ─ C，base = V4            → PASS（当前标准 predecessor 正常链）
+ * - Case B：R(v3) ─ V4 ─ C，base = R（显式 input）→ FAIL（contractVersion 3 < 4）
+ * - Case C：R ─ V4 ─ B / ─ C（sibling）base = B   → FAIL（ancestry）
+ * - Case D：R ─ V4 ─ C ─ B，base = B              → FAIL（base 是 candidate 后代）
+ * - Case E：复制合法 V4 再删除 gate-surface.json   → FAIL（verifier 本体缺文件）
+ * - Case F：contractVersion 降到 3                → FAIL（capability）
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPTS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const REPO_ROOT = path.resolve(SCRIPTS_DIR, '..', '..');
+const RESOLVER = path.join(REPO_ROOT, 'scripts', 'ci', 'resolve-trusted-base.mjs');
+
+const VERIFIER_FILES = [
+    'scripts/ci/gate-surface.json',
+    'scripts/ci/gate-invariants.json',
+    'scripts/ci/gate-parity.mjs',
+    'scripts/ci/resolve-trusted-base.mjs',
+    'scripts/ci/materialize-trusted-gate.sh',
+    'scripts/ci/doctor-github-ruleset.mjs',
+];
+
+function git(args, cwd, opts = {}) {
+    const result = spawnSync('git', args, { cwd, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, ...opts });
+    if (result.status !== 0 && !opts.allowFailure) {
+        throw new Error('git ' + args.join(' ') + ' failed: ' + (result.stderr || result.stdout));
+    }
+    return result;
+}
+
+/**
+ * 构造 DAG 夹具：
+ * - R0：Epoch 2 历史 root（v3 时代：contractVersion 3 / schemaVersion 2，无 gate-surface.json，
+ *   与真实 cb587e01 同构）——root tag 指向它（root 只是历史信任纪元起点，不要求当前能力）；
+ * - V4：当前标准 verifier（contract 4 / schema 3 / 全部 verifier 本体文件）；
+ * - C：candidate（V4 后代）。
+ * @param {Object} opts { v4Contract, withSurface } 控制 V4 的 capability 变异
+ */
+function makeDagRepo({ v4Contract = 4, withSurface = true } = {}) {
+    const dir = path.join(os.tmpdir(), 'pixiv rollback repo ' + Date.now() + '-' + Math.random().toString(36).slice(2));
+    fs.mkdirSync(dir, { recursive: true });
+    git(['init', '-q'], dir);
+    git(['config', 'user.email', 't@example.com'], dir);
+    git(['config', 'user.name', 'test'], dir);
+    git(['config', 'core.autocrlf', 'false'], dir);
+    fs.writeFileSync(path.join(dir, '.gitignore'), 'build/\n', 'utf8');
+
+    // R0：v3 时代 root（contract 3 / schema 2，无 gate-surface.json，与 cb587e01 同构）
+    fs.mkdirSync(path.join(dir, 'scripts', 'i18n'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'scripts', 'ci'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'scripts', 'i18n', 'gate-policy.json'),
+        JSON.stringify({
+            schemaVersion: 2, gateEpoch: 2, contractVersion: 3,
+            i18nEnforcementStartCommit: '05f4ebed7ce00f0b923fe48ec2e0971610511547',
+            requiredPaths: [], protectedBranches: ['refs/heads/master'],
+            requiredWorkflowJobs: ['java-tests'], requiredWorkflowFiles: [],
+            requiredPackageScripts: [], requiredExternalChecks: [],
+        }, null, 2) + '\n', 'utf8');
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'R0 (epoch 2 historical root, contract v3)'], dir);
+    const r0 = git(['rev-parse', 'HEAD'], dir).stdout.trim();
+    git(['tag', 'i18n-gate-epoch-2-root', r0], dir);
+
+    // V4（或变异）：当前标准 verifier
+    const policy = {
+        schemaVersion: 3, gateEpoch: 2, contractVersion: v4Contract,
+        i18nEnforcementStartCommit: r0,
+        requiredPaths: [], protectedBranches: ['refs/heads/master'],
+        requiredWorkflowJobs: ['java-tests'], requiredWorkflowFiles: [],
+        requiredPackageScripts: [], requiredExternalChecks: [],
+    };
+    fs.writeFileSync(path.join(dir, 'scripts', 'i18n', 'gate-policy.json'),
+        JSON.stringify(policy, null, 2) + '\n', 'utf8');
+    for (const rel of VERIFIER_FILES) {
+        if (!withSurface && rel === 'scripts/ci/gate-surface.json') {
+            continue;
+        }
+        fs.mkdirSync(path.dirname(path.join(dir, ...rel.split('/'))), { recursive: true });
+        fs.copyFileSync(path.join(REPO_ROOT, ...rel.split('/')), path.join(dir, ...rel.split('/')));
+    }
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'V4 verifier'], dir);
+    const v4 = git(['rev-parse', 'HEAD'], dir).stdout.trim();
+
+    // C：candidate
+    fs.writeFileSync(path.join(dir, 'feature.txt'), 'feature\n', 'utf8');
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'C candidate'], dir);
+    const c = git(['rev-parse', 'HEAD'], dir).stdout.trim();
+
+    return { dir, r0, v4, c };
+}
+
+function runResolver(root, args) {
+    return spawnSync('node', [RESOLVER, '--repo-root', root, ...args],
+        { cwd: root, encoding: 'utf8' });
+}
+
+function cleanRepo(root) {
+    if (!root) {
+        return;
+    }
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+        try {
+            fs.rmSync(root, { recursive: true, force: true });
+            return;
+        } catch (e) {
+            if (attempt === 5) {
+                throw e;
+            }
+            execFileSync('bash', ['-c', 'sleep 0.5'], { stdio: 'ignore' });
+        }
+    }
+}
+
+test('verifier rollback Case A：合法 current verifier（R ─ V4 ─ C，base = V4）→ PASS', () => {
+    const { dir, v4, c } = makeDagRepo();
+    try {
+        const run = runResolver(dir, ['--event-name', 'pull_request', '--candidate', c,
+            '--pr-base', v4, '--mode']);
+        assert.equal(run.status, 0, run.stdout + run.stderr);
+        const j = JSON.parse(run.stdout);
+        assert.equal(j.mode, 'NORMAL');
+        assert.equal(j.base, v4, '当前标准 predecessor 正常链必须可用');
+    } finally {
+        cleanRepo(dir);
+    }
+});
+
+test('verifier rollback Case B：旧 verifier 是祖先（base = R(v3)，root <= base < candidate 成立）→ FAIL', () => {
+    const { dir, r0, c } = makeDagRepo();
+    try {
+        // 显式 trusted_base_sha = R0：即使 root <= R0 < C 成立，capability 太旧也必须 FAIL
+        const run = runResolver(dir, ['--event-name', 'pull_request', '--candidate', c,
+            '--pr-base', r0, '--mode']);
+        assert.notEqual(run.status, 0, '旧 verifier 作为 trusted base 必须 FAIL CLOSED');
+        assert.match(run.stderr, /contractVersion 3 < current minimum 4|verifier rollback is refused/,
+            '必须显式回归：ancestry 成立但 verifier capability 太旧 → FAIL');
+        // input 显式传入同一旧 base 也必须 FAIL
+        const viaInput = runResolver(dir, ['--event-name', 'workflow_dispatch', '--candidate', c,
+            '--input-base', r0, '--default-branch', 'master', '--mode']);
+        assert.notEqual(viaInput.status, 0, '显式 trusted_base_sha = 旧 verifier 必须 FAIL');
+        assert.match(viaInput.stderr, /contractVersion 3 < current minimum 4|verifier rollback is refused/);
+    } finally {
+        cleanRepo(dir);
+    }
+});
+
+test('verifier rollback Case C：sibling base（R ─ V4 ─ B / ─ C）→ FAIL（ancestry）', () => {
+    const { dir, v4, c } = makeDagRepo();
+    try {
+        git(['checkout', '-q', '-b', 'sibling-b', v4], dir);
+        fs.writeFileSync(path.join(dir, 'b.txt'), 'b\n', 'utf8');
+        git(['add', '-A'], dir);
+        git(['commit', '-q', '-m', 'B sibling'], dir);
+        const b = git(['rev-parse', 'HEAD'], dir).stdout.trim();
+        git(['checkout', '-q', 'master'], dir);
+        const run = runResolver(dir, ['--event-name', 'pull_request', '--candidate', c,
+            '--pr-base', b, '--mode']);
+        assert.notEqual(run.status, 0, 'sibling base 必须 FAIL');
+        assert.match(run.stderr, /not an ancestor of the candidate/);
+    } finally {
+        cleanRepo(dir);
+    }
+});
+
+test('verifier rollback Case D：base 是 candidate 后代（R ─ V4 ─ C ─ B）→ FAIL（ancestry）', () => {
+    const { dir, c } = makeDagRepo();
+    try {
+        fs.writeFileSync(path.join(dir, 'b.txt'), 'b\n', 'utf8');
+        git(['add', '-A'], dir);
+        git(['commit', '-q', '-m', 'B descendant of candidate'], dir);
+        const b = git(['rev-parse', 'HEAD'], dir).stdout.trim();
+        const run = runResolver(dir, ['--event-name', 'pull_request', '--candidate', c,
+            '--pr-base', b, '--mode']);
+        assert.notEqual(run.status, 0, 'base 是 candidate 后代必须 FAIL');
+        assert.match(run.stderr, /not an ancestor of the candidate/);
+    } finally {
+        cleanRepo(dir);
+    }
+});
+
+test('verifier rollback Case E：无 gate-surface.json 的 verifier → FAIL（verifier 本体缺文件）', () => {
+    const { dir, v4, c } = makeDagRepo({ withSurface: false });
+    try {
+        const run = runResolver(dir, ['--event-name', 'pull_request', '--candidate', c,
+            '--pr-base', v4, '--mode']);
+        assert.notEqual(run.status, 0, '缺 gate-surface.json 的 verifier 必须 FAIL');
+        assert.match(run.stderr, /missing scripts\/ci\/gate-surface.json|verifier baseline/);
+    } finally {
+        cleanRepo(dir);
+    }
+});
+
+test('verifier rollback Case F：contractVersion 降到 3 → FAIL（capability）', () => {
+    const { dir, v4, c } = makeDagRepo({ v4Contract: 3 });
+    try {
+        const run = runResolver(dir, ['--event-name', 'pull_request', '--candidate', c,
+            '--pr-base', v4, '--mode']);
+        assert.notEqual(run.status, 0, 'contractVersion 3 的 verifier 必须 FAIL');
+        assert.match(run.stderr, /contractVersion 3 < current minimum 4|verifier rollback is refused/);
+    } finally {
+        cleanRepo(dir);
+    }
+});

--- a/scripts/i18n/trust-gate.mjs
+++ b/scripts/i18n/trust-gate.mjs
@@ -5,20 +5,24 @@
  *
  * 用法：
  *   npm run i18n:trust-gate -- --show
- *   npm run i18n:trust-gate -- --prepare-root --epoch 3
+ *   node <Epoch-2-trusted-bundle>/scripts/i18n/trust-gate.mjs --prepare-root --epoch 3
+ *     --trusted-source <exact-sha>
+ *   node <Epoch-2-trusted-bundle>/scripts/i18n/trust-gate.mjs --seal-root --ref HEAD
+ *     --trusted-source <exact-sha>
  *   npm run i18n:trust-gate -- --adopt-root --ref HEAD --epoch 2
  *   npm run i18n:trust-gate -- --advance --ref HEAD
  *   npm run i18n:trust-gate -- --version
  *
  * prepare-root（Epoch 2 → 3 一次性 first admission）：
- * - 当前工作树脚本只负责从 pixiv.i18n.trustedGateRef 物化并启动 bridge；实际批准代码、
- *   library 与 bridge spec 必须逐字来自该 trusted bundle；
- * - trusted source 必须属于受保护 origin/master 历史、包含 Epoch 2 root，且必须精确等于
+ * - 第一条 first-admission 执行代码必须直接来自已物化的 Epoch 2 trusted bundle；当前工作树
+ *   candidate CLI 不代理、不启动 bridge；
+ * - trusted source 必须精确等于实时 origin/master tip、包含 Epoch 2 root，且必须精确等于
  *   staged Epoch 3 root 的单一 parent；candidate 只作为被审核对象；
  * - bridge 只归一化 sourceEpoch=2 → targetEpoch=3、root 身份与已知 GATE-03 context 身份纠正，
  *   其它内容仍由 Epoch 2 trusted contract/parity 审核；
- * - 成功后只写仓库外的一次性 ticket，绑定双 epoch、trusted source、parent 与 tree；
- *   失败不推进 anchor，也不写部分 ticket。
+ * - prepare 成功后只写仓库外的一次性 ticket，绑定双 epoch、trusted source、parent 与 tree；
+ *   commit 后由同一 trusted bridge 的 seal-root 唯一绑定 candidate SHA；失败不推进 anchor，
+ *   也不写部分 ticket。
  *
  * adopt-root（人工 root adoption / TOFU；Epoch 2 root 的唯一建立方式）：
  * - 新的 root 不可能由自己自动证明自己可信：root 由人工 code review + 完整自动测试 +
@@ -173,6 +177,7 @@ const FIRST_ADMISSION_KEYS = [
     trustedGate.FIRST_ADMISSION_TRUSTED_SOURCE_KEY,
     trustedGate.FIRST_ADMISSION_PARENT_KEY,
     trustedGate.FIRST_ADMISSION_TREE_KEY,
+    trustedGate.FIRST_ADMISSION_CANDIDATE_KEY,
 ];
 
 function getFirstAdmissionTicket(repoRoot) {
@@ -189,6 +194,7 @@ function getFirstAdmissionTicket(repoRoot) {
         trustedSource: get(trustedGate.FIRST_ADMISSION_TRUSTED_SOURCE_KEY),
         parent: get(trustedGate.FIRST_ADMISSION_PARENT_KEY),
         tree: get(trustedGate.FIRST_ADMISSION_TREE_KEY),
+        candidate: get(trustedGate.FIRST_ADMISSION_CANDIDATE_KEY),
     };
 }
 
@@ -212,7 +218,7 @@ function clearFirstAdmissionTicket(repoRoot, strict = false) {
 }
 
 function ticketFieldForKey(key) {
-    const fields = ['sourceEpoch', 'targetEpoch', 'trustedSource', 'parent', 'tree'];
+    const fields = ['sourceEpoch', 'targetEpoch', 'trustedSource', 'parent', 'tree', 'candidate'];
     return fields[FIRST_ADMISSION_KEYS.indexOf(key)];
 }
 
@@ -221,10 +227,12 @@ function setFirstAdmissionTicket(repoRoot, ticket) {
         throw new Error('an unconsumed first-admission ticket already exists');
     }
     const values = [ticket.sourceEpoch, ticket.targetEpoch, ticket.trustedSource,
-        ticket.parent, ticket.tree];
+        ticket.parent, ticket.tree, ticket.candidate];
     try {
         for (let i = 0; i < FIRST_ADMISSION_KEYS.length; i += 1) {
-            git(['config', '--local', FIRST_ADMISSION_KEYS[i], String(values[i])], repoRoot);
+            if (values[i] !== null && values[i] !== undefined) {
+                git(['config', '--local', FIRST_ADMISSION_KEYS[i], String(values[i])], repoRoot);
+            }
         }
         const actual = getFirstAdmissionTicket(repoRoot);
         if (JSON.stringify(actual) !== JSON.stringify({
@@ -233,6 +241,7 @@ function setFirstAdmissionTicket(repoRoot, ticket) {
             trustedSource: ticket.trustedSource,
             parent: ticket.parent,
             tree: ticket.tree,
+            candidate: ticket.candidate || null,
         })) {
             throw new Error('first-admission ticket verification failed');
         }
@@ -241,6 +250,29 @@ function setFirstAdmissionTicket(repoRoot, ticket) {
             clearFirstAdmissionTicket(repoRoot, true);
         } catch (cleanupError) {
             throw new Error(e.message + '; partial ticket cleanup failed: ' + cleanupError.message);
+        }
+        throw e;
+    }
+}
+
+function sealFirstAdmissionCandidate(repoRoot, ticket, candidateSha) {
+    const current = getFirstAdmissionTicket(repoRoot);
+    if (JSON.stringify(current) !== JSON.stringify({ ...ticket, candidate: null })) {
+        throw new Error('first-admission ticket changed before candidate sealing');
+    }
+    try {
+        git(['config', '--local', trustedGate.FIRST_ADMISSION_CANDIDATE_KEY, candidateSha], repoRoot);
+        if (getFirstAdmissionTicket(repoRoot).candidate !== candidateSha) {
+            throw new Error('first-admission candidate SHA verification failed');
+        }
+    } catch (e) {
+        try {
+            git(['config', '--local', '--unset-all', trustedGate.FIRST_ADMISSION_CANDIDATE_KEY], repoRoot);
+        } catch (ignored) {
+            // The key may not have been written. Preserve the prepared ticket either way.
+        }
+        if (getFirstAdmissionTicket(repoRoot).candidate !== null) {
+            throw new Error(e.message + '; partial candidate seal cleanup failed');
         }
         throw e;
     }
@@ -375,13 +407,10 @@ function runGateParity(repoRoot, candidateSha, trustedDir, invariantsOnly) {
     }
 }
 
-function loadFirstAdmissionSpec(bundleRoot) {
-    const file = path.join(bundleRoot, ...FIRST_ADMISSION_SPEC_REL.split('/'));
-    if (!fs.existsSync(file)) {
-        throw new Error('trusted verifier has no Epoch 2 first-admission bridge specification');
-    }
-    const spec = JSON.parse(fs.readFileSync(file, 'utf8'));
+function validateFirstAdmissionSpec(spec) {
     if (spec.schemaVersion !== 1 || spec.sourceEpoch !== 2 || spec.targetEpoch !== 3
+        || spec.protectedRemote !== 'origin'
+        || spec.protectedBranch !== 'refs/heads/master'
         || spec.protectedBranchRef !== 'refs/remotes/origin/master'
         || !spec.requiredContextReplacements
         || Object.keys(spec.requiredContextReplacements).length !== 6
@@ -391,8 +420,23 @@ function loadFirstAdmissionSpec(bundleRoot) {
     return spec;
 }
 
+function loadFirstAdmissionSpec(bundleRoot) {
+    const file = path.join(bundleRoot, ...FIRST_ADMISSION_SPEC_REL.split('/'));
+    if (!fs.existsSync(file)) {
+        throw new Error('trusted verifier has no Epoch 2 first-admission bridge specification');
+    }
+    return validateFirstAdmissionSpec(JSON.parse(fs.readFileSync(file, 'utf8')));
+}
+
+function loadFirstAdmissionSpecAtRef(repoRoot, ref) {
+    return validateFirstAdmissionSpec(loadJsonAtRef(repoRoot, ref, FIRST_ADMISSION_SPEC_REL));
+}
+
 function assertExecutingTrustedBundle(repoRoot, trustedSource) {
     const bundleRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+    if (fs.realpathSync(bundleRoot) === fs.realpathSync(repoRoot)) {
+        throw new Error('first-admission bridge must execute from an external materialized trusted bundle');
+    }
     const trustedPaths = git(['ls-tree', '-r', '--name-only', trustedSource, '--',
         ...trustedGate.GATE_PATHS], repoRoot).split('\n').filter(Boolean);
     for (const rel of trustedPaths) {
@@ -412,24 +456,39 @@ function loadJsonAtRef(repoRoot, ref, rel) {
     return JSON.parse(git(['show', ref + ':' + rel], repoRoot));
 }
 
+function resolveLiveProtectedTip(repoRoot, spec) {
+    const lookup = run(['git', 'ls-remote', '--exit-code', spec.protectedRemote,
+        spec.protectedBranch], {
+        cwd: repoRoot,
+        env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    });
+    const lines = (lookup.stdout || '').trim().split(/\r?\n/).filter(Boolean);
+    if (lookup.status !== 0 || lines.length !== 1) {
+        throw new Error('cannot resolve the live protected master tip from origin');
+    }
+    const fields = lines[0].trim().split(/\s+/);
+    if (fields.length !== 2 || fields[1] !== spec.protectedBranch
+        || !trustedGate.SHA_RE.test(fields[0])) {
+        throw new Error('origin returned an invalid protected master tip');
+    }
+    return fields[0];
+}
+
 function assertProtectedFirstAdmissionSource(repoRoot, trustedSource, spec) {
     const configuredSource = trustedGate.getTrustedRef(repoRoot);
     const configuredEpoch = trustedGate.getTrustedEpoch(repoRoot);
     if (configuredSource !== trustedSource || configuredEpoch !== String(spec.sourceEpoch)) {
         throw new Error('first-admission source must exactly match local trustedGateRef + sourceEpoch');
     }
+    const localProtectedTip = trustedGate.resolveCommit(repoRoot, spec.protectedBranchRef);
+    const liveProtectedTip = resolveLiveProtectedTip(repoRoot, spec);
     if (!trustedGate.resolveCommit(repoRoot, trustedSource)
-        || !trustedGate.resolveCommit(repoRoot, spec.protectedBranchRef)
-        || !trustedGate.isAncestor(repoRoot, trustedSource, spec.protectedBranchRef)) {
-        throw new Error('trusted first-admission source is not in protected origin/master history');
+        || localProtectedTip !== trustedSource || liveProtectedTip !== trustedSource) {
+        throw new Error('trusted first-admission source must equal the local and live protected master tip');
     }
     const previousRoot = trustedGate.resolveRootTag(repoRoot, spec.sourceEpoch);
     if (!previousRoot || !trustedGate.isAncestor(repoRoot, previousRoot, trustedSource)) {
         throw new Error('protected previous-epoch root is missing from the trusted source chain');
-    }
-    const head = trustedGate.resolveCommit(repoRoot, 'HEAD');
-    if (head !== trustedSource) {
-        throw new Error('Epoch 3 root parent must exactly equal the trusted Epoch 2 source');
     }
 }
 
@@ -584,6 +643,9 @@ function runPrepareRootFromTrustedBundle(repoRoot, epochArg, trustedSource) {
             throw new Error('--epoch must be exactly ' + trustedExecution.spec.targetEpoch);
         }
         assertProtectedFirstAdmissionSource(repoRoot, trustedSource, trustedExecution.spec);
+        if (trustedGate.resolveCommit(repoRoot, 'HEAD') !== trustedSource) {
+            throw new Error('Epoch 3 root parent must exactly equal the trusted Epoch 2 source');
+        }
     } catch (e) {
         fail(e.message);
     }
@@ -628,46 +690,70 @@ function runPrepareRootFromTrustedBundle(repoRoot, epochArg, trustedSource) {
             trustedSource,
             parent: candidate.parent,
             tree: candidate.tree,
+            candidate: null,
         });
     } finally {
         rmrfRetry(candidateDir);
         rmrfRetry(trustedDir);
     }
     console.log('trust-gate: Gate Epoch ' + trustedExecution.spec.targetEpoch
-        + ' root prepared for one exact commit by trusted source ' + trustedSource + ': parent '
-        + candidate.parent + ', tree ' + candidate.tree);
+        + ' root tree prepared by trusted source ' + trustedSource + ': parent '
+        + candidate.parent + ', tree ' + candidate.tree
+        + '. Commit it once, then run the trusted bridge with --seal-root --ref HEAD.');
 }
 
 function runPrepareRoot(repoRoot, epochArg, trustedSourceArg) {
+    if (!trustedSourceArg) {
+        fail('prepare-root must execute directly from a materialized Epoch 2 trusted bundle'
+            + ' with --trusted-source <exact-sha>; candidate launchers are forbidden');
+    }
+    runPrepareRootFromTrustedBundle(repoRoot, epochArg, trustedSourceArg);
+}
+
+function runSealRoot(repoRoot, refArg, trustedSource) {
     if (trustedGate.isCI()) {
-        fail('root preparation is forbidden in CI (CI=true); it is an explicit local trust decision');
+        fail('root sealing is forbidden in CI (CI=true); it is an explicit local trust decision');
     }
-    if (trustedSourceArg) {
-        runPrepareRootFromTrustedBundle(repoRoot, epochArg, trustedSourceArg);
-        return;
+    if (!trustedSource) {
+        fail('seal-root must execute directly from a materialized Epoch 2 trusted bundle'
+            + ' with --trusted-source <exact-sha>; candidate launchers are forbidden');
     }
-    const current = trustedGate.getTrustedRef(repoRoot);
-    if (!current || !trustedGate.resolveCommit(repoRoot, current)) {
-        fail('root preparation requires a resolvable local trustedGateRef');
-    }
-    const gateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv-first-admission-source-'));
+    let trustedExecution;
     try {
-        trustedGate.materializeTrustedGate(repoRoot, current, gateDir);
-        const bridgeSpec = path.join(gateDir, ...FIRST_ADMISSION_SPEC_REL.split('/'));
-        if (!fs.existsSync(bridgeSpec)) {
-            fail('trusted verifier has no one-time Epoch 2 first-admission bridge');
-        }
-        const cli = path.join(gateDir, 'scripts', 'i18n', 'trust-gate.mjs');
-        const result = run(['node', cli, '--prepare-root', '--epoch', String(epochArg),
-            '--trusted-source', current], { cwd: repoRoot });
-        process.stdout.write(result.stdout || '');
-        process.stderr.write(result.stderr || '');
-        if (result.status !== 0) {
-            fail('trusted first-admission bridge rejected the staged root candidate');
-        }
-    } finally {
-        rmrfRetry(gateDir);
+        trustedExecution = assertExecutingTrustedBundle(repoRoot, trustedSource);
+        assertProtectedFirstAdmissionSource(repoRoot, trustedSource, trustedExecution.spec);
+    } catch (e) {
+        fail(e.message);
     }
+    assertCleanState(repoRoot);
+    const candidateSha = trustedGate.resolveCommit(repoRoot, refArg);
+    if (!candidateSha || candidateSha !== trustedGate.resolveCommit(repoRoot, 'HEAD')) {
+        fail('seal-root requires --ref to resolve to the current HEAD commit');
+    }
+    const ticket = getFirstAdmissionTicket(repoRoot);
+    const expected = {
+        sourceEpoch: String(trustedExecution.spec.sourceEpoch),
+        targetEpoch: String(trustedExecution.spec.targetEpoch),
+        trustedSource,
+        parent: trustedSource,
+        tree: git(['rev-parse', candidateSha + '^{tree}'], repoRoot),
+        candidate: null,
+    };
+    if (JSON.stringify(ticket) !== JSON.stringify(expected)) {
+        fail('seal-root requires the exact unconsumed prepared ticket and candidate tree');
+    }
+    const parents = git(['rev-list', '--parents', '-n', '1', candidateSha], repoRoot).split(/\s+/);
+    if (parents.length !== 2 || parents[1] !== trustedSource) {
+        fail('sealed Epoch 3 root candidate must have the exact trusted source as its single parent');
+    }
+    try {
+        assertExactContextCorrection(repoRoot, candidateSha, trustedSource, trustedExecution.spec);
+        sealFirstAdmissionCandidate(repoRoot, ticket, candidateSha);
+    } catch (e) {
+        fail(e.message);
+    }
+    console.log('trust-gate: trusted first-admission bridge sealed the unique Epoch '
+        + trustedExecution.spec.targetEpoch + ' root candidate ' + candidateSha);
 }
 
 function setAnchorAndConsumeFirstAdmission(repoRoot, sha, epoch, previousRef, previousEpoch, ticket) {
@@ -716,6 +802,13 @@ function runAdoptRoot(repoRoot, refArg, epochArg) {
             fail('a local trust anchor already exists at ' + current
                 + '; use --advance within the current epoch');
         }
+        let sourceSpec;
+        try {
+            sourceSpec = loadFirstAdmissionSpecAtRef(repoRoot, current);
+            assertProtectedFirstAdmissionSource(repoRoot, current, sourceSpec);
+        } catch (e) {
+            fail('first-admission adoption source check failed: ' + e.message);
+        }
         const prepared = getFirstAdmissionTicket(repoRoot);
         const parents = git(['rev-list', '--parents', '-n', '1', sha], repoRoot).split(/\s+/);
         const tree = git(['rev-parse', sha + '^{tree}'], repoRoot);
@@ -723,11 +816,12 @@ function runAdoptRoot(repoRoot, refArg, epochArg) {
             || prepared.sourceEpoch !== String(previousEpoch)
             || prepared.targetEpoch !== String(trustedGate.CURRENT_GATE_EPOCH)
             || prepared.trustedSource !== current
+            || prepared.candidate !== sha
             || parents.length !== 2 || prepared.parent !== parents[1]
             || prepared.parent !== current || prepared.tree !== tree
             || !trustedGate.isAncestor(repoRoot, current, 'refs/remotes/origin/master')) {
             fail('existing-anchor root adoption requires an unconsumed trusted first-admission ticket'
-                + ' with the exact source epoch, target epoch, trusted source, parent and tree');
+                + ' with the exact source epoch, target epoch, trusted source, parent, tree and sealed candidate SHA');
         }
         const previousRoot = trustedGate.resolveRootTag(repoRoot, previousEpoch);
         if (!previousRoot || !trustedGate.isAncestor(repoRoot, previousRoot, current)) {
@@ -921,7 +1015,8 @@ function parseArgs(argv) {
     const args = { command: null, ref: null, epoch: null, trustedSource: null, version: false };
     for (let i = 0; i < argv.length; i += 1) {
         const arg = argv[i];
-        if (arg === '--prepare-root' || arg === '--adopt-root' || arg === '--advance' || arg === '--show') {
+        if (arg === '--prepare-root' || arg === '--seal-root' || arg === '--adopt-root'
+            || arg === '--advance' || arg === '--show') {
             args.command = arg.slice(2);
         } else if (arg === '--ref') {
             args.ref = argv[++i];
@@ -949,6 +1044,9 @@ function parseArgs(argv) {
     if (args.command === 'prepare-root' && !args.epoch) {
         throw new Error('--epoch <next-epoch> is required for prepare-root');
     }
+    if (args.command === 'seal-root' && !args.ref) {
+        throw new Error('--ref <commit> is required for seal-root');
+    }
     if (args.command === 'advance') {
         if (!args.ref) {
             throw new Error('--ref <commit> is required for advance');
@@ -956,6 +1054,7 @@ function parseArgs(argv) {
     }
     if (!args.command) {
         throw new Error('usage: trust-gate.mjs --show | --prepare-root --epoch <next> |'
+            + ' --seal-root --ref HEAD |'
             + ' --adopt-root --ref HEAD --epoch <current> | --advance --ref HEAD');
     }
     return args;
@@ -983,6 +1082,10 @@ function main() {
     }
     if (args.command === 'prepare-root') {
         runPrepareRoot(repoRoot, args.epoch, args.trustedSource);
+        return;
+    }
+    if (args.command === 'seal-root') {
+        runSealRoot(repoRoot, args.ref, args.trustedSource);
         return;
     }
     if (args.command === 'adopt-root') {

--- a/scripts/i18n/trust-gate.mjs
+++ b/scripts/i18n/trust-gate.mjs
@@ -51,7 +51,8 @@ import trustedGate from './lib/trusted-gate.mjs';
 import snapshot from './lib/repository-snapshot.mjs';
 
 const TRUST_CLI_VERSION = '2';
-const MIN_ROOT_CONTRACT_VERSION = 3;
+// 当前新标准 verifier 最低能力由 lib/trusted-gate.mjs 的 CURRENT_MIN_* + REQUIRED_VERIFIER_FILES 定义；
+// adopt-root / advance 前必须断言候选与 trusted anchor 满足该 baseline（低于 → OUTDATED GATE VERIFIER）。
 
 function fail(message) {
     console.error('trust-gate ERROR: ' + message);
@@ -273,9 +274,12 @@ function runAdoptRoot(repoRoot, refArg, epochArg) {
         console.log('trust-gate: ROOT ADMISSION — ' + sha
             + ' is the Gate Epoch 2 root candidate; running the full root admission suite...');
         const policy = materializeAndLoadPolicy(repoRoot, sha, gateDir);
-        if (policy.contractVersion < MIN_ROOT_CONTRACT_VERSION) {
-            fail('root admission requires contractVersion >= ' + MIN_ROOT_CONTRACT_VERSION
-                + ' (got ' + policy.contractVersion + '); fail closed');
+        // 新标准 root admission 也必须满足当前 verifier baseline（旧 v3 root 候选不再有资格；
+        // 旧提交按旧标准存在，新标准只接受具备当前能力的 verifier）
+        try {
+            trustedGate.assertSupportedTrustedVerifierDir(gateDir);
+        } catch (e) {
+            fail('OUTDATED GATE VERIFIER: ' + e.message);
         }
         const required = policy.requiredPaths;
         const missing = required.filter((p) => !fs.existsSync(path.join(gateDir, ...p.split('/'))));
@@ -355,6 +359,12 @@ function runAdvance(repoRoot, refArg) {
     try {
         // 1. 从当前 trusted ref 物化 Epoch 2 contract + policy
         trustedGate.materializeTrustedGate(repoRoot, current, trustedDir);
+        // 1.5 当前 trusted verifier 必须满足当前 verifier baseline（能力只增不减，不兼容旧 verifier）
+        try {
+            trustedGate.assertSupportedTrustedVerifierDir(trustedDir);
+        } catch (e) {
+            fail('OUTDATED GATE VERIFIER: ' + e.message);
+        }
 
         // 2. trusted contract 验证 candidate ref（policy / required files / checker / hooks / 自保护）
         console.log('trust-gate: running the trusted gate contract against ' + sha + '...');
@@ -392,6 +402,7 @@ function runShow(repoRoot) {
         return;
     }
     let contractVersion = 'n/a';
+    let baseline = 'n/a';
     const gateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv-trust-show-'));
     try {
         try {
@@ -399,6 +410,12 @@ function runShow(repoRoot) {
             const policy = trustedGate.loadPolicyFromDir(gateDir);
             if (policy) {
                 contractVersion = String(policy.contractVersion);
+            }
+            try {
+                trustedGate.assertSupportedTrustedVerifierDir(gateDir);
+                baseline = 'OK';
+            } catch (e) {
+                baseline = 'BELOW CURRENT VERIFIER BASELINE (OUTDATED GATE VERIFIER)';
             }
         } catch (e) {
             // anchor 无法物化时只提示
@@ -409,6 +426,7 @@ function runShow(repoRoot) {
     console.log('trustedGateEpoch: ' + epoch);
     console.log('trustedGateRef: ' + current);
     console.log('contractVersion: ' + contractVersion);
+    console.log('verifierBaseline: ' + baseline);
     console.log('gateEpochRootTag: ' + (root || 'refs/tags/i18n-gate-epoch-2-root <missing (install after admission)>'));
 }
 

--- a/scripts/i18n/trust-gate.mjs
+++ b/scripts/i18n/trust-gate.mjs
@@ -5,6 +5,7 @@
  *
  * 用法：
  *   npm run i18n:trust-gate -- --show
+ *   npm run i18n:trust-gate -- --prepare-root --epoch 3
  *   npm run i18n:trust-gate -- --adopt-root --ref HEAD --epoch 2
  *   npm run i18n:trust-gate -- --advance --ref HEAD
  *   npm run i18n:trust-gate -- --version
@@ -50,9 +51,9 @@ import { fileURLToPath } from 'url';
 import trustedGate from './lib/trusted-gate.mjs';
 import snapshot from './lib/repository-snapshot.mjs';
 
-const TRUST_CLI_VERSION = '2';
-// 当前新标准 verifier 最低能力由 lib/trusted-gate.mjs 的 CURRENT_MIN_* + REQUIRED_VERIFIER_FILES 定义；
-// adopt-root / advance 前必须断言候选与 trusted anchor 满足该 baseline（低于 → OUTDATED GATE VERIFIER）。
+const TRUST_CLI_VERSION = '3';
+// verifier 最低能力由 trusted gate-policy.json 的 minimumTrustedVerifier 定义；NORMAL contract
+// 保证该声明只能单调增强，adopt-root / advance 前均按声明 fail closed。
 
 function fail(message) {
     console.error('trust-gate ERROR: ' + message);
@@ -131,6 +132,69 @@ function assertCleanState(repoRoot) {
     }
 }
 
+/** Root preparation accepts a staged candidate only; unstaged/untracked files could mask its tests. */
+function assertRootPreparationState(repoRoot) {
+    if (trustedGate.isIndexClean(repoRoot)) {
+        fail('root preparation requires a staged candidate index');
+    }
+    try {
+        git(['diff', '--quiet'], repoRoot);
+    } catch (e) {
+        fail('root preparation refuses unstaged tracked changes; stage the exact candidate first');
+    }
+    const untracked = git(['ls-files', '--others', '--exclude-standard'], repoRoot);
+    if (untracked) {
+        fail('root preparation refuses untracked files that could affect validation: '
+            + untracked.split('\n').slice(0, 5).join(' | '));
+    }
+}
+
+function getPreparedRoot(repoRoot) {
+    const get = (key) => {
+        try {
+            return git(['config', '--local', '--get', key], repoRoot) || null;
+        } catch (e) {
+            return null;
+        }
+    };
+    return {
+        epoch: get(trustedGate.PREPARED_ROOT_EPOCH_KEY),
+        parent: get(trustedGate.PREPARED_ROOT_PARENT_KEY),
+        tree: get(trustedGate.PREPARED_ROOT_TREE_KEY),
+    };
+}
+
+function setPreparedRoot(repoRoot, epoch, parent, tree) {
+    git(['config', '--local', trustedGate.PREPARED_ROOT_EPOCH_KEY, String(epoch)], repoRoot);
+    git(['config', '--local', trustedGate.PREPARED_ROOT_PARENT_KEY, parent], repoRoot);
+    git(['config', '--local', trustedGate.PREPARED_ROOT_TREE_KEY, tree], repoRoot);
+}
+
+function clearPreparedRoot(repoRoot) {
+    for (const key of [trustedGate.PREPARED_ROOT_EPOCH_KEY, trustedGate.PREPARED_ROOT_PARENT_KEY,
+        trustedGate.PREPARED_ROOT_TREE_KEY]) {
+        try {
+            git(['config', '--local', '--unset-all', key], repoRoot);
+        } catch (e) {
+            // Missing preparation keys are already clear.
+        }
+    }
+}
+
+function createIndexCandidateCommit(repoRoot) {
+    const parent = trustedGate.resolveCommit(repoRoot, 'HEAD');
+    if (!parent) {
+        fail('HEAD must resolve to a full commit before root preparation');
+    }
+    const tree = git(['write-tree'], repoRoot);
+    const sha = git(['commit-tree', tree, '-p', parent], repoRoot,
+        { input: 'Gate root preparation validation\n' });
+    if (!trustedGate.SHA_RE.test(tree) || !trustedGate.SHA_RE.test(sha)) {
+        fail('cannot create the isolated staged root candidate');
+    }
+    return { parent, tree, sha };
+}
+
 /** 运行完整 i18n 测试套件（排除本 CLI 自身测试文件，避免递归）。 */
 function runFullSuite(repoRoot) {
     const result = trustedGate.runI18nTestSuite(repoRoot, 'trust-gate.test.mjs');
@@ -177,9 +241,9 @@ function validateRefWithGate(repoRoot, refSha, gateDir) {
 }
 
 /** 物化 ref 的 gate bundle 并读取 policy（无 policy → fail closed，Epoch 2 不迁移旧 anchor）。 */
-function materializeAndLoadPolicy(repoRoot, sha, gateDir) {
+function materializeAndLoadPolicy(repoRoot, sha, gateDir, expectedEpoch = trustedGate.CURRENT_GATE_EPOCH) {
     trustedGate.materializeTrustedGate(repoRoot, sha, gateDir);
-    const policy = trustedGate.loadPolicyFromDir(gateDir);
+    const policy = trustedGate.loadPolicyFromDir(gateDir, expectedEpoch);
     if (!policy) {
         throw new Error('gate bundle at ' + sha + ' has no gate-policy.json;'
             + ' obsolete-epoch anchors are not migrated; fail closed');
@@ -246,38 +310,105 @@ function runGateParity(repoRoot, candidateSha, trustedDir, invariantsOnly) {
     }
 }
 
+function runPrepareRoot(repoRoot, epochArg) {
+    if (trustedGate.isCI()) {
+        fail('root preparation is forbidden in CI (CI=true); it is an explicit local trust decision');
+    }
+    const targetEpoch = Number(epochArg);
+    const currentEpoch = Number(trustedGate.getTrustedEpoch(repoRoot));
+    const current = trustedGate.getTrustedRef(repoRoot);
+    if (!Number.isInteger(targetEpoch) || targetEpoch !== trustedGate.CURRENT_GATE_EPOCH) {
+        fail('--epoch must equal the candidate verifier epoch ' + trustedGate.CURRENT_GATE_EPOCH);
+    }
+    if (!current || !Number.isInteger(currentEpoch) || targetEpoch !== currentEpoch + 1) {
+        fail('root preparation requires an existing trusted anchor from the immediately previous epoch');
+    }
+    if (!trustedGate.resolveCommit(repoRoot, current)) {
+        fail('trusted gate anchor ' + current + ' does not resolve to a commit');
+    }
+    const head = trustedGate.resolveCommit(repoRoot, 'HEAD');
+    if (!head || !trustedGate.isAncestor(repoRoot, current, head)) {
+        fail('HEAD must descend from the current trusted anchor before root preparation');
+    }
+    const previousRoot = trustedGate.resolveRootTag(repoRoot, currentEpoch);
+    if (!previousRoot || !trustedGate.isAncestor(repoRoot, previousRoot, current)
+        || !trustedGate.isAncestor(repoRoot, previousRoot, head)) {
+        fail('the protected previous-epoch root tag is missing or not an ancestor of the current trust chain');
+    }
+    assertRootPreparationState(repoRoot);
+    clearPreparedRoot(repoRoot);
+    const candidate = createIndexCandidateCommit(repoRoot);
+    const gateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv-prepare-root-'));
+    try {
+        console.log('trust-gate: preparing Gate Epoch ' + targetEpoch + ' root candidate from staged tree '
+            + candidate.tree + '...');
+        const policy = materializeAndLoadPolicy(repoRoot, candidate.sha, gateDir, targetEpoch);
+        trustedGate.assertSupportedTrustedVerifierDir(gateDir, targetEpoch,
+            policy.minimumTrustedVerifier);
+        const missing = policy.requiredPaths
+            .filter((p) => !fs.existsSync(path.join(gateDir, ...p.split('/'))));
+        if (missing.length > 0) {
+            fail('required gate files missing from staged root candidate: ' + missing.join(', '));
+        }
+        runFullSuite(repoRoot);
+        validateRefWithGate(repoRoot, candidate.sha, gateDir);
+        runRootContract(repoRoot, candidate.sha, gateDir);
+        runGateParity(repoRoot, candidate.sha, gateDir, true);
+        setPreparedRoot(repoRoot, targetEpoch, candidate.parent, candidate.tree);
+    } finally {
+        rmrfRetry(gateDir);
+    }
+    console.log('trust-gate: Gate Epoch ' + targetEpoch + ' root prepared for one exact commit: parent '
+        + candidate.parent + ', tree ' + candidate.tree);
+}
+
 function runAdoptRoot(repoRoot, refArg, epochArg) {
     if (trustedGate.isCI()) {
-        fail('root adoption is forbidden in CI (CI=true); the Epoch 2 trust root must be'
+        fail('root adoption is forbidden in CI (CI=true); the Gate Epoch '
+            + trustedGate.CURRENT_GATE_EPOCH + ' trust root must be'
             + ' established by a human locally');
     }
     if (String(epochArg) !== String(trustedGate.CURRENT_GATE_EPOCH)) {
         fail('--epoch must be exactly ' + trustedGate.CURRENT_GATE_EPOCH
-            + ' (Epoch 2 is the only supported gate epoch; got ' + epochArg + ')');
+            + ' (the executing verifier supports exactly one gate epoch; got ' + epochArg + ')');
     }
     const current = trustedGate.getTrustedRef(repoRoot);
-    if (current) {
-        fail('a local trust anchor already exists at ' + current
-            + '; root adoption is only for establishing a NEW Epoch 2 root —'
-            + ' use --advance to move the existing anchor, or explicitly remove both'
-            + ' pixiv.i18n.trustedGateEpoch / pixiv.i18n.trustedGateRef first');
-    }
+    const previousEpoch = Number(trustedGate.getTrustedEpoch(repoRoot));
     const sha = trustedGate.resolveCommit(repoRoot, refArg);
     if (!sha) {
         fail('ref "' + refArg + '" must resolve to a full commit; worktree paths are not accepted');
     }
     assertCleanState(repoRoot);
 
+    if (current) {
+        if (previousEpoch === trustedGate.CURRENT_GATE_EPOCH) {
+            fail('a local trust anchor already exists at ' + current
+                + '; use --advance within the current epoch');
+        }
+        const prepared = getPreparedRoot(repoRoot);
+        const parents = git(['rev-list', '--parents', '-n', '1', sha], repoRoot).split(/\s+/);
+        const tree = git(['rev-parse', sha + '^{tree}'], repoRoot);
+        if (previousEpoch !== trustedGate.CURRENT_GATE_EPOCH - 1
+            || prepared.epoch !== String(trustedGate.CURRENT_GATE_EPOCH)
+            || parents.length !== 2 || prepared.parent !== parents[1] || prepared.tree !== tree
+            || !trustedGate.isAncestor(repoRoot, current, parents[1])) {
+            fail('existing-anchor root adoption requires a successfully prepared next-epoch commit'
+                + ' with the exact parent and tree');
+        }
+    }
+
     const gateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv-adopt-root-'));
     try {
         // ROOT ADMISSION：物化候选自身的 gate bundle（候选 = root candidate）
         console.log('trust-gate: ROOT ADMISSION — ' + sha
-            + ' is the Gate Epoch 2 root candidate; running the full root admission suite...');
+            + ' is the Gate Epoch ' + trustedGate.CURRENT_GATE_EPOCH
+            + ' root candidate; running the full root admission suite...');
         const policy = materializeAndLoadPolicy(repoRoot, sha, gateDir);
         // 新标准 root admission 也必须满足当前 verifier baseline（旧 v3 root 候选不再有资格；
         // 旧提交按旧标准存在，新标准只接受具备当前能力的 verifier）
         try {
-            trustedGate.assertSupportedTrustedVerifierDir(gateDir);
+            trustedGate.assertSupportedTrustedVerifierDir(gateDir,
+                trustedGate.CURRENT_GATE_EPOCH, policy.minimumTrustedVerifier);
         } catch (e) {
             fail('OUTDATED GATE VERIFIER: ' + e.message);
         }
@@ -293,19 +424,24 @@ function runAdoptRoot(repoRoot, refArg, epochArg) {
         validateRefWithGate(repoRoot, sha, gateDir);
         console.log('trust-gate: running the root contract self-test (workflow / package / self-protection)...');
         runRootContract(repoRoot, sha, gateDir);
-        console.log('trust-gate: running gate parity against the Epoch 2 invariants manifest...');
+        console.log('trust-gate: running gate parity against the Gate Epoch '
+            + trustedGate.CURRENT_GATE_EPOCH + ' invariants manifest...');
         runGateParity(repoRoot, sha, gateDir, true);
     } finally {
         rmrfRetry(gateDir);
     }
 
     console.error('');
-    console.error('This is the explicit Gate Epoch 2 root adoption decision.');
-    console.error('The repository state at ' + sha + ' becomes the local Epoch 2 trust root.');
+    console.error('This is the explicit Gate Epoch ' + trustedGate.CURRENT_GATE_EPOCH
+        + ' root adoption decision.');
+    console.error('The repository state at ' + sha + ' becomes the local Gate Epoch '
+        + trustedGate.CURRENT_GATE_EPOCH + ' trust root.');
     console.error('Only an explicit trust command can advance it.');
     console.error('');
     trustedGate.setTrustedAnchor(repoRoot, sha);
-    console.log('trust-gate: Epoch 2 root adopted; local anchor set to '
+    clearPreparedRoot(repoRoot);
+    console.log('trust-gate: Gate Epoch ' + trustedGate.CURRENT_GATE_EPOCH
+        + ' root adopted; local anchor set to '
         + 'git config --local pixiv.i18n.trustedGateEpoch ' + trustedGate.CURRENT_GATE_EPOCH
         + ' + pixiv.i18n.trustedGateRef ' + sha);
 }
@@ -316,15 +452,13 @@ function runAdvance(repoRoot, refArg) {
     }
     const current = trustedGate.getTrustedRef(repoRoot);
     if (!current) {
-        fail('no trusted gate anchor; establish the Epoch 2 root first:'
-            + ' npm run i18n:trust-gate -- --adopt-root --ref HEAD --epoch 2');
+        fail('no trusted gate anchor; run --adopt-root for the current Gate Epoch first');
     }
     if (!trustedGate.isTrustedEpochCurrent(repoRoot)) {
         fail('OBSOLETE GATE EPOCH: the local anchor belongs to epoch '
             + (trustedGate.getTrustedEpoch(repoRoot) || '<missing>') + ' (' + trustedGate.describeTrustedEpoch(repoRoot)
-            + '). Epoch 1 anchors are not migrated and have no automatic upgrade rights;'
-            + ' run the explicit Epoch 2 root adoption command instead:'
-            + ' npm run i18n:trust-gate -- --adopt-root --ref <new-root> --epoch 2');
+            + '). Obsolete anchors are not migrated and have no automatic upgrade rights;'
+            + ' run --adopt-root for the current Gate Epoch instead');
     }
     const sha = trustedGate.resolveCommit(repoRoot, refArg);
     if (!sha) {
@@ -345,12 +479,12 @@ function runAdvance(repoRoot, refArg) {
     const root = trustedGate.resolveRootTag(repoRoot);
     if (root) {
         if (!trustedGate.isAncestor(repoRoot, root, current)) {
-            fail('the current anchor ' + current + ' does not descend from the Gate Epoch 2 trust root '
-                + root + '; re-adopt the root first:'
-                + ' npm run i18n:trust-gate -- --adopt-root --ref HEAD --epoch 2');
+            fail('the current anchor ' + current + ' does not descend from the Gate Epoch '
+                + trustedGate.CURRENT_GATE_EPOCH + ' trust root ' + root + '; re-adopt the root first');
         }
         if (!trustedGate.isAncestor(repoRoot, root, sha)) {
-            fail('candidate ' + sha + ' does not descend from the Gate Epoch 2 trust root ' + root
+            fail('candidate ' + sha + ' does not descend from the Gate Epoch '
+                + trustedGate.CURRENT_GATE_EPOCH + ' trust root ' + root
                 + '; v1 / legacy / transition compatibility paths are retired; refusing to advance');
         }
     }
@@ -397,8 +531,10 @@ function runShow(repoRoot) {
     if (!current || !trustedGate.isTrustedEpochCurrent(repoRoot)) {
         console.log('trustedGateEpoch: ' + (epoch || '<not set>'));
         console.log('trustedGateRef: ' + (current || '<not set>'));
-        console.log('gateEpochRootTag: ' + (root || 'refs/tags/i18n-gate-epoch-2-root <missing>'));
-        console.log('run: npm run i18n:trust-gate -- --adopt-root --ref HEAD --epoch 2');
+        console.log('gateEpochRootTag: ' + (root || 'refs/tags/'
+            + trustedGate.rootTagNameForEpoch(trustedGate.CURRENT_GATE_EPOCH) + ' <missing>'));
+        console.log('run: npm run i18n:trust-gate -- --adopt-root --ref HEAD --epoch '
+            + trustedGate.CURRENT_GATE_EPOCH);
         return;
     }
     let contractVersion = 'n/a';
@@ -407,10 +543,10 @@ function runShow(repoRoot) {
     try {
         try {
             trustedGate.materializeTrustedGate(repoRoot, current, gateDir);
-            const policy = trustedGate.loadPolicyFromDir(gateDir);
-            if (policy) {
-                contractVersion = String(policy.contractVersion);
-            }
+            const policy = JSON.parse(fs.readFileSync(
+                path.join(gateDir, 'scripts', 'i18n', 'gate-policy.json'), 'utf8'));
+            contractVersion = Number.isInteger(policy.contractVersion)
+                ? String(policy.contractVersion) : 'n/a';
             try {
                 trustedGate.assertSupportedTrustedVerifierDir(gateDir);
                 baseline = 'OK';
@@ -427,14 +563,16 @@ function runShow(repoRoot) {
     console.log('trustedGateRef: ' + current);
     console.log('contractVersion: ' + contractVersion);
     console.log('verifierBaseline: ' + baseline);
-    console.log('gateEpochRootTag: ' + (root || 'refs/tags/i18n-gate-epoch-2-root <missing (install after admission)>'));
+    console.log('gateEpochRootTag: ' + (root || 'refs/tags/'
+        + trustedGate.rootTagNameForEpoch(trustedGate.CURRENT_GATE_EPOCH)
+        + ' <missing (install after admission)>'));
 }
 
 function parseArgs(argv) {
     const args = { command: null, ref: null, epoch: null, version: false };
     for (let i = 0; i < argv.length; i += 1) {
         const arg = argv[i];
-        if (arg === '--adopt-root' || arg === '--advance' || arg === '--show') {
+        if (arg === '--prepare-root' || arg === '--adopt-root' || arg === '--advance' || arg === '--show') {
             args.command = arg.slice(2);
         } else if (arg === '--ref') {
             args.ref = argv[++i];
@@ -454,8 +592,11 @@ function parseArgs(argv) {
             throw new Error('--ref <commit> is required for adopt-root');
         }
         if (!args.epoch) {
-            throw new Error('--epoch 2 is required for adopt-root');
+            throw new Error('--epoch <current-epoch> is required for adopt-root');
         }
+    }
+    if (args.command === 'prepare-root' && !args.epoch) {
+        throw new Error('--epoch <next-epoch> is required for prepare-root');
     }
     if (args.command === 'advance') {
         if (!args.ref) {
@@ -463,7 +604,8 @@ function parseArgs(argv) {
         }
     }
     if (!args.command) {
-        throw new Error('usage: trust-gate.mjs --show | --adopt-root --ref HEAD --epoch 2 | --advance --ref HEAD');
+        throw new Error('usage: trust-gate.mjs --show | --prepare-root --epoch <next> |'
+            + ' --adopt-root --ref HEAD --epoch <current> | --advance --ref HEAD');
     }
     return args;
 }
@@ -486,6 +628,10 @@ function main() {
     }
     if (args.command === 'show') {
         runShow(repoRoot);
+        return;
+    }
+    if (args.command === 'prepare-root') {
+        runPrepareRoot(repoRoot, args.epoch);
         return;
     }
     if (args.command === 'adopt-root') {

--- a/scripts/i18n/trust-gate.mjs
+++ b/scripts/i18n/trust-gate.mjs
@@ -756,7 +756,32 @@ function runSealRoot(repoRoot, refArg, trustedSource) {
         + trustedExecution.spec.targetEpoch + ' root candidate ' + candidateSha);
 }
 
-function setAnchorAndConsumeFirstAdmission(repoRoot, sha, epoch, previousRef, previousEpoch, ticket) {
+function assertFirstAdmissionCommitPoint(repoRoot, sha, previousRef, previousEpoch, ticket, sourceSpec) {
+    try {
+        assertProtectedFirstAdmissionSource(repoRoot, previousRef, sourceSpec);
+        const currentTicket = getFirstAdmissionTicket(repoRoot);
+        const parents = git(['rev-list', '--parents', '-n', '1', sha], repoRoot).split(/\s+/);
+        const tree = git(['rev-parse', sha + '^{tree}'], repoRoot);
+        if (trustedGate.getTrustedRef(repoRoot) !== previousRef
+            || trustedGate.getTrustedEpoch(repoRoot) !== String(previousEpoch)
+            || trustedGate.resolveCommit(repoRoot, sourceSpec.protectedBranchRef) !== previousRef
+            || JSON.stringify(currentTicket) !== JSON.stringify(ticket)
+            || currentTicket.candidate !== sha
+            || parents.length !== 2 || parents[1] !== previousRef
+            || tree !== ticket.tree
+            || trustedGate.resolveCommit(repoRoot, 'HEAD') !== sha
+            || !trustedGate.isIndexClean(repoRoot)
+            || !trustedGate.isWorktreeClean(repoRoot)) {
+            throw new Error('trusted source, ticket, root commit or repository state changed');
+        }
+    } catch (e) {
+        throw new Error('first-admission commit-point revalidation failed: ' + e.message);
+    }
+}
+
+function setAnchorAndConsumeFirstAdmission(repoRoot, sha, epoch, previousRef, previousEpoch,
+    ticket, sourceSpec) {
+    assertFirstAdmissionCommitPoint(repoRoot, sha, previousRef, previousEpoch, ticket, sourceSpec);
     try {
         trustedGate.setTrustedAnchor(repoRoot, sha, epoch);
         clearFirstAdmissionTicket(repoRoot, true);
@@ -797,6 +822,7 @@ function runAdoptRoot(repoRoot, refArg, epochArg) {
     assertCleanState(repoRoot);
 
     let firstAdmissionTicket = null;
+    let firstAdmissionSourceSpec = null;
     if (current) {
         if (previousEpoch === trustedGate.CURRENT_GATE_EPOCH) {
             fail('a local trust anchor already exists at ' + current
@@ -828,6 +854,7 @@ function runAdoptRoot(repoRoot, refArg, epochArg) {
             fail('first-admission ticket source no longer belongs to the protected previous root chain');
         }
         firstAdmissionTicket = prepared;
+        firstAdmissionSourceSpec = sourceSpec;
     } else if (ticketHasValues(getFirstAdmissionTicket(repoRoot))) {
         fail('a first-admission ticket cannot be consumed without its trusted source anchor');
     }
@@ -876,7 +903,7 @@ function runAdoptRoot(repoRoot, refArg, epochArg) {
     if (firstAdmissionTicket) {
         try {
             setAnchorAndConsumeFirstAdmission(repoRoot, sha, trustedGate.CURRENT_GATE_EPOCH,
-                current, previousEpoch, firstAdmissionTicket);
+                current, previousEpoch, firstAdmissionTicket, firstAdmissionSourceSpec);
         } catch (e) {
             fail('root adoption state transaction failed: ' + e.message);
         }

--- a/scripts/i18n/trust-gate.mjs
+++ b/scripts/i18n/trust-gate.mjs
@@ -10,6 +10,16 @@
  *   npm run i18n:trust-gate -- --advance --ref HEAD
  *   npm run i18n:trust-gate -- --version
  *
+ * prepare-root（Epoch 2 → 3 一次性 first admission）：
+ * - 当前工作树脚本只负责从 pixiv.i18n.trustedGateRef 物化并启动 bridge；实际批准代码、
+ *   library 与 bridge spec 必须逐字来自该 trusted bundle；
+ * - trusted source 必须属于受保护 origin/master 历史、包含 Epoch 2 root，且必须精确等于
+ *   staged Epoch 3 root 的单一 parent；candidate 只作为被审核对象；
+ * - bridge 只归一化 sourceEpoch=2 → targetEpoch=3、root 身份与已知 GATE-03 context 身份纠正，
+ *   其它内容仍由 Epoch 2 trusted contract/parity 审核；
+ * - 成功后只写仓库外的一次性 ticket，绑定双 epoch、trusted source、parent 与 tree；
+ *   失败不推进 anchor，也不写部分 ticket。
+ *
  * adopt-root（人工 root adoption / TOFU；Epoch 2 root 的唯一建立方式）：
  * - 新的 root 不可能由自己自动证明自己可信：root 由人工 code review + 完整自动测试 +
  *   root admission 门禁共同建立，本命令只执行 root-specific 自动检查；
@@ -52,6 +62,8 @@ import trustedGate from './lib/trusted-gate.mjs';
 import snapshot from './lib/repository-snapshot.mjs';
 
 const TRUST_CLI_VERSION = '3';
+const FIRST_ADMISSION_SPEC_REL = path.posix.join('scripts', 'i18n',
+    'epoch-2-first-admission.json');
 // verifier 最低能力由 trusted gate-policy.json 的 minimumTrustedVerifier 定义；NORMAL contract
 // 保证该声明只能单调增强，adopt-root / advance 前均按声明 fail closed。
 
@@ -64,6 +76,12 @@ function git(args, repoRoot, opts = {}) {
     return execFileSync('git', args, {
         cwd: repoRoot, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], ...opts,
     }).trim();
+}
+
+function gitBuffer(args, repoRoot, opts = {}) {
+    return execFileSync('git', args, {
+        cwd: repoRoot, encoding: null, stdio: ['pipe', 'pipe', 'pipe'], ...opts,
+    });
 }
 
 function hasBash() {
@@ -149,7 +167,15 @@ function assertRootPreparationState(repoRoot) {
     }
 }
 
-function getPreparedRoot(repoRoot) {
+const FIRST_ADMISSION_KEYS = [
+    trustedGate.FIRST_ADMISSION_SOURCE_EPOCH_KEY,
+    trustedGate.FIRST_ADMISSION_TARGET_EPOCH_KEY,
+    trustedGate.FIRST_ADMISSION_TRUSTED_SOURCE_KEY,
+    trustedGate.FIRST_ADMISSION_PARENT_KEY,
+    trustedGate.FIRST_ADMISSION_TREE_KEY,
+];
+
+function getFirstAdmissionTicket(repoRoot) {
     const get = (key) => {
         try {
             return git(['config', '--local', '--get', key], repoRoot) || null;
@@ -158,26 +184,65 @@ function getPreparedRoot(repoRoot) {
         }
     };
     return {
-        epoch: get(trustedGate.PREPARED_ROOT_EPOCH_KEY),
-        parent: get(trustedGate.PREPARED_ROOT_PARENT_KEY),
-        tree: get(trustedGate.PREPARED_ROOT_TREE_KEY),
+        sourceEpoch: get(trustedGate.FIRST_ADMISSION_SOURCE_EPOCH_KEY),
+        targetEpoch: get(trustedGate.FIRST_ADMISSION_TARGET_EPOCH_KEY),
+        trustedSource: get(trustedGate.FIRST_ADMISSION_TRUSTED_SOURCE_KEY),
+        parent: get(trustedGate.FIRST_ADMISSION_PARENT_KEY),
+        tree: get(trustedGate.FIRST_ADMISSION_TREE_KEY),
     };
 }
 
-function setPreparedRoot(repoRoot, epoch, parent, tree) {
-    git(['config', '--local', trustedGate.PREPARED_ROOT_EPOCH_KEY, String(epoch)], repoRoot);
-    git(['config', '--local', trustedGate.PREPARED_ROOT_PARENT_KEY, parent], repoRoot);
-    git(['config', '--local', trustedGate.PREPARED_ROOT_TREE_KEY, tree], repoRoot);
+function ticketHasValues(ticket) {
+    return Object.values(ticket).some((value) => value !== null);
 }
 
-function clearPreparedRoot(repoRoot) {
-    for (const key of [trustedGate.PREPARED_ROOT_EPOCH_KEY, trustedGate.PREPARED_ROOT_PARENT_KEY,
-        trustedGate.PREPARED_ROOT_TREE_KEY]) {
+function clearFirstAdmissionTicket(repoRoot, strict = false) {
+    for (const key of FIRST_ADMISSION_KEYS) {
         try {
             git(['config', '--local', '--unset-all', key], repoRoot);
         } catch (e) {
-            // Missing preparation keys are already clear.
+            if (strict && getFirstAdmissionTicket(repoRoot)[ticketFieldForKey(key)] !== null) {
+                throw e;
+            }
         }
+    }
+    if (strict && ticketHasValues(getFirstAdmissionTicket(repoRoot))) {
+        throw new Error('first-admission ticket could not be cleared atomically');
+    }
+}
+
+function ticketFieldForKey(key) {
+    const fields = ['sourceEpoch', 'targetEpoch', 'trustedSource', 'parent', 'tree'];
+    return fields[FIRST_ADMISSION_KEYS.indexOf(key)];
+}
+
+function setFirstAdmissionTicket(repoRoot, ticket) {
+    if (ticketHasValues(getFirstAdmissionTicket(repoRoot))) {
+        throw new Error('an unconsumed first-admission ticket already exists');
+    }
+    const values = [ticket.sourceEpoch, ticket.targetEpoch, ticket.trustedSource,
+        ticket.parent, ticket.tree];
+    try {
+        for (let i = 0; i < FIRST_ADMISSION_KEYS.length; i += 1) {
+            git(['config', '--local', FIRST_ADMISSION_KEYS[i], String(values[i])], repoRoot);
+        }
+        const actual = getFirstAdmissionTicket(repoRoot);
+        if (JSON.stringify(actual) !== JSON.stringify({
+            sourceEpoch: String(ticket.sourceEpoch),
+            targetEpoch: String(ticket.targetEpoch),
+            trustedSource: ticket.trustedSource,
+            parent: ticket.parent,
+            tree: ticket.tree,
+        })) {
+            throw new Error('first-admission ticket verification failed');
+        }
+    } catch (e) {
+        try {
+            clearFirstAdmissionTicket(repoRoot, true);
+        } catch (cleanupError) {
+            throw new Error(e.message + '; partial ticket cleanup failed: ' + cleanupError.message);
+        }
+        throw e;
     }
 }
 
@@ -310,56 +375,321 @@ function runGateParity(repoRoot, candidateSha, trustedDir, invariantsOnly) {
     }
 }
 
-function runPrepareRoot(repoRoot, epochArg) {
+function loadFirstAdmissionSpec(bundleRoot) {
+    const file = path.join(bundleRoot, ...FIRST_ADMISSION_SPEC_REL.split('/'));
+    if (!fs.existsSync(file)) {
+        throw new Error('trusted verifier has no Epoch 2 first-admission bridge specification');
+    }
+    const spec = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (spec.schemaVersion !== 1 || spec.sourceEpoch !== 2 || spec.targetEpoch !== 3
+        || spec.protectedBranchRef !== 'refs/remotes/origin/master'
+        || !spec.requiredContextReplacements
+        || Object.keys(spec.requiredContextReplacements).length !== 6
+        || !Array.isArray(spec.allowedChangedPaths) || spec.allowedChangedPaths.length === 0) {
+        throw new Error('invalid Epoch 2 first-admission bridge specification');
+    }
+    return spec;
+}
+
+function assertExecutingTrustedBundle(repoRoot, trustedSource) {
+    const bundleRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+    const trustedPaths = git(['ls-tree', '-r', '--name-only', trustedSource, '--',
+        ...trustedGate.GATE_PATHS], repoRoot).split('\n').filter(Boolean);
+    for (const rel of trustedPaths) {
+        const own = path.join(bundleRoot, ...rel.split('/'));
+        if (!fs.existsSync(own)) {
+            throw new Error('executing bridge bundle is missing ' + rel);
+        }
+        const trusted = gitBuffer(['show', trustedSource + ':' + rel], repoRoot);
+        if (!fs.readFileSync(own).equals(trusted)) {
+            throw new Error('first-admission bridge must execute from the exact trusted bundle: ' + rel);
+        }
+    }
+    return { bundleRoot, spec: loadFirstAdmissionSpec(bundleRoot) };
+}
+
+function loadJsonAtRef(repoRoot, ref, rel) {
+    return JSON.parse(git(['show', ref + ':' + rel], repoRoot));
+}
+
+function assertProtectedFirstAdmissionSource(repoRoot, trustedSource, spec) {
+    const configuredSource = trustedGate.getTrustedRef(repoRoot);
+    const configuredEpoch = trustedGate.getTrustedEpoch(repoRoot);
+    if (configuredSource !== trustedSource || configuredEpoch !== String(spec.sourceEpoch)) {
+        throw new Error('first-admission source must exactly match local trustedGateRef + sourceEpoch');
+    }
+    if (!trustedGate.resolveCommit(repoRoot, trustedSource)
+        || !trustedGate.resolveCommit(repoRoot, spec.protectedBranchRef)
+        || !trustedGate.isAncestor(repoRoot, trustedSource, spec.protectedBranchRef)) {
+        throw new Error('trusted first-admission source is not in protected origin/master history');
+    }
+    const previousRoot = trustedGate.resolveRootTag(repoRoot, spec.sourceEpoch);
+    if (!previousRoot || !trustedGate.isAncestor(repoRoot, previousRoot, trustedSource)) {
+        throw new Error('protected previous-epoch root is missing from the trusted source chain');
+    }
+    const head = trustedGate.resolveCommit(repoRoot, 'HEAD');
+    if (head !== trustedSource) {
+        throw new Error('Epoch 3 root parent must exactly equal the trusted Epoch 2 source');
+    }
+}
+
+function assertExactContextCorrection(repoRoot, candidateSha, trustedSource, spec) {
+    const oldContexts = Object.keys(spec.requiredContextReplacements);
+    const newContexts = Object.values(spec.requiredContextReplacements);
+    const sourceRules = loadJsonAtRef(repoRoot, trustedSource,
+        'scripts/ci/github-ruleset-invariants.json');
+    const candidateRules = loadJsonAtRef(repoRoot, candidateSha,
+        'scripts/ci/github-ruleset-invariants.json');
+    if (JSON.stringify(sourceRules.master.requiredChecks) !== JSON.stringify(oldContexts)
+        || JSON.stringify(candidateRules.master.requiredChecks) !== JSON.stringify(newContexts)) {
+        throw new Error('first admission permits only the exact known required-context identity correction');
+    }
+    const sourceRootName = trustedGate.rootTagNameForEpoch(spec.sourceEpoch);
+    const targetRootName = trustedGate.rootTagNameForEpoch(spec.targetEpoch);
+    if (!candidateRules[sourceRootName]
+        || JSON.stringify(candidateRules[sourceRootName]) !== JSON.stringify(sourceRules[sourceRootName])
+        || JSON.stringify(candidateRules[targetRootName]) !== JSON.stringify(sourceRules[sourceRootName])) {
+        throw new Error('Epoch 3 ruleset invariants must preserve Epoch 2 root protection and add identical Epoch 3 protection');
+    }
+
+    const sourcePolicy = loadJsonAtRef(repoRoot, trustedSource, 'scripts/i18n/gate-policy.json');
+    const candidatePolicy = loadJsonAtRef(repoRoot, candidateSha, 'scripts/i18n/gate-policy.json');
+    if (sourcePolicy.gateEpoch !== spec.sourceEpoch || candidatePolicy.gateEpoch !== spec.targetEpoch) {
+        throw new Error('first admission requires the exact sourceEpoch=2 and targetEpoch=3 transition');
+    }
+    const definitions = candidatePolicy.requiredExternalCheckDefinitions || [];
+    if (definitions.length !== 1 || definitions[0].requiredContext !== 'check-shared-snippets') {
+        throw new Error('Epoch 3 requiredExternalCheckDefinitions.requiredContext must be check-shared-snippets');
+    }
+    for (const list of [candidatePolicy.requiredPaths,
+        candidatePolicy.minimumTrustedVerifier && candidatePolicy.minimumTrustedVerifier.requiredFiles]) {
+        if (!Array.isArray(list) || list.includes(FIRST_ADMISSION_SPEC_REL)) {
+            throw new Error('Epoch 3 policy must remove the one-time Epoch 2 bridge specification');
+        }
+    }
+    const bridgeAtCandidate = run(['git', 'cat-file', '-e', candidateSha + ':' + FIRST_ADMISSION_SPEC_REL],
+        { cwd: repoRoot });
+    if (bridgeAtCandidate.status === 0) {
+        throw new Error('Epoch 3 root must not retain the Epoch 2 first-admission bridge specification');
+    }
+    const grepArgs = ['git', 'grep', '-n', '-F'];
+    for (const oldContext of oldContexts) {
+        grepArgs.push('-e', oldContext);
+    }
+    grepArgs.push(candidateSha, '--', '.');
+    const oldContextScan = run(grepArgs, { cwd: repoRoot });
+    if (oldContextScan.status === 0) {
+        throw new Error('Epoch 3 root still contains an old or dual required context:\n'
+            + (oldContextScan.stdout || '').slice(0, 4000));
+    }
+    if (oldContextScan.status !== 1) {
+        throw new Error('cannot scan the Epoch 3 candidate for forbidden old contexts');
+    }
+
+    const allowed = new Set(spec.allowedChangedPaths);
+    const changes = git(['diff', '--name-status', trustedSource, candidateSha], repoRoot)
+        .split('\n').filter(Boolean);
+    for (const line of changes) {
+        const fields = line.split('\t');
+        const status = fields[0];
+        const rel = fields[fields.length - 1];
+        if (!allowed.has(rel) || (status !== 'M' && !(status === 'D' && rel === FIRST_ADMISSION_SPEC_REL))) {
+            throw new Error('first admission refuses out-of-scope or non-mechanical change: ' + line);
+        }
+    }
+}
+
+function updateIndexBlob(repoRoot, indexFile, refForMode, rel, bytes) {
+    const env = { ...process.env, GIT_INDEX_FILE: indexFile };
+    const modeLine = git(['ls-tree', refForMode, '--', rel], repoRoot);
+    const mode = modeLine ? modeLine.split(/\s+/)[0] : '100644';
+    const blob = git(['hash-object', '-w', '--stdin'], repoRoot, { input: bytes });
+    git(['update-index', '--add', '--cacheinfo', mode, blob, rel], repoRoot, { env });
+}
+
+function normalizeFirstAdmissionCandidate(repoRoot, candidateSha, trustedSource, spec) {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv-first-admission-normalized-'));
+    const indexFile = path.join(temp, 'index');
+    const env = { ...process.env, GIT_INDEX_FILE: indexFile };
+    try {
+        git(['read-tree', candidateSha], repoRoot, { env });
+        const paths = git(['ls-tree', '-r', '--name-only', candidateSha, '--',
+            ...trustedGate.GATE_PATHS], repoRoot).split('\n').filter(Boolean);
+        const targetRoot = trustedGate.rootTagNameForEpoch(spec.targetEpoch);
+        const sourceRoot = trustedGate.rootTagNameForEpoch(spec.sourceEpoch);
+        for (const rel of paths) {
+            if (rel === 'scripts/i18n/gate-policy.json'
+                || rel === 'scripts/ci/github-ruleset-invariants.json') {
+                continue;
+            }
+            const original = gitBuffer(['show', candidateSha + ':' + rel], repoRoot);
+            const text = original.toString('utf8');
+            const normalized = text
+                .replaceAll(targetRoot, sourceRoot)
+                .replaceAll('CURRENT_GATE_EPOCH = ' + spec.targetEpoch + ';',
+                    'CURRENT_GATE_EPOCH = ' + spec.sourceEpoch + ';')
+                .replaceAll('"gateEpoch": ' + spec.targetEpoch,
+                    '"gateEpoch": ' + spec.sourceEpoch);
+            if (normalized !== text) {
+                updateIndexBlob(repoRoot, indexFile, candidateSha, rel, Buffer.from(normalized, 'utf8'));
+            }
+        }
+
+        const policy = loadJsonAtRef(repoRoot, candidateSha, 'scripts/i18n/gate-policy.json');
+        policy.gateEpoch = spec.sourceEpoch;
+        const reverse = new Map(Object.entries(spec.requiredContextReplacements)
+            .map(([oldValue, newValue]) => [newValue, oldValue]));
+        for (const definition of policy.requiredExternalCheckDefinitions || []) {
+            definition.requiredContext = reverse.get(definition.requiredContext) || definition.requiredContext;
+        }
+        for (const [list, sourceList] of [
+            [policy.requiredPaths, loadJsonAtRef(repoRoot, trustedSource,
+                'scripts/i18n/gate-policy.json').requiredPaths],
+            [policy.minimumTrustedVerifier.requiredFiles, loadJsonAtRef(repoRoot, trustedSource,
+                'scripts/i18n/gate-policy.json').minimumTrustedVerifier.requiredFiles],
+        ]) {
+            if (sourceList.includes(FIRST_ADMISSION_SPEC_REL) && !list.includes(FIRST_ADMISSION_SPEC_REL)) {
+                list.push(FIRST_ADMISSION_SPEC_REL);
+            }
+        }
+        updateIndexBlob(repoRoot, indexFile, candidateSha, 'scripts/i18n/gate-policy.json',
+            Buffer.from(JSON.stringify(policy, null, 2) + '\n', 'utf8'));
+
+        const rules = loadJsonAtRef(repoRoot, candidateSha,
+            'scripts/ci/github-ruleset-invariants.json');
+        rules.master.requiredChecks = Object.keys(spec.requiredContextReplacements);
+        delete rules[targetRoot];
+        updateIndexBlob(repoRoot, indexFile, candidateSha,
+            'scripts/ci/github-ruleset-invariants.json',
+            Buffer.from(JSON.stringify(rules, null, 2) + '\n', 'utf8'));
+
+        updateIndexBlob(repoRoot, indexFile, trustedSource, FIRST_ADMISSION_SPEC_REL,
+            gitBuffer(['show', trustedSource + ':' + FIRST_ADMISSION_SPEC_REL], repoRoot));
+        const tree = git(['write-tree'], repoRoot, { env });
+        return git(['commit-tree', tree, '-p', trustedSource], repoRoot,
+            { input: 'Normalized Epoch 2 first-admission candidate\n' });
+    } finally {
+        rmrfRetry(temp);
+    }
+}
+
+function runPrepareRootFromTrustedBundle(repoRoot, epochArg, trustedSource) {
     if (trustedGate.isCI()) {
         fail('root preparation is forbidden in CI (CI=true); it is an explicit local trust decision');
     }
-    const targetEpoch = Number(epochArg);
-    const currentEpoch = Number(trustedGate.getTrustedEpoch(repoRoot));
-    const current = trustedGate.getTrustedRef(repoRoot);
-    if (!Number.isInteger(targetEpoch) || targetEpoch !== trustedGate.CURRENT_GATE_EPOCH) {
-        fail('--epoch must equal the candidate verifier epoch ' + trustedGate.CURRENT_GATE_EPOCH);
-    }
-    if (!current || !Number.isInteger(currentEpoch) || targetEpoch !== currentEpoch + 1) {
-        fail('root preparation requires an existing trusted anchor from the immediately previous epoch');
-    }
-    if (!trustedGate.resolveCommit(repoRoot, current)) {
-        fail('trusted gate anchor ' + current + ' does not resolve to a commit');
-    }
-    const head = trustedGate.resolveCommit(repoRoot, 'HEAD');
-    if (!head || !trustedGate.isAncestor(repoRoot, current, head)) {
-        fail('HEAD must descend from the current trusted anchor before root preparation');
-    }
-    const previousRoot = trustedGate.resolveRootTag(repoRoot, currentEpoch);
-    if (!previousRoot || !trustedGate.isAncestor(repoRoot, previousRoot, current)
-        || !trustedGate.isAncestor(repoRoot, previousRoot, head)) {
-        fail('the protected previous-epoch root tag is missing or not an ancestor of the current trust chain');
+    let trustedExecution;
+    try {
+        trustedExecution = assertExecutingTrustedBundle(repoRoot, trustedSource);
+        if (Number(epochArg) !== trustedExecution.spec.targetEpoch) {
+            throw new Error('--epoch must be exactly ' + trustedExecution.spec.targetEpoch);
+        }
+        assertProtectedFirstAdmissionSource(repoRoot, trustedSource, trustedExecution.spec);
+    } catch (e) {
+        fail(e.message);
     }
     assertRootPreparationState(repoRoot);
-    clearPreparedRoot(repoRoot);
+    if (ticketHasValues(getFirstAdmissionTicket(repoRoot))) {
+        fail('an unconsumed first-admission ticket already exists');
+    }
     const candidate = createIndexCandidateCommit(repoRoot);
-    const gateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv-prepare-root-'));
+    const candidateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv-prepare-root-candidate-'));
+    const trustedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv-prepare-root-trusted-'));
     try {
-        console.log('trust-gate: preparing Gate Epoch ' + targetEpoch + ' root candidate from staged tree '
+        console.log('trust-gate: trusted Epoch ' + trustedExecution.spec.sourceEpoch
+            + ' first-admission bridge is auditing Gate Epoch ' + trustedExecution.spec.targetEpoch
+            + ' staged tree '
             + candidate.tree + '...');
-        const policy = materializeAndLoadPolicy(repoRoot, candidate.sha, gateDir, targetEpoch);
-        trustedGate.assertSupportedTrustedVerifierDir(gateDir, targetEpoch,
+        assertExactContextCorrection(repoRoot, candidate.sha, trustedSource, trustedExecution.spec);
+        const normalized = normalizeFirstAdmissionCandidate(repoRoot, candidate.sha,
+            trustedSource, trustedExecution.spec);
+        trustedGate.materializeTrustedGate(repoRoot, trustedSource, trustedDir);
+        trustedGate.assertSupportedTrustedVerifierDir(trustedDir,
+            trustedExecution.spec.sourceEpoch);
+        runTrustedContract(repoRoot, normalized, trustedDir);
+        runGateParity(repoRoot, normalized, trustedDir, false);
+
+        const policy = materializeAndLoadPolicy(repoRoot, candidate.sha, candidateDir,
+            trustedExecution.spec.targetEpoch);
+        trustedGate.assertSupportedTrustedVerifierDir(candidateDir,
+            trustedExecution.spec.targetEpoch,
             policy.minimumTrustedVerifier);
         const missing = policy.requiredPaths
-            .filter((p) => !fs.existsSync(path.join(gateDir, ...p.split('/'))));
+            .filter((p) => !fs.existsSync(path.join(candidateDir, ...p.split('/'))));
         if (missing.length > 0) {
             fail('required gate files missing from staged root candidate: ' + missing.join(', '));
         }
         runFullSuite(repoRoot);
-        validateRefWithGate(repoRoot, candidate.sha, gateDir);
-        runRootContract(repoRoot, candidate.sha, gateDir);
-        runGateParity(repoRoot, candidate.sha, gateDir, true);
-        setPreparedRoot(repoRoot, targetEpoch, candidate.parent, candidate.tree);
+        validateRefWithGate(repoRoot, candidate.sha, candidateDir);
+        runRootContract(repoRoot, candidate.sha, candidateDir);
+        runGateParity(repoRoot, candidate.sha, candidateDir, true);
+        setFirstAdmissionTicket(repoRoot, {
+            sourceEpoch: trustedExecution.spec.sourceEpoch,
+            targetEpoch: trustedExecution.spec.targetEpoch,
+            trustedSource,
+            parent: candidate.parent,
+            tree: candidate.tree,
+        });
+    } finally {
+        rmrfRetry(candidateDir);
+        rmrfRetry(trustedDir);
+    }
+    console.log('trust-gate: Gate Epoch ' + trustedExecution.spec.targetEpoch
+        + ' root prepared for one exact commit by trusted source ' + trustedSource + ': parent '
+        + candidate.parent + ', tree ' + candidate.tree);
+}
+
+function runPrepareRoot(repoRoot, epochArg, trustedSourceArg) {
+    if (trustedGate.isCI()) {
+        fail('root preparation is forbidden in CI (CI=true); it is an explicit local trust decision');
+    }
+    if (trustedSourceArg) {
+        runPrepareRootFromTrustedBundle(repoRoot, epochArg, trustedSourceArg);
+        return;
+    }
+    const current = trustedGate.getTrustedRef(repoRoot);
+    if (!current || !trustedGate.resolveCommit(repoRoot, current)) {
+        fail('root preparation requires a resolvable local trustedGateRef');
+    }
+    const gateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv-first-admission-source-'));
+    try {
+        trustedGate.materializeTrustedGate(repoRoot, current, gateDir);
+        const bridgeSpec = path.join(gateDir, ...FIRST_ADMISSION_SPEC_REL.split('/'));
+        if (!fs.existsSync(bridgeSpec)) {
+            fail('trusted verifier has no one-time Epoch 2 first-admission bridge');
+        }
+        const cli = path.join(gateDir, 'scripts', 'i18n', 'trust-gate.mjs');
+        const result = run(['node', cli, '--prepare-root', '--epoch', String(epochArg),
+            '--trusted-source', current], { cwd: repoRoot });
+        process.stdout.write(result.stdout || '');
+        process.stderr.write(result.stderr || '');
+        if (result.status !== 0) {
+            fail('trusted first-admission bridge rejected the staged root candidate');
+        }
     } finally {
         rmrfRetry(gateDir);
     }
-    console.log('trust-gate: Gate Epoch ' + targetEpoch + ' root prepared for one exact commit: parent '
-        + candidate.parent + ', tree ' + candidate.tree);
+}
+
+function setAnchorAndConsumeFirstAdmission(repoRoot, sha, epoch, previousRef, previousEpoch, ticket) {
+    try {
+        trustedGate.setTrustedAnchor(repoRoot, sha, epoch);
+        clearFirstAdmissionTicket(repoRoot, true);
+    } catch (e) {
+        const rollbackErrors = [];
+        try {
+            trustedGate.setTrustedAnchor(repoRoot, previousRef, previousEpoch);
+        } catch (rollbackError) {
+            rollbackErrors.push('anchor rollback failed: ' + rollbackError.message);
+        }
+        try {
+            clearFirstAdmissionTicket(repoRoot);
+            setFirstAdmissionTicket(repoRoot, ticket);
+        } catch (rollbackError) {
+            rollbackErrors.push('ticket rollback failed: ' + rollbackError.message);
+        }
+        throw new Error(e.message + (rollbackErrors.length > 0
+            ? '; ' + rollbackErrors.join('; ') : ''));
+    }
 }
 
 function runAdoptRoot(repoRoot, refArg, epochArg) {
@@ -380,21 +710,32 @@ function runAdoptRoot(repoRoot, refArg, epochArg) {
     }
     assertCleanState(repoRoot);
 
+    let firstAdmissionTicket = null;
     if (current) {
         if (previousEpoch === trustedGate.CURRENT_GATE_EPOCH) {
             fail('a local trust anchor already exists at ' + current
                 + '; use --advance within the current epoch');
         }
-        const prepared = getPreparedRoot(repoRoot);
+        const prepared = getFirstAdmissionTicket(repoRoot);
         const parents = git(['rev-list', '--parents', '-n', '1', sha], repoRoot).split(/\s+/);
         const tree = git(['rev-parse', sha + '^{tree}'], repoRoot);
         if (previousEpoch !== trustedGate.CURRENT_GATE_EPOCH - 1
-            || prepared.epoch !== String(trustedGate.CURRENT_GATE_EPOCH)
-            || parents.length !== 2 || prepared.parent !== parents[1] || prepared.tree !== tree
-            || !trustedGate.isAncestor(repoRoot, current, parents[1])) {
-            fail('existing-anchor root adoption requires a successfully prepared next-epoch commit'
-                + ' with the exact parent and tree');
+            || prepared.sourceEpoch !== String(previousEpoch)
+            || prepared.targetEpoch !== String(trustedGate.CURRENT_GATE_EPOCH)
+            || prepared.trustedSource !== current
+            || parents.length !== 2 || prepared.parent !== parents[1]
+            || prepared.parent !== current || prepared.tree !== tree
+            || !trustedGate.isAncestor(repoRoot, current, 'refs/remotes/origin/master')) {
+            fail('existing-anchor root adoption requires an unconsumed trusted first-admission ticket'
+                + ' with the exact source epoch, target epoch, trusted source, parent and tree');
         }
+        const previousRoot = trustedGate.resolveRootTag(repoRoot, previousEpoch);
+        if (!previousRoot || !trustedGate.isAncestor(repoRoot, previousRoot, current)) {
+            fail('first-admission ticket source no longer belongs to the protected previous root chain');
+        }
+        firstAdmissionTicket = prepared;
+    } else if (ticketHasValues(getFirstAdmissionTicket(repoRoot))) {
+        fail('a first-admission ticket cannot be consumed without its trusted source anchor');
     }
 
     const gateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv-adopt-root-'));
@@ -438,8 +779,16 @@ function runAdoptRoot(repoRoot, refArg, epochArg) {
         + trustedGate.CURRENT_GATE_EPOCH + ' trust root.');
     console.error('Only an explicit trust command can advance it.');
     console.error('');
-    trustedGate.setTrustedAnchor(repoRoot, sha);
-    clearPreparedRoot(repoRoot);
+    if (firstAdmissionTicket) {
+        try {
+            setAnchorAndConsumeFirstAdmission(repoRoot, sha, trustedGate.CURRENT_GATE_EPOCH,
+                current, previousEpoch, firstAdmissionTicket);
+        } catch (e) {
+            fail('root adoption state transaction failed: ' + e.message);
+        }
+    } else {
+        trustedGate.setTrustedAnchor(repoRoot, sha);
+    }
     console.log('trust-gate: Gate Epoch ' + trustedGate.CURRENT_GATE_EPOCH
         + ' root adopted; local anchor set to '
         + 'git config --local pixiv.i18n.trustedGateEpoch ' + trustedGate.CURRENT_GATE_EPOCH
@@ -569,7 +918,7 @@ function runShow(repoRoot) {
 }
 
 function parseArgs(argv) {
-    const args = { command: null, ref: null, epoch: null, version: false };
+    const args = { command: null, ref: null, epoch: null, trustedSource: null, version: false };
     for (let i = 0; i < argv.length; i += 1) {
         const arg = argv[i];
         if (arg === '--prepare-root' || arg === '--adopt-root' || arg === '--advance' || arg === '--show') {
@@ -578,6 +927,8 @@ function parseArgs(argv) {
             args.ref = argv[++i];
         } else if (arg === '--epoch') {
             args.epoch = argv[++i];
+        } else if (arg === '--trusted-source') {
+            args.trustedSource = argv[++i];
         } else if (arg === '--version') {
             args.version = true;
         } else {
@@ -631,7 +982,7 @@ function main() {
         return;
     }
     if (args.command === 'prepare-root') {
-        runPrepareRoot(repoRoot, args.epoch);
+        runPrepareRoot(repoRoot, args.epoch, args.trustedSource);
         return;
     }
     if (args.command === 'adopt-root') {


### PR DESCRIPTION
## 变更内容

加固 Epoch 2 verifier 的单调合同、可信来源解析和 GitHub Ruleset 漂移检测，并建立由 Epoch 2 trusted bundle 执行、只允许一次已知 GATE-03 身份纠正的 Epoch 3 first-admission bridge。

- 冻结 minimum verifier baseline、Quality Gate push 覆盖范围和裸 required context 合同
- feature branch 始终使用受保护 master 历史中的可信 predecessor
- `allowBypass=false` 拒绝任意 bypass actor
- first-admission ticket 精确绑定 source/target epoch、trusted source、parent、tree 和 sealed candidate SHA
- adopt-root 在最终状态事务前重新验证全部信任事实，失败时保留 Epoch 2 anchor 和 ticket

## 验证

- [x] 已运行与变更范围相称的专项与仓库级 i18n / Gate 测试
- [x] required checks 全部通过（本 PR 的六项实时 check-runs 均为 `success`）
- [x] Gate / workflow 变更已完成 trusted contract / parity 验证
- [x] CHANGELOG 已判断：纯内部门禁与信任边界加固，无用户可见变化，不更新

已推送候选 `651b969ca2235408b631e109c9b99aa15ff483a6` 的 Quality Gate push run 已真实通过 `java-tests`、`javascript-tests`、`signature-guard`、`trusted-gate-contract`、`i18n-check`；PR 专属 `check-shared-snippets` 仍以本 PR 的实时结果为准。
