### PR TITLE
feat(release): Nightly 支持手动跳过 CHANGELOG 门槛并沿用上次发布说明

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: '33 18 * * *'
   workflow_dispatch:
+    inputs:
+      skip-changelog-gate:
+        description: '填写 true 可跳过 CHANGELOG 门槛强制构建；CHANGELOG 与上次 nightly 基线无差异时沿用上一次发布说明。默认 false'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   resolve-version:
@@ -36,7 +42,15 @@ jobs:
           # misread as "no changes". First Nightly (no baseline tag yet) uses
           # the [Unreleased] section instead. The decision lives in
           # scripts/nightly-changelog-gate.sh so the exact matrix is tested.
+          # Manual dispatch may pass skip-changelog-gate=true to force a build
+          # without changelog changes (e.g. to pick up republished plugin
+          # artifacts); release notes then fall back to the previous nightly.
           HAS_CHANGES=$(./scripts/nightly-changelog-gate.sh CHANGELOG.md nightly)
+          if [ "$HAS_CHANGES" = "false" ] \
+             && [ "${{ github.event_name }}" = "workflow_dispatch" ] \
+             && [ "${{ github.event.inputs.skip-changelog-gate }}" = "true" ]; then
+            HAS_CHANGES=true
+          fi
           echo "has_changes=$HAS_CHANGES" >> "$GITHUB_OUTPUT"
 
       - name: Resolve next version
@@ -339,6 +353,8 @@ jobs:
       - name: Diff changelog since last nightly
         id: changelog
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git fetch --tags origin 2>/dev/null || true
 
@@ -360,6 +376,32 @@ jobs:
           fi
 
           if [ -s CHANGELOG_DIFF.md ]; then
+            has_notes=true
+          else
+            has_notes=false
+          fi
+
+          # skip-changelog-gate dispatch with an unchanged CHANGELOG reuses the
+          # previous nightly release notes (both Release body and update.json),
+          # so a forced rebuild never publishes empty or misleading notes.
+          if [ "$has_notes" = "false" ] \
+             && [ "${{ github.event_name }}" = "workflow_dispatch" ] \
+             && [ "${{ github.event.inputs.skip-changelog-gate }}" = "true" ] \
+             && git rev-parse --verify nightly^{commit} >/dev/null 2>&1 \
+             && git diff --quiet nightly -- CHANGELOG.md; then
+            mkdir -p previous-update
+            if gh release download nightly \
+                 --pattern 'update.json' \
+                 --dir previous-update \
+                 --clobber >/dev/null 2>&1; then
+              jq -r '.releaseNotes // empty' previous-update/update.json > CHANGELOG_DIFF.md
+              if [ -s CHANGELOG_DIFF.md ]; then
+                has_notes=true
+              fi
+            fi
+          fi
+
+          if [ "$has_notes" = "true" ]; then
             echo "has_notes=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_notes=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 变更内容

为 Nightly Build 工作流新增 skip-changelog-gate 手动触发输入：管理员在 Actions 页手动触发时可填 	rue 短路 CHANGELOG 门槛强制构建（用于拉取已重新发布的插件 artifact 等场景）。CHANGELOG 与上次 nightly 基线无差异时，发布说明沿用上一次 nightly 的 update.json releaseNotes；有差异时仍走原有 diff 流程，参数不干扰正常发布。

## 验证

- [x] 已运行与风险相称的构建 / 测试 / gate（test:i18n 282 通过、gate-parity 88 项通过、gate-contract 237 项通过、i18n:check 通过、YAML 解析与 bash -n 语法检查通过）
- [x] required checks 全部通过（推送 CI 5/5 success，PR merge candidate 检查继续观察）
- [x] Gate / workflow 变更已完成适用的 trusted contract / parity 验证
- [x] CHANGELOG 已按 changelog-conventions.md 判断并更新（如适用）——纯内部 CI 编排，无用户可见变化，不更新

## 关联

（无）