### PR TITLE
fix(plugin-douyin): 删除写入 data/douyin/downloads 的错误构造器入口

### DIFF
--- a/pixivdownload-plugin-douyin/src/main/java/top/sywyar/pixivdownload/douyin/download/DouyinDownloadService.java
+++ b/pixivdownload-plugin-douyin/src/main/java/top/sywyar/pixivdownload/douyin/download/DouyinDownloadService.java
@@ -2,7 +2,6 @@ package top.sywyar.pixivdownload.douyin.download;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import top.sywyar.pixivdownload.config.RuntimePathProvider;
 import top.sywyar.pixivdownload.core.download.InteractiveDownloadExecutionLane;
 import top.sywyar.pixivdownload.plugin.api.download.queue.QueueGenerationDrain;
 import top.sywyar.pixivdownload.plugin.api.download.queue.QueueNotAcceptingException;
@@ -67,18 +66,6 @@ public class DouyinDownloadService {
     private final ConcurrentMap<TaskIdentity, String> runningStatusIds = new ConcurrentHashMap<>();
     private final Object runningLock = new Object();
     private final QueueTaskTracker taskTracker = new QueueTaskTracker(QUEUE_TYPE);
-
-    public DouyinDownloadService(DouyinUrlParser parser,
-                                 DouyinClient client,
-                                 DouyinMediaDownloader mediaDownloader,
-                                 InteractiveDownloadExecutionLane interactiveDownloadExecutionLane,
-                                 RuntimePathProvider runtimePathProvider) {
-        this(parser, client, mediaDownloader, interactiveDownloadExecutionLane,
-                requireRuntimePathProvider(runtimePathProvider)
-                        .resolvePluginDataDirectory("douyin")
-                        .resolve("downloads")
-                        .normalize());
-    }
 
     public DouyinDownloadService(DouyinUrlParser parser,
                                  DouyinClient inheritClient,
@@ -808,13 +795,6 @@ public class DouyinDownloadService {
 
     private static int positiveLimit(int limit) {
         return limit > 0 ? Math.min(limit, 100) : DEFAULT_PAGE_SIZE;
-    }
-
-    private static RuntimePathProvider requireRuntimePathProvider(RuntimePathProvider runtimePathProvider) {
-        if (runtimePathProvider == null) {
-            throw new IllegalArgumentException("Runtime path provider must not be null");
-        }
-        return runtimePathProvider;
     }
 
     private static String safeTitle(String title, String fallbackId) {


### PR DESCRIPTION
## 变更内容

删除 `DouyinDownloadService` 中经 `RuntimePathProvider` 把作品下载目录解析到 `data/douyin/downloads` 的公开构造器入口（该目录违反运行期文件规范：作品产物不得写入 `data/`）。所有生产入口统一依赖 `DouyinPluginSettingsService`：默认使用 `{下载根}/douyin`，插件配置 `douyin.download.directory` 覆盖时改用配置目录；`RuntimePathProvider.resolvePluginDataDirectory("douyin")` 只保留给缓存、索引等辅助数据。同步清理无引用的 `requireRuntimePathProvider` 辅助方法与 import，测试继续使用 package-private `Path` 构造器，未新增路径抽象。

## 验证

- [x] 已运行与风险相称的构建 / 测试 / gate：`./mvnw -pl pixivdownload-plugin-douyin -am test -Dexec.skip=true`，36 个测试类全部通过（含 `DouyinDownloadServiceTest` 41 项）；pre-commit / pre-push 本地门禁通过
- [x] required checks 全部通过（待 PR 运行后确认）
- [x] Gate / workflow 变更已完成适用的 trusted contract / parity 验证（不适用：本次无 Gate / workflow 变更）
- [x] CHANGELOG 已按 changelog-conventions.md 判断并更新（如适用）（无用户可见变化，不写）

## 关联

无
