### PR TITLE
fix(i18n): 接纳精确 Epoch root 合并推送

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -162,7 +162,17 @@ jobs:
                       echo "protected branch push has no valid event.before; fail closed" >&2
                       exit 1
                     fi
-                    base="$before"
+                    root_line="$(git rev-list --parents -n 1 "$root")"
+                    candidate_line="$(git rev-list --parents -n 1 "$candidate")"
+                    root_tree="$(git rev-parse --verify "$root^{tree}")"
+                    candidate_tree="$(git rev-parse --verify "$candidate^{tree}")"
+                    if [ "$root_line" = "$root $before" ] \
+                        && [ "$candidate_line" = "$candidate $before $root" ] \
+                        && [ "$candidate_tree" = "$root_tree" ]; then
+                      base="$root"
+                    else
+                      base="$before"
+                    fi
                   else
                     # Feature branch event.before is not trusted: it may be a previously failed verifier.
                     fork_base="$(git merge-base "$candidate" "$default_tip" 2>/dev/null || printf '%s' '')"
@@ -506,7 +516,17 @@ jobs:
                       echo "protected branch push has no valid event.before; fail closed" >&2
                       exit 1
                     fi
-                    base="$before"
+                    root_line="$(git rev-list --parents -n 1 "$root")"
+                    candidate_line="$(git rev-list --parents -n 1 "$candidate")"
+                    root_tree="$(git rev-parse --verify "$root^{tree}")"
+                    candidate_tree="$(git rev-parse --verify "$candidate^{tree}")"
+                    if [ "$root_line" = "$root $before" ] \
+                        && [ "$candidate_line" = "$candidate $before $root" ] \
+                        && [ "$candidate_tree" = "$root_tree" ]; then
+                      base="$root"
+                    else
+                      base="$before"
+                    fi
                   else
                     # Feature branch event.before is not trusted: it may be a previously failed verifier.
                     fork_base="$(git merge-base "$candidate" "$default_tip" 2>/dev/null || printf '%s' '')"
@@ -873,7 +893,17 @@ jobs:
                       echo "protected branch push has no valid event.before; fail closed" >&2
                       exit 1
                     fi
-                    base="$before"
+                    root_line="$(git rev-list --parents -n 1 "$root")"
+                    candidate_line="$(git rev-list --parents -n 1 "$candidate")"
+                    root_tree="$(git rev-parse --verify "$root^{tree}")"
+                    candidate_tree="$(git rev-parse --verify "$candidate^{tree}")"
+                    if [ "$root_line" = "$root $before" ] \
+                        && [ "$candidate_line" = "$candidate $before $root" ] \
+                        && [ "$candidate_tree" = "$root_tree" ]; then
+                      base="$root"
+                    else
+                      base="$before"
+                    fi
                   else
                     # Feature branch event.before is not trusted: it may be a previously failed verifier.
                     fork_base="$(git merge-base "$candidate" "$default_tip" 2>/dev/null || printf '%s' '')"

--- a/scripts/ci/gate-parity.mjs
+++ b/scripts/ci/gate-parity.mjs
@@ -479,6 +479,7 @@ function auditWorkflow(checks, trustedDoc, candidateDoc, candidateRoot) {
             && /--pr-head/.test(resText) && /resolveLiveDefaultBranch/.test(resText)
             && /commitParents/.test(resText) && /commitTree/.test(resText)
             && /exact root pull request admission/.test(resText)
+            && /isExactRootMergePush/.test(resText) && /exact root merge push/.test(resText)
             && !isNoopStep(resText);
         pushCheck('resolve-trusted-base.mjs keeps root/input-precedence/ancestry semantics', resOk,
             'candidate weakened scripts/ci/resolve-trusted-base.mjs (must keep the Epoch 3 root tag /'
@@ -532,6 +533,13 @@ function auditWorkflow(checks, trustedDoc, candidateDoc, candidateRoot) {
                 && /--candidate "\$candidate"/.test(stepRun(s)) && !/--pr-head/.test(stepRun(s))
                 && /CANDIDATE_SHA/.test(stepRun(s))),
             jobId + ' must bind root PR admission to the live base, root parent, merge parents and root tree');
+        pushCheck(jobId + ': exact root merge push uses root only for sealed topology',
+            jobSteps(job).some((s) => /root_line=.*rev-list --parents/.test(stepRun(s))
+                && /candidate_line=.*rev-list --parents/.test(stepRun(s))
+                && /candidate_tree=.*\^\{tree\}/.test(stepRun(s))
+                && /candidate \$before \$root/.test(stepRun(s))
+                && /base="\$root"/.test(stepRun(s))),
+            jobId + ' must bind root merge push to root parent, merge parents and root tree');
     }
 
     // 失败吞没 / 条件跳过禁令：只针对运行关键门禁命令的 step；纯 no-op step 一律拒绝

