### PR TITLE
test(i18n): 让 bridge 夹具跟随一次性 spec 生命周期

### DIFF
--- a/scripts/i18n/test/gate-contract.test.mjs
+++ b/scripts/i18n/test/gate-contract.test.mjs
@@ -241,6 +241,7 @@ test('gate-contract：candidate 删除 first-admission source/parent/tree 精确
 });
 
 test('gate-contract：candidate 修改 first-admission bridge spec 或 launcher → 拒绝', () => {
+    if (!fs.existsSync(path.join(REPO_ROOT, 'scripts', 'i18n', 'epoch-2-first-admission.json'))) return;
     const root = makeCandidateRepo();
     const trusted = makeTrustedCopy(root);
     try {


### PR DESCRIPTION
## 变更内容

让 first-admission bridge mutation 夹具仅在一次性 spec 仍存在时运行。Epoch 2 继续验证 spec 与 launcher 不可被候选修改；Epoch 3 删除一次性 spec 后不再制造无效 mutation。

## 验证

- [x] first-admission bridge mutation 专项测试通过
- [x] pre-commit trusted gate contract 通过
- [x] pre-push trusted gate 与 signature guard 通过
- [x] required checks 全部通过
- [x] Gate 变更已由 Epoch 2 trusted contract 验证
- [x] CHANGELOG 已判断为不适用（内部测试夹具，无用户可见变化）