--- a/scripts/ci/resolve-trusted-base.mjs
+++ b/scripts/ci/resolve-trusted-base.mjs
@@ -21,7 +21,8 @@
  *    - inputs.trusted_base_sha 非空 → 使用它（workflow_call 的 github.event_name 是调用方
  *      的原始 event，不能依赖 event 猜测；调用者只 propose，本脚本负责 prove）；
  *    - 否则按当前 event：pull_request → base.sha；merge_group → base_sha；
- *      push 到受保护默认分支 → event.before；其它分支 push（无论 before 是否非零）→
+ *      push 到受保护默认分支 → event.before；仅 exact root merge push（root parent == before、
+ *      merge parents == [before, root]、merge tree == root tree）使用 root；其它分支 push →
  *      merge-base(candidate, 受保护默认分支) 的 fork base；
  *      workflow_dispatch → 默认分支远端 ref；其它 → fail closed；
  *    - 每个来源的 base 都必须满足完整 provenance：base 是 commit、base != candidate、
@@ -276,6 +277,23 @@ function isExactRootPullRequest(repoRoot, args, mergeCandidate, root) {
     return true;
 }
 
+function isExactRootMergePush(repoRoot, args, mergeCandidate, root) {
+    if (args.eventName !== 'push'
+        || (args.gitRef && args.gitRef !== 'refs/heads/' + args.defaultBranch)
+        || !SHA_RE.test(args.before || '') || args.before === ZERO) {
+        return false;
+    }
+    const before = resolveCommit(repoRoot, args.before);
+    if (!before) {
+        return false;
+    }
+    const rootParents = commitParents(repoRoot, root);
+    const mergeParents = commitParents(repoRoot, mergeCandidate);
+    return rootParents.length === 1 && rootParents[0] === before
+        && mergeParents.length === 2 && mergeParents[0] === before && mergeParents[1] === root
+        && commitTree(repoRoot, mergeCandidate) === commitTree(repoRoot, root);
+}
+
 /** 新分支（before 全零）的 fork base：merge-base(candidate, 受保护默认分支)。 */
 function resolveForkBase(repoRoot, candidate, defaultBranch) {
     const tip = resolveDefaultBranch(repoRoot, defaultBranch);
@@ -308,7 +326,7 @@ function resolveProtectedPredecessor(repoRoot, candidate, defaultBranch) {
 }
 
 /** 根据 event / inputs 解析 NORMAL 模式 trusted base（input 优先级最高）。 */
-function resolveNormalBase(repoRoot, args) {
+function resolveNormalBase(repoRoot, args, candidate, root) {
     // 1. 显式 input 优先（reusable workflow 的 event_name 是调用方原始 event，不能依赖它）
     if (SHA_RE.test(args.inputBase || '')) {
         return args.inputBase;
@@ -331,6 +349,9 @@ function resolveNormalBase(repoRoot, args) {
             if (!before) {
                 fail('event.before ' + args.before + ' is not present in the local object database');
                 return null;
+            }
+            if (isExactRootMergePush(repoRoot, args, candidate, root)) {
+                return root;
             }
             return before;
         }
@@ -416,7 +437,7 @@ function main() {
             + ' (root tag missing or pointing at the candidate); the root gate runs with the full'
             + ' root self-protection suite.');
     } else {
-        base = resolveNormalBase(repoRoot, args);
+        base = resolveNormalBase(repoRoot, args, candidate, root);
         if (!base) {
             fail('cannot determine a trusted base for ' + candidate + ' (event ' + args.eventName
                 + ', no explicit trusted_base_sha input); fail closed');
@@ -460,7 +481,8 @@ function main() {
             }
         }
         if (args.eventName === 'push' && args.gitRef === 'refs/heads/' + args.defaultBranch
-            && args.before && SHA_RE.test(args.before) && args.before !== ZERO && base !== args.before) {
+            && args.before && SHA_RE.test(args.before) && args.before !== ZERO && base !== args.before
+            && !isExactRootMergePush(repoRoot, args, candidate, root)) {
             fail('trusted base ' + base + ' does not resolve to the protected push before commit '
                 + args.before);
             return;

--- a/scripts/i18n/gate-contract.mjs
+++ b/scripts/i18n/gate-contract.mjs
@@ -1230,6 +1230,7 @@ function runWorkflowContractChecks(repoRoot, candidateRoot) {
             && /--pr-head/.test(resText) && /resolveLiveDefaultBranch/.test(resText)
             && /commitParents/.test(resText) && /commitTree/.test(resText)
             && /exact root pull request admission/.test(resText)
+            && /isExactRootMergePush/.test(resText) && /exact root merge push/.test(resText)
             && !isNoopStep(resText);
         pushCheck(checks, 'resolve-trusted-base.mjs keeps root/input-precedence/ancestry semantics', resOk,
             'candidate weakened scripts/ci/resolve-trusted-base.mjs (must keep the Epoch 3 root tag /'
@@ -1342,6 +1343,16 @@ function runWorkflowContractChecks(repoRoot, candidateRoot) {
             exactRootPr,
             jobId + ' must audit the protected root head only after the PR merge ref matches the live'
                 + ' base, root parent, merge parents and root tree');
+        const exactRootMergePush = jobSteps(job).some((s) =>
+            /root_line=.*rev-list --parents/.test(stepRun(s))
+            && /candidate_line=.*rev-list --parents/.test(stepRun(s))
+            && /candidate_tree=.*\^\{tree\}/.test(stepRun(s))
+            && /candidate \$before \$root/.test(stepRun(s))
+            && /base="\$root"/.test(stepRun(s)));
+        pushCheck(checks, jobId + ': exact root merge push uses root only for sealed topology',
+            exactRootMergePush,
+            jobId + ' must use the Epoch 3 root as base only when root parent == before,'
+                + ' merge parents == [before, root], and merge tree == root tree');
     }
 
     const jGuard = jobs['signature-guard'];

--- a/scripts/i18n/test/quality-gate-root-admission.test.mjs
+++ b/scripts/i18n/test/quality-gate-root-admission.test.mjs
@@ -265,6 +265,40 @@ test('root admission：PR merge ref 仅在 live base、root 单一 parent 与 me
     }
 });
 
+test('protected push：精确 root merge 以 root 为 trusted base，tree 或 parent 变化均 fail closed', () => {
+    const repo = makeRepo();
+    try {
+        const root = git(['rev-parse', 'HEAD'], repo).stdout.trim();
+        const before = git(['rev-parse', 'HEAD^'], repo).stdout.trim();
+        const rootTree = git(['rev-parse', root + '^{tree}'], repo).stdout.trim();
+        git(['tag', 'i18n-gate-epoch-3-root', root], repo);
+
+        const merge = git(['commit-tree', rootTree, '-p', before, '-p', root], repo,
+            { input: 'Exact root merge push\n' }).stdout.trim();
+        const remote = path.join(repo, '.git', 'test-origin.git');
+        git(['--git-dir', remote, 'update-ref', 'refs/heads/master', before], repo);
+        git(['update-ref', 'refs/remotes/origin/master', before], repo);
+        git(['-c', 'core.hooksPath=/dev/null', 'push', '-q', 'origin', merge + ':refs/heads/master'], repo);
+        const args = ['--event-name', 'push', '--candidate', merge, '--before', before,
+            '--default-branch', 'master', '--ref', 'refs/heads/master', '--mode'];
+        const accepted = runResolver(repo, args);
+        assert.equal(accepted.status, 0, accepted.stdout + accepted.stderr);
+        assert.deepEqual(JSON.parse(accepted.stdout), { mode: 'NORMAL', base: root, root });
+
+        const badTree = git(['commit-tree', before + '^{tree}', '-p', before, '-p', root], repo,
+            { input: 'Wrong tree root merge push\n' }).stdout.trim();
+        const treeMismatch = runResolver(repo, args.map((arg) => arg === merge ? badTree : arg));
+        assert.notEqual(treeMismatch.status, 0, 'merge tree 变化必须 fail closed');
+
+        const wrongParents = git(['commit-tree', rootTree, '-p', root, '-p', before], repo,
+            { input: 'Wrong parents root merge push\n' }).stdout.trim();
+        const parentMismatch = runResolver(repo, args.map((arg) => arg === merge ? wrongParents : arg));
+        assert.notEqual(parentMismatch.status, 0, 'merge parent 身份或顺序变化必须 fail closed');
+    } finally {
+        cleanRepo(repo);
+    }
+});
+
 test('reusable input 优先级：显式 trusted_base_sha 优先于 event；input == candidate / 不含 root → 拒绝', () => {
     const root = makeRepo();
     try {

--- a/scripts/i18n/test/quality-gate-workflow.test.mjs
+++ b/scripts/i18n/test/quality-gate-workflow.test.mjs
@@ -293,6 +293,30 @@ test('workflow 契约：任一 gate job 将 exact root PR helper 退回 event SH
     }
 });
 
+test('workflow 契约：任一 gate job 删除 exact root merge push parent 证明 → 拒绝', () => {
+    const root = makeFullCandidateRepo();
+    const trusted = makeTrustedCopy(root);
+    try {
+        const doc = readWorkflow(root);
+        const step = doc.jobs['signature-guard'].steps.find((candidate) =>
+            typeof candidate.run === 'string' && /candidate_line=.*rev-list --parents/.test(candidate.run));
+        assert.ok(step, 'fixture 必须包含 exact root merge push parent 证明');
+        const original = step.run;
+        step.run = step.run.replace('candidate_line="$(git rev-list --parents -n 1 "$candidate")"',
+            'candidate_line="$candidate"');
+        assert.notEqual(step.run, original, 'fixture 必须真实删除 candidate parent 证明');
+        writeWorkflow(root, doc);
+        commitBypass(root, 'drop exact root merge push parent proof');
+        const sha = git(['rev-parse', 'HEAD'], root).stdout.trim();
+        const run = runContract(trusted, root, ['--repo-root', root, '--candidate-ref', sha]);
+        assert.notEqual(run.status, 0, 'exact root merge push parent 证明被删除时必须 fail closed');
+        assert.match(run.stdout + run.stderr, /exact root merge push|merge parents/);
+    } finally {
+        cleanRepo(root);
+        fs.rmSync(trusted, { recursive: true, force: true });
+    }
+});
+
 test('workflow 契约：trusted consumer 删除 event SHA 双绑定 → 拒绝', () => {
     const root = makeFullCandidateRepo();
     const trusted = makeTrustedCopy(root);


### PR DESCRIPTION
## 变更内容

- 仅在 Epoch 3 root 的 parent、master merge parents 与 tree 精确匹配时，以 root 作为 protected push 的 trusted base
- 在三个 Quality Gate bootstrap 中镜像相同拓扑证明
- 将该证明纳入 gate contract / parity 自保护，并增加 resolver 与 workflow mutation 回归

## 原因

Epoch 3 root 首次通过 Merge commit 进入 master 时，push event.before 仍是 Epoch 2 trusted source。普通 NORMAL 解析会把这个 pre-root commit 当作 base，导致 master Quality Gate 确定性 fail closed。修复只接纳唯一的 sealed root merge 拓扑；后续普通 push 仍严格使用 event.before。

## 影响

- 修复 Epoch 3 root 首次并入 master 后的 push provenance
- 不移动 root tag，不修改 first-admission bridge、Ruleset context 或兼容逻辑
- 无用户可见行为变化，因此不更新 CHANGELOG / README / 在线文档

## 验证

- 精确 root merge resolver 回归：通过
- workflow contract 降级 mutation：通过
- 完整 i18n/Gate suite：其余 274 项通过；首次由 WSL Bash 引起的 6 项依赖解析失败，在 Git for Windows Bash 下 6/6 通过；2 项 Windows symlink 测试按既有条件跳过
- pre-commit：GATE CONTRACT OK（246 checks）
- pre-push：trusted gate 与 signature guard 通过
- Push Quality Gate：5/5 成功（run 31342264850）
