### PR TITLE
refactor(db): 使用参数对象封装作品写入参数

### DIFF
--- a/pixivdownload-app/src/main/java/top/sywyar/pixivdownload/core/db/InsertArtworkArgument.java
+++ b/pixivdownload-app/src/main/java/top/sywyar/pixivdownload/core/db/InsertArtworkArgument.java
@@ -1,0 +1,34 @@
+package top.sywyar.pixivdownload.core.db;
+
+import lombok.Builder;
+
+import java.util.Objects;
+
+/**
+ * 写入作品下载记录所需的完整参数。
+ */
+@Builder
+public record InsertArtworkArgument(
+        Long artworkId,
+        String title,
+        String folder,
+        Integer count,
+        String extensions,
+        Long time,
+        Integer xRestrict,
+        Boolean isAi,
+        Long authorId,
+        String description,
+        Long fileName,
+        Long fileAuthorNameId,
+        Long seriesId,
+        Long seriesOrder
+) {
+    public InsertArtworkArgument {
+        Objects.requireNonNull(artworkId, "artworkId");
+        Objects.requireNonNull(folder, "folder");
+        Objects.requireNonNull(count, "count");
+        Objects.requireNonNull(time, "time");
+        fileName = fileName == null ? PixivDatabase.DEFAULT_FILE_NAME_TEMPLATE_ID : fileName;
+    }
+}

--- a/pixivdownload-app/src/main/java/top/sywyar/pixivdownload/core/db/PixivDatabase.java
+++ b/pixivdownload-app/src/main/java/top/sywyar/pixivdownload/core/db/PixivDatabase.java
@@ -83,53 +83,14 @@ public class PixivDatabase {
     }
 
     @Transactional
-    public void insertArtwork(long artworkId, String title, String folder, int count,
-                              String extensions, long time, Integer xRestrict, Boolean isAi, Long authorId,
-                              String description, long fileName, Long fileAuthorNameId,
-                              Long seriesId, Long seriesOrder) {
+    public void insertArtwork(InsertArtworkArgument argument) {
         // 软删除残留行的 folder/time 已失效，先清掉再写入全新行，重新下载即复位 deleted 标记；
         // 普通已下载行不受影响（INSERT OR IGNORE 保持原有的不覆盖语义）。
-        pixivMapper.deleteIfMarkedDeleted(artworkId);
-        pixivMapper.insertOrIgnore(artworkId, title, encodePath(folder),
-                count, extensions, time, xRestrict, isAi, authorId, description, fileName, fileAuthorNameId,
-                seriesId, seriesOrder);
-    }
-
-    public void insertArtwork(long artworkId, String title, String folder, int count,
-                              String extensions, long time, Integer xRestrict, Boolean isAi, Long authorId,
-                              String description, long fileName, Long fileAuthorNameId) {
-        insertArtwork(artworkId, title, folder, count, extensions, time, xRestrict, isAi, authorId,
-                description, fileName, fileAuthorNameId, null, null);
-    }
-
-    public void insertArtwork(long artworkId, String title, String folder, int count,
-                              String extensions, long time, Integer xRestrict, Boolean isAi, Long authorId,
-                              String description, long fileName) {
-        insertArtwork(artworkId, title, folder, count, extensions, time, xRestrict, isAi,
-                authorId, description, fileName, null);
-    }
-
-    public void insertArtwork(long artworkId, String title, String folder, int count,
-                              String extensions, long time, Integer xRestrict, Boolean isAi, Long authorId,
-                              String description) {
-        insertArtwork(artworkId, title, folder, count, extensions, time, xRestrict, isAi,
-                authorId, description, DEFAULT_FILE_NAME_TEMPLATE_ID);
-    }
-
-    public void insertArtwork(long artworkId, String title, String folder, int count,
-                              String extensions, long time, Integer xRestrict, Long authorId,
-                              String description) {
-        insertArtwork(artworkId, title, folder, count, extensions, time, xRestrict, null, authorId, description);
-    }
-
-    public void insertArtwork(long artworkId, String title, String folder, int count,
-                              String extensions, long time, Integer xRestrict, Long authorId) {
-        insertArtwork(artworkId, title, folder, count, extensions, time, xRestrict, authorId, null);
-    }
-
-    public void insertArtwork(long artworkId, String title, String folder, int count,
-                              String extensions, long time, Integer xRestrict) {
-        insertArtwork(artworkId, title, folder, count, extensions, time, xRestrict, null, null);
+        pixivMapper.deleteIfMarkedDeleted(argument.artworkId());
+        pixivMapper.insertOrIgnore(argument.artworkId(), argument.title(), encodePath(argument.folder()),
+                argument.count(), argument.extensions(), argument.time(), argument.xRestrict(), argument.isAi(),
+                argument.authorId(), argument.description(), argument.fileName(), argument.fileAuthorNameId(),
+                argument.seriesId(), argument.seriesOrder());
     }
 
     @Transactional

--- a/pixivdownload-app/src/main/java/top/sywyar/pixivdownload/core/download/ArtworkDownloadHistoryAdapter.java
+++ b/pixivdownload-app/src/main/java/top/sywyar/pixivdownload/core/download/ArtworkDownloadHistoryAdapter.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 import top.sywyar.pixivdownload.core.artwork.download.ArtworkDownloadCompletion;
 import top.sywyar.pixivdownload.core.artwork.download.ArtworkDownloadHistory;
 import top.sywyar.pixivdownload.core.db.ArtworkRecord;
+import top.sywyar.pixivdownload.core.db.InsertArtworkArgument;
 import top.sywyar.pixivdownload.core.db.PixivDatabase;
 import top.sywyar.pixivdownload.core.db.TagDto;
 import top.sywyar.pixivdownload.core.metadata.ArtworkMetadataQuality;
@@ -63,20 +64,22 @@ public class ArtworkDownloadHistoryAdapter implements ArtworkDownloadHistory {
             fileAuthorNameId = resolvedFileAuthorNameId;
         }
         pixivDatabase.insertArtwork(
-                completion.artworkId(),
-                title,
-                completion.folder().toAbsolutePath().toString(),
-                completion.imageCount(),
-                String.join(",", completion.extensions()),
-                completion.recordTime(),
-                restriction,
-                aiGenerated,
-                authorId,
-                description,
-                fileNameTemplateId,
-                fileAuthorNameId,
-                seriesId,
-                seriesOrder
+                InsertArtworkArgument.builder()
+                        .artworkId(completion.artworkId())
+                        .title(title)
+                        .folder(completion.folder().toAbsolutePath().toString())
+                        .count(completion.imageCount())
+                        .extensions(String.join(",", completion.extensions()))
+                        .time(completion.recordTime())
+                        .xRestrict(restriction)
+                        .isAi(aiGenerated)
+                        .authorId(authorId)
+                        .description(description)
+                        .fileName(fileNameTemplateId)
+                        .fileAuthorNameId(fileAuthorNameId)
+                        .seriesId(seriesId)
+                        .seriesOrder(seriesOrder)
+                        .build()
         );
         pixivDatabase.refreshArtworkMetadataAfterDownload(
                 completion.artworkId(),

--- a/pixivdownload-app/src/main/java/top/sywyar/pixivdownload/core/download/ArtworkMetadataRecoveryService.java
+++ b/pixivdownload-app/src/main/java/top/sywyar/pixivdownload/core/download/ArtworkMetadataRecoveryService.java
@@ -7,6 +7,7 @@ import top.sywyar.pixivdownload.author.AuthorService;
 import top.sywyar.pixivdownload.core.pixiv.PixivDescriptionHtml;
 import top.sywyar.pixivdownload.core.appconfig.DownloadConfig;
 import top.sywyar.pixivdownload.core.db.ArtworkRecord;
+import top.sywyar.pixivdownload.core.db.InsertArtworkArgument;
 import top.sywyar.pixivdownload.core.db.PixivDatabase;
 import top.sywyar.pixivdownload.core.download.request.RecoverMetadataRequest;
 import top.sywyar.pixivdownload.i18n.AppMessages;
@@ -106,12 +107,18 @@ public class ArtworkMetadataRecoveryService {
         String absoluteFolder = flatDir.toAbsolutePath().toString();
         log.info(logMessage("download.log.stale-record.restored",
                 id(artworkId), absoluteFolder));
-        pixivDatabase.insertArtwork(artworkId,
-                StringUtils.hasText(meta.getTitle()) ? meta.getTitle() : "",
-                absoluteFolder, count, extensions,
-                pixivDatabase.getUniqueTime(), meta.getXRestrict(), meta.getIsAi(),
-                meta.getAuthorId(),
-                normalizedDescription == null ? "" : normalizedDescription);
+        pixivDatabase.insertArtwork(InsertArtworkArgument.builder()
+                .artworkId(artworkId)
+                .title(StringUtils.hasText(meta.getTitle()) ? meta.getTitle() : "")
+                .folder(absoluteFolder)
+                .count(count)
+                .extensions(extensions)
+                .time(pixivDatabase.getUniqueTime())
+                .xRestrict(meta.getXRestrict())
+                .isAi(meta.getIsAi())
+                .authorId(meta.getAuthorId())
+                .description(normalizedDescription == null ? "" : normalizedDescription)
+                .build());
         observeAuthorIfPresent(artworkId, meta);
         return pixivDatabase.getArtwork(artworkId);
     }
@@ -158,8 +165,15 @@ public class ArtworkMetadataRecoveryService {
         String absoluteFolder = flatDir.toAbsolutePath().toString();
         log.info(logMessage("download.log.stale-record.restored",
                 id(artworkId), absoluteFolder));
-        pixivDatabase.insertArtwork(artworkId, "", absoluteFolder, count, extensions,
-                pixivDatabase.getUniqueTime(), null, null, null, "");
+        pixivDatabase.insertArtwork(InsertArtworkArgument.builder()
+                .artworkId(artworkId)
+                .title("")
+                .folder(absoluteFolder)
+                .count(count)
+                .extensions(extensions)
+                .time(pixivDatabase.getUniqueTime())
+                .description("")
+                .build());
         return pixivDatabase.getArtwork(artworkId);
     }
 

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/core/db/PixivDatabaseTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/core/db/PixivDatabaseTest.java
@@ -76,7 +76,7 @@ class PixivDatabaseTest {
         @Test
         @DisplayName("插入作品后应能查询到")
         void shouldInsertAndRetrieveArtwork() {
-            pixivDatabase.insertArtwork(12345L, "测试作品", "/path/to/12345", 3, "jpg", 1700000001L, 0);
+            insertArtwork(12345L, "测试作品", "/path/to/12345", 3, "jpg", 1700000001L, 0);
 
             ArtworkRecord record = pixivDatabase.getArtwork(12345L);
 
@@ -90,14 +90,29 @@ class PixivDatabaseTest {
             assertThat(record.xRestrict()).isEqualTo(0);
             assertThat(record.isAi()).isNull();
             assertThat(record.authorId()).isNull();
+            assertThat(record.fileName()).isEqualTo(PixivDatabase.DEFAULT_FILE_NAME_TEMPLATE_ID);
             assertThat(record.moved()).isFalse();
+        }
+
+        @Test
+        @DisplayName("缺少必填字段时应拒绝构建作品写入参数")
+        void shouldRejectMissingRequiredInsertArgumentField() {
+            assertThatThrownBy(() -> InsertArtworkArgument.builder()
+                    .title("test")
+                    .folder("/path")
+                    .count(1)
+                    .extensions("jpg")
+                    .time(1L)
+                    .build())
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessage("artworkId");
         }
 
         @Test
         @DisplayName("插入作品时应写入 authorId")
         void shouldInsertArtworkWithAuthorId() {
-            pixivDatabase.insertArtwork(12346L, "author test", "/path/to/12346",
-                    1, "png", 1700000007L, 0, 777L);
+            pixivDatabase.insertArtwork(artwork(12346L, "author test", "/path/to/12346",
+                    1, "png", 1700000007L, 0).authorId(777L).build());
 
             ArtworkRecord record = pixivDatabase.getArtwork(12346L);
 
@@ -108,8 +123,12 @@ class PixivDatabaseTest {
         @Test
         @DisplayName("插入作品时应写入 isAi")
         void shouldInsertArtworkWithIsAi() {
-            pixivDatabase.insertArtwork(12347L, "ai test", "/path/to/12347",
-                    1, "png", 1700000008L, 0, true, 888L, "desc");
+            pixivDatabase.insertArtwork(artwork(12347L, "ai test", "/path/to/12347",
+                    1, "png", 1700000008L, 0)
+                    .isAi(true)
+                    .authorId(888L)
+                    .description("desc")
+                    .build());
 
             ArtworkRecord record = pixivDatabase.getArtwork(12347L);
 
@@ -125,8 +144,13 @@ class PixivDatabaseTest {
         void shouldInsertArtworkWithFileNameTemplateId() {
             long templateId = pixivDatabase.getOrCreateFileNameTemplateId("{artwork_title}_p{page}");
 
-            pixivDatabase.insertArtwork(12348L, "file name test", "/path/to/12348",
-                    1, "png", 1700000012L, 0, false, 888L, "desc", templateId);
+            pixivDatabase.insertArtwork(artwork(12348L, "file name test", "/path/to/12348",
+                    1, "png", 1700000012L, 0)
+                    .isAi(false)
+                    .authorId(888L)
+                    .description("desc")
+                    .fileName(templateId)
+                    .build());
 
             ArtworkRecord record = pixivDatabase.getArtwork(12348L);
 
@@ -139,7 +163,7 @@ class PixivDatabaseTest {
         @Test
         @DisplayName("插入 R18 作品")
         void shouldInsertR18Artwork() {
-            pixivDatabase.insertArtwork(11111L, "R18作品", "/path/r18", 1, "png", 1700000002L, 1);
+            insertArtwork(11111L, "R18作品", "/path/r18", 1, "png", 1700000002L, 1);
 
             ArtworkRecord record = pixivDatabase.getArtwork(11111L);
 
@@ -150,7 +174,7 @@ class PixivDatabaseTest {
         @Test
         @DisplayName("插入 R18G 作品")
         void shouldInsertR18GArtwork() {
-            pixivDatabase.insertArtwork(11112L, "R18G作品", "/path/r18g", 1, "png", 1700000009L, 2);
+            insertArtwork(11112L, "R18G作品", "/path/r18g", 1, "png", 1700000009L, 2);
 
             ArtworkRecord record = pixivDatabase.getArtwork(11112L);
 
@@ -161,7 +185,7 @@ class PixivDatabaseTest {
         @Test
         @DisplayName("xRestrict 为 null 的作品")
         void shouldHandleNullXRestrict() {
-            pixivDatabase.insertArtwork(22222L, "普通作品", "/path/normal", 1, "jpg", 1700000003L, (Integer) null);
+            insertArtwork(22222L, "普通作品", "/path/normal", 1, "jpg", 1700000003L, null);
 
             ArtworkRecord record = pixivDatabase.getArtwork(22222L);
 
@@ -172,8 +196,8 @@ class PixivDatabaseTest {
         @Test
         @DisplayName("INSERT OR IGNORE 重复插入不应覆盖")
         void shouldIgnoreDuplicateInsert() {
-            pixivDatabase.insertArtwork(12345L, "原始标题", "/path/1", 1, "jpg", 1700000004L, 0);
-            pixivDatabase.insertArtwork(12345L, "新标题", "/path/2", 2, "png", 1700000005L, 1);
+            insertArtwork(12345L, "原始标题", "/path/1", 1, "jpg", 1700000004L, 0);
+            insertArtwork(12345L, "新标题", "/path/2", 2, "png", 1700000005L, 1);
 
             ArtworkRecord record = pixivDatabase.getArtwork(12345L);
             assertThat(record.title()).isEqualTo("原始标题");
@@ -185,8 +209,14 @@ class PixivDatabaseTest {
         void shouldRefreshDownloadedArtworkMetadataWithoutReplacingWithEmptyValues() {
             long fileNameId = pixivDatabase.getOrCreateFileNameTemplateId("{artwork_title}_p{page}");
             long fileAuthorNameId = pixivDatabase.getOrCreateFileAuthorNameId("新作者");
-            pixivDatabase.insertArtwork(12345L, "旧标题", "/path/1", 1, "jpg", 1700000004L,
-                    0, false, 10L, "旧简介", 1L, null, 7L, 1L);
+            pixivDatabase.insertArtwork(artwork(12345L, "旧标题", "/path/1", 1, "jpg", 1700000004L, 0)
+                    .isAi(false)
+                    .authorId(10L)
+                    .description("旧简介")
+                    .fileName(1L)
+                    .seriesId(7L)
+                    .seriesOrder(1L)
+                    .build());
             pixivDatabase.saveArtworkTags(12345L, List.of(new TagDto(null, "旧标签", null)));
 
             pixivDatabase.refreshArtworkMetadataAfterDownload(12345L, "新标题", 2, true,
@@ -221,7 +251,7 @@ class PixivDatabaseTest {
         @Test
         @DisplayName("文件夹路径末尾斜杠应被去除")
         void shouldStripTrailingSlash() {
-            pixivDatabase.insertArtwork(33333L, "test", "/path/to/folder/", 1, "jpg", 1700000006L, 0);
+            insertArtwork(33333L, "test", "/path/to/folder/", 1, "jpg", 1700000006L, 0);
 
             ArtworkRecord record = pixivDatabase.getArtwork(33333L);
             assertThat(record.folder()).isEqualTo("/path/to/folder");
@@ -235,7 +265,7 @@ class PixivDatabaseTest {
     void shouldCheckArtworkExistence() {
         assertThat(pixivDatabase.hasArtwork(12345L)).isFalse();
 
-        pixivDatabase.insertArtwork(12345L, "test", "/path", 1, "jpg", 1700000010L, 0);
+        insertArtwork(12345L, "test", "/path", 1, "jpg", 1700000010L, 0);
 
         assertThat(pixivDatabase.hasArtwork(12345L)).isTrue();
     }
@@ -245,7 +275,7 @@ class PixivDatabaseTest {
     @Test
     @DisplayName("删除作品后应查询不到")
     void shouldDeleteArtwork() {
-        pixivDatabase.insertArtwork(12345L, "test", "/path", 1, "jpg", 1700000011L, 0);
+        insertArtwork(12345L, "test", "/path", 1, "jpg", 1700000011L, 0);
         assertThat(pixivDatabase.hasArtwork(12345L)).isTrue();
 
         pixivDatabase.deleteArtwork(12345L);
@@ -255,7 +285,7 @@ class PixivDatabaseTest {
     @Test
     @DisplayName("删除作品应一并清理标签关联与收藏夹关联")
     void shouldDeleteArtworkSatelliteRows() throws Exception {
-        pixivDatabase.insertArtwork(12345L, "test", "/path", 1, "jpg", 1700000011L, 0);
+        insertArtwork(12345L, "test", "/path", 1, "jpg", 1700000011L, 0);
         pixivDatabase.saveArtworkTags(12345L, List.of(new TagDto(null, "tag-a", null)));
         try (var conn = dataSource.getConnection(); var st = conn.createStatement()) {
             st.execute("INSERT INTO artwork_collections(collection_id, artwork_id, added_time) VALUES (1, 12345, 0)");
@@ -276,7 +306,7 @@ class PixivDatabaseTest {
     @Test
     @DisplayName("软删除标记后主行保留：hasArtwork 仍命中、hasActiveArtwork 不命中、记录带 deleted 标志")
     void shouldMarkArtworkDeletedKeepingRow() {
-        pixivDatabase.insertArtwork(12345L, "test", "/path", 1, "jpg", 1700000011L, 0);
+        insertArtwork(12345L, "test", "/path", 1, "jpg", 1700000011L, 0);
         assertThat(pixivDatabase.hasActiveArtwork(12345L)).isTrue();
         assertThat(pixivDatabase.isArtworkDeleted(12345L)).isFalse();
 
@@ -293,7 +323,7 @@ class PixivDatabaseTest {
     @Test
     @DisplayName("软删除标记应照旧清理标签关联与收藏夹关联")
     void shouldMarkArtworkDeletedAndCleanSatelliteRows() throws Exception {
-        pixivDatabase.insertArtwork(12345L, "test", "/path", 1, "jpg", 1700000011L, 0);
+        insertArtwork(12345L, "test", "/path", 1, "jpg", 1700000011L, 0);
         pixivDatabase.saveArtworkTags(12345L, List.of(new TagDto(null, "tag-a", null)));
         try (var conn = dataSource.getConnection(); var st = conn.createStatement()) {
             st.execute("INSERT INTO artwork_collections(collection_id, artwork_id, added_time) VALUES (1, 12345, 0)");
@@ -312,10 +342,10 @@ class PixivDatabaseTest {
     @Test
     @DisplayName("软删除的作品被重新下载落库后删除标记复位，记录被全新行替换")
     void shouldReviveDeletedArtworkOnReinsert() {
-        pixivDatabase.insertArtwork(12345L, "old", "/old", 1, "jpg", 1700000011L, 0);
+        insertArtwork(12345L, "old", "/old", 1, "jpg", 1700000011L, 0);
         pixivDatabase.markArtworkDeleted(12345L);
 
-        pixivDatabase.insertArtwork(12345L, "new", "/new", 2, "png", 1700000012L, 1);
+        insertArtwork(12345L, "new", "/new", 2, "png", 1700000012L, 1);
 
         ArtworkRecord record = pixivDatabase.getArtwork(12345L);
         assertThat(record).isNotNull();
@@ -328,9 +358,9 @@ class PixivDatabaseTest {
     @Test
     @DisplayName("未被软删除的已有记录重新插入时保持原行不被覆盖（INSERT OR IGNORE 语义不变）")
     void shouldKeepActiveRowOnReinsert() {
-        pixivDatabase.insertArtwork(12345L, "old", "/old", 1, "jpg", 1700000011L, 0);
+        insertArtwork(12345L, "old", "/old", 1, "jpg", 1700000011L, 0);
 
-        pixivDatabase.insertArtwork(12345L, "new", "/new", 2, "png", 1700000012L, 1);
+        insertArtwork(12345L, "new", "/new", 2, "png", 1700000012L, 1);
 
         ArtworkRecord record = pixivDatabase.getArtwork(12345L);
         assertThat(record).isNotNull();
@@ -341,8 +371,8 @@ class PixivDatabaseTest {
     @Test
     @DisplayName("软删除的作品不再出现在历史 ID 列表中")
     void shouldExcludeDeletedFromIdLists() {
-        pixivDatabase.insertArtwork(1L, "a", "/a", 1, "jpg", 1700000020L, 0);
-        pixivDatabase.insertArtwork(2L, "b", "/b", 1, "jpg", 1700000021L, 0);
+        insertArtwork(1L, "a", "/a", 1, "jpg", 1700000020L, 0);
+        insertArtwork(2L, "b", "/b", 1, "jpg", 1700000021L, 0);
         pixivDatabase.markArtworkDeleted(2L);
 
         assertThat(pixivDatabase.getAllArtworkIds()).containsExactly(1L);
@@ -354,9 +384,9 @@ class PixivDatabaseTest {
     @Test
     @DisplayName("获取所有作品ID")
     void shouldReturnAllArtworkIds() {
-        pixivDatabase.insertArtwork(1L, "a", "/a", 1, "jpg", 1700000020L, 0);
-        pixivDatabase.insertArtwork(2L, "b", "/b", 1, "jpg", 1700000021L, 0);
-        pixivDatabase.insertArtwork(3L, "c", "/c", 1, "jpg", 1700000022L, 0);
+        insertArtwork(1L, "a", "/a", 1, "jpg", 1700000020L, 0);
+        insertArtwork(2L, "b", "/b", 1, "jpg", 1700000021L, 0);
+        insertArtwork(3L, "c", "/c", 1, "jpg", 1700000022L, 0);
 
         List<Long> ids = pixivDatabase.getAllArtworkIds();
         assertThat(ids).containsExactlyInAnyOrder(1L, 2L, 3L);
@@ -367,9 +397,9 @@ class PixivDatabaseTest {
     @Test
     @DisplayName("按时间倒序排列")
     void shouldReturnIdsSortedByTimeDesc() {
-        pixivDatabase.insertArtwork(1L, "a", "/a", 1, "jpg", 1700000030L, 0);
-        pixivDatabase.insertArtwork(2L, "b", "/b", 1, "jpg", 1700000032L, 0);
-        pixivDatabase.insertArtwork(3L, "c", "/c", 1, "jpg", 1700000031L, 0);
+        insertArtwork(1L, "a", "/a", 1, "jpg", 1700000030L, 0);
+        insertArtwork(2L, "b", "/b", 1, "jpg", 1700000032L, 0);
+        insertArtwork(3L, "c", "/c", 1, "jpg", 1700000031L, 0);
 
         List<Long> ids = pixivDatabase.getArtworkIdsSortedByTimeDesc();
         assertThat(ids).containsExactly(2L, 3L, 1L);
@@ -381,7 +411,7 @@ class PixivDatabaseTest {
     @DisplayName("分页查询按时间倒序")
     void shouldReturnPagedResults() {
         for (int i = 1; i <= 20; i++) {
-            pixivDatabase.insertArtwork(i, "art" + i, "/path/" + i, 1, "jpg", 1700000040L + i, 0);
+            insertArtwork((long) i, "art" + i, "/path/" + i, 1, "jpg", 1700000040L + i, 0);
         }
 
         List<Long> page0 = pixivDatabase.getArtworkIdsSortedByTimeDescPaged(0, 5);
@@ -396,9 +426,9 @@ class PixivDatabaseTest {
     @Test
     @DisplayName("按作者排序分页时应将 null authorId 排在最后")
     void shouldReturnPagedResultsSortedByAuthorId() {
-        pixivDatabase.insertArtwork(1L, "a", "/a", 1, "jpg", 100L, 0, 20L);
-        pixivDatabase.insertArtwork(2L, "b", "/b", 1, "jpg", 200L, 0, null);
-        pixivDatabase.insertArtwork(3L, "c", "/c", 1, "jpg", 150L, 0, 10L);
+        pixivDatabase.insertArtwork(artwork(1L, "a", "/a", 1, "jpg", 100L, 0).authorId(20L).build());
+        pixivDatabase.insertArtwork(artwork(2L, "b", "/b", 1, "jpg", 200L, 0).build());
+        pixivDatabase.insertArtwork(artwork(3L, "c", "/c", 1, "jpg", 150L, 0).authorId(10L).build());
 
         List<Long> ids = pixivDatabase.getArtworkIdsSortedByAuthorIdAscPaged(0, 10);
 
@@ -408,8 +438,8 @@ class PixivDatabaseTest {
     @Test
     @DisplayName("应更新作品 authorId 并查询缺失 authorId 的记录")
     void shouldUpdateAndQueryMissingAuthorIds() {
-        pixivDatabase.insertArtwork(10L, "a", "/a", 1, "jpg", 1000L, 0, null);
-        pixivDatabase.insertArtwork(11L, "b", "/b", 1, "jpg", 1001L, 0, 88L);
+        pixivDatabase.insertArtwork(artwork(10L, "a", "/a", 1, "jpg", 1000L, 0).build());
+        pixivDatabase.insertArtwork(artwork(11L, "b", "/b", 1, "jpg", 1001L, 0).authorId(88L).build());
 
         assertThat(pixivDatabase.getArtworkIdsMissingAuthor()).containsExactly(10L);
 
@@ -426,8 +456,8 @@ class PixivDatabaseTest {
     void shouldCountArtworks() {
         assertThat(pixivDatabase.countArtworks()).isZero();
 
-        pixivDatabase.insertArtwork(1L, "a", "/a", 1, "jpg", 1700000050L, 0);
-        pixivDatabase.insertArtwork(2L, "b", "/b", 1, "jpg", 1700000051L, 0);
+        insertArtwork(1L, "a", "/a", 1, "jpg", 1700000050L, 0);
+        insertArtwork(2L, "b", "/b", 1, "jpg", 1700000051L, 0);
 
         assertThat(pixivDatabase.countArtworks()).isEqualTo(2);
     }
@@ -441,7 +471,7 @@ class PixivDatabaseTest {
         @Test
         @DisplayName("更新移动信息")
         void shouldUpdateMoveInfo() {
-            pixivDatabase.insertArtwork(12345L, "test", "/original/path", 1, "jpg", 1700000060L, 0);
+            insertArtwork(12345L, "test", "/original/path", 1, "jpg", 1700000060L, 0);
 
             pixivDatabase.updateArtworkMove(12345L, "/new/path", 1700000070L);
 
@@ -454,7 +484,7 @@ class PixivDatabaseTest {
         @Test
         @DisplayName("移动路径末尾斜杠应被去除")
         void shouldStripTrailingSlashOnMove() {
-            pixivDatabase.insertArtwork(12345L, "test", "/path", 1, "jpg", 1700000061L, 0);
+            insertArtwork(12345L, "test", "/path", 1, "jpg", 1700000061L, 0);
 
             pixivDatabase.updateArtworkMove(12345L, "/new/path/", 1700000071L);
 
@@ -465,8 +495,8 @@ class PixivDatabaseTest {
         @Test
         @DisplayName("传入 classifierTargetFolder 应把它注册为前缀，子目录共用 {N}/<seq>")
         void shouldRegisterClassifierTargetFolderAsPrefix() {
-            pixivDatabase.insertArtwork(701001L, "a", "/orig/a", 1, "jpg", 1700000400L, 0);
-            pixivDatabase.insertArtwork(701002L, "b", "/orig/b", 1, "jpg", 1700000401L, 0);
+            insertArtwork(701001L, "a", "/orig/a", 1, "jpg", 1700000400L, 0);
+            insertArtwork(701002L, "b", "/orig/b", 1, "jpg", 1700000401L, 0);
 
             String preset = "/cls/preset-root";
             // 多图先落到编号子目录，应被编码到同一个 preset 前缀下
@@ -483,8 +513,8 @@ class PixivDatabaseTest {
         @Test
         @DisplayName("移动到未注册路径时应自动注册前缀，下次同前缀子目录直接编码")
         void shouldAutoRegisterUnknownMoveTargetAsPrefix() {
-            pixivDatabase.insertArtwork(700001L, "a", "/orig/a", 1, "jpg", 1700000200L, 0);
-            pixivDatabase.insertArtwork(700002L, "b", "/orig/b", 1, "jpg", 1700000201L, 0);
+            insertArtwork(700001L, "a", "/orig/a", 1, "jpg", 1700000200L, 0);
+            insertArtwork(700002L, "b", "/orig/b", 1, "jpg", 1700000201L, 0);
 
             String firstTarget = "/dyn/added-after-startup";
             pixivDatabase.updateArtworkMove(700001L, firstTarget, 1700000300L);
@@ -506,7 +536,7 @@ class PixivDatabaseTest {
     @Test
     @DisplayName("通过移动路径查找作品")
     void shouldFindArtworkByMoveFolder() {
-        pixivDatabase.insertArtwork(12345L, "test", "/original", 1, "jpg", 1700000080L, 0);
+        insertArtwork(12345L, "test", "/original", 1, "jpg", 1700000080L, 0);
         pixivDatabase.updateArtworkMove(12345L, "/moved/12345", 1700000090L);
 
         ArtworkRecord record = pixivDatabase.getArtworkByMoveFolder("/moved/12345");
@@ -530,8 +560,8 @@ class PixivDatabaseTest {
     @Test
     @DisplayName("查找早于指定时间的作品")
     void shouldReturnArtworksOlderThan() {
-        pixivDatabase.insertArtwork(1L, "old", "/old", 1, "jpg", 1000L, 0);
-        pixivDatabase.insertArtwork(2L, "new", "/new", 1, "jpg", 2000L, 0);
+        insertArtwork(1L, "old", "/old", 1, "jpg", 1000L, 0);
+        insertArtwork(2L, "new", "/new", 1, "jpg", 2000L, 0);
 
         List<ArtworkRecord> old = pixivDatabase.getArtworksOlderThan(1500L);
         assertThat(old).hasSize(1);
@@ -588,15 +618,34 @@ class PixivDatabaseTest {
     @DisplayName("getUniqueTime 应返回不与已有记录冲突的时间戳")
     void shouldReturnUniqueTime() {
         long time1 = pixivDatabase.getUniqueTime();
-        pixivDatabase.insertArtwork(1L, "a", "/a", 1, "jpg", time1, 0);
+        insertArtwork(1L, "a", "/a", 1, "jpg", time1, 0);
 
         long time2 = pixivDatabase.getUniqueTime();
         assertThat(time2).isGreaterThanOrEqualTo(time1);
 
         // 确保 time2 与 time1 不冲突
-        pixivDatabase.insertArtwork(2L, "b", "/b", 1, "jpg", time2, 0);
+        insertArtwork(2L, "b", "/b", 1, "jpg", time2, 0);
         assertThat(pixivDatabase.hasArtwork(2L)).isTrue();
     }
+
+    private void insertArtwork(long artworkId, String title, String folder, int count,
+                               String extensions, long time, Integer xRestrict) {
+        pixivDatabase.insertArtwork(artwork(artworkId, title, folder, count, extensions, time, xRestrict).build());
+    }
+
+    private static InsertArtworkArgument.InsertArtworkArgumentBuilder artwork(
+            long artworkId, String title, String folder, int count,
+            String extensions, long time, Integer xRestrict) {
+        return InsertArtworkArgument.builder()
+                .artworkId(artworkId)
+                .title(title)
+                .folder(folder)
+                .count(count)
+                .extensions(extensions)
+                .time(time)
+                .xRestrict(xRestrict);
+    }
+
     @Test
     @DisplayName("重复初始化时不应因 authorId 列迁移失败")
     void shouldAllowRepeatedInit() {

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/core/download/ArtworkDownloadPortsAdapterTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/core/download/ArtworkDownloadPortsAdapterTest.java
@@ -7,6 +7,7 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.transaction.annotation.Transactional;
 import top.sywyar.pixivdownload.core.artwork.download.ArtworkDownloadCompletion;
 import top.sywyar.pixivdownload.core.db.ArtworkRecord;
+import top.sywyar.pixivdownload.core.db.InsertArtworkArgument;
 import top.sywyar.pixivdownload.core.db.PixivDatabase;
 import top.sywyar.pixivdownload.core.db.TagDto;
 import top.sywyar.pixivdownload.core.work.model.WorkTag;
@@ -18,7 +19,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -53,22 +53,22 @@ class ArtworkDownloadPortsAdapterTest {
 
         verify(pixivDatabase).getOrCreateFileNameTemplateId("{artwork_title}_p{page}");
         verify(pixivDatabase).getOrCreateFileAuthorNameId("author");
-        verify(pixivDatabase).insertArtwork(
-                42L,
-                "title",
-                tempDir.resolve("42").toAbsolutePath().toString(),
-                2,
-                "png,jpg",
-                303L,
-                1,
-                true,
-                84L,
-                "description",
-                5L,
-                6L,
-                7L,
-                8L
-        );
+        verify(pixivDatabase).insertArtwork(InsertArtworkArgument.builder()
+                .artworkId(42L)
+                .title("title")
+                .folder(tempDir.resolve("42").toAbsolutePath().toString())
+                .count(2)
+                .extensions("png,jpg")
+                .time(303L)
+                .xRestrict(1)
+                .isAi(true)
+                .authorId(84L)
+                .description("description")
+                .fileName(5L)
+                .fileAuthorNameId(6L)
+                .seriesId(7L)
+                .seriesOrder(8L)
+                .build());
         verify(pixivDatabase).refreshArtworkMetadataAfterDownload(
                 42L, "title", 1, true, 84L, "description", 5L, 6L, 7L, 8L);
         @SuppressWarnings("unchecked")
@@ -87,9 +87,7 @@ class ArtworkDownloadPortsAdapterTest {
         PixivDatabase pixivDatabase = mock(PixivDatabase.class);
         ArtworkDownloadHistoryAdapter adapter = new ArtworkDownloadHistoryAdapter(pixivDatabase);
         RuntimeException failure = new RuntimeException("insert failed");
-        doThrow(failure).when(pixivDatabase).insertArtwork(
-                anyLong(), any(), any(), anyInt(), any(), anyLong(), any(), any(),
-                any(), any(), anyLong(), any(), any(), any());
+        doThrow(failure).when(pixivDatabase).insertArtwork(any(InsertArtworkArgument.class));
 
         assertThatThrownBy(() -> adapter.record(sampleCompletion())).isSameAs(failure);
 
@@ -106,9 +104,7 @@ class ArtworkDownloadPortsAdapterTest {
 
         assertThatThrownBy(() -> adapter.record(sampleCompletion())).isSameAs(failure);
 
-        verify(pixivDatabase).insertArtwork(
-                anyLong(), any(), any(), anyInt(), any(), anyLong(), any(), any(),
-                any(), any(), anyLong(), any(), any(), any());
+        verify(pixivDatabase).insertArtwork(any(InsertArtworkArgument.class));
     }
 
     @Test
@@ -127,10 +123,22 @@ class ArtworkDownloadPortsAdapterTest {
                 0, false, null, " ", "{artwork_id}_p{page}", null,
                 null, null, null));
 
-        verify(pixivDatabase).insertArtwork(
-                42L, "旧标题", tempDir.resolve("42").toAbsolutePath().toString(),
-                2, "png,jpg", 303L, 2, true, 84L, "旧简介",
-                5L, 6L, 7L, 8L);
+        verify(pixivDatabase).insertArtwork(InsertArtworkArgument.builder()
+                .artworkId(42L)
+                .title("旧标题")
+                .folder(tempDir.resolve("42").toAbsolutePath().toString())
+                .count(2)
+                .extensions("png,jpg")
+                .time(303L)
+                .xRestrict(2)
+                .isAi(true)
+                .authorId(84L)
+                .description("旧简介")
+                .fileName(5L)
+                .fileAuthorNameId(6L)
+                .seriesId(7L)
+                .seriesOrder(8L)
+                .build());
         verify(pixivDatabase).refreshArtworkMetadataAfterDownload(
                 42L, null, null, null, null, null, 5L, null, null, null);
         verify(pixivDatabase).replaceArtworkTagsAfterDownload(42L, List.of());

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/core/download/ArtworkMetadataRecoveryServiceTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/core/download/ArtworkMetadataRecoveryServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.context.i18n.LocaleContextHolder;
 import top.sywyar.pixivdownload.author.AuthorService;
 import top.sywyar.pixivdownload.core.appconfig.DownloadConfig;
 import top.sywyar.pixivdownload.core.db.ArtworkRecord;
+import top.sywyar.pixivdownload.core.db.InsertArtworkArgument;
 import top.sywyar.pixivdownload.core.db.PixivDatabase;
 import top.sywyar.pixivdownload.core.download.request.RecoverMetadataRequest;
 import top.sywyar.pixivdownload.i18n.AppMessages;
@@ -71,8 +72,7 @@ class ArtworkMetadataRecoveryServiceTest {
 
             assertThat(result).isSameAs(existing);
             verify(pixivDatabase, never()).fillArtworkMetadataIfMissing(anyLong(), any(), any(), any(), any(), any());
-            verify(pixivDatabase, never()).insertArtwork(anyLong(), anyString(), anyString(), anyInt(),
-                    anyString(), anyLong(), any(), any(), any(), anyString());
+            verify(pixivDatabase, never()).insertArtwork(any(InsertArtworkArgument.class));
             verify(authorService, never()).observe(anyLong(), any());
         }
 
@@ -92,8 +92,7 @@ class ArtworkMetadataRecoveryServiceTest {
             assertThat(result).isSameAs(enriched);
             verify(pixivDatabase).fillArtworkMetadataIfMissing(eq(22222L), eq("新标题"),
                     eq(1), eq(true), eq(1234L), eq("新简介"));
-            verify(pixivDatabase, never()).insertArtwork(anyLong(), anyString(), anyString(), anyInt(),
-                    anyString(), anyLong(), any(), any(), any(), anyString());
+            verify(pixivDatabase, never()).insertArtwork(any(InsertArtworkArgument.class));
             verify(authorService).observe(1234L, "newauthor");
         }
 
@@ -114,8 +113,18 @@ class ArtworkMetadataRecoveryServiceTest {
             ArtworkRecord result = recoveryService.recoverMetadata(artworkId, req);
 
             assertThat(result).isSameAs(inserted);
-            verify(pixivDatabase).insertArtwork(artworkId, "Pixiv 标题", absolute, 2, "jpg",
-                    1700000300L, 1, true, 5678L, "简介");
+            verify(pixivDatabase).insertArtwork(InsertArtworkArgument.builder()
+                    .artworkId(artworkId)
+                    .title("Pixiv 标题")
+                    .folder(absolute)
+                    .count(2)
+                    .extensions("jpg")
+                    .time(1700000300L)
+                    .xRestrict(1)
+                    .isAi(true)
+                    .authorId(5678L)
+                    .description("简介")
+                    .build());
             verify(authorService).observe(5678L, "auth");
         }
 
@@ -130,8 +139,7 @@ class ArtworkMetadataRecoveryServiceTest {
                     "标题", 1234L, "auth", 0, false, "简介");
 
             assertThat(recoveryService.recoverMetadata(artworkId, req)).isNull();
-            verify(pixivDatabase, never()).insertArtwork(anyLong(), anyString(), anyString(), anyInt(),
-                    anyString(), anyLong(), any(), any(), any(), anyString());
+            verify(pixivDatabase, never()).insertArtwork(any(InsertArtworkArgument.class));
             verify(authorService, never()).observe(anyLong(), any());
         }
 
@@ -143,8 +151,7 @@ class ArtworkMetadataRecoveryServiceTest {
                     "标题", 1234L, "auth", 0, false, "简介");
 
             assertThat(recoveryService.recoverMetadata(44444L, req)).isNull();
-            verify(pixivDatabase, never()).insertArtwork(anyLong(), anyString(), anyString(), anyInt(),
-                    anyString(), anyLong(), any(), any(), any(), anyString());
+            verify(pixivDatabase, never()).insertArtwork(any(InsertArtworkArgument.class));
             verify(authorService, never()).observe(anyLong(), any());
         }
 
@@ -162,8 +169,15 @@ class ArtworkMetadataRecoveryServiceTest {
             ArtworkRecord result = recoveryService.recoverMetadata(artworkId, null);
 
             assertThat(result).isSameAs(inserted);
-            verify(pixivDatabase).insertArtwork(artworkId, "", absolute, 1, "jpg",
-                    1700000300L, null, null, null, "");
+            verify(pixivDatabase).insertArtwork(InsertArtworkArgument.builder()
+                    .artworkId(artworkId)
+                    .title("")
+                    .folder(absolute)
+                    .count(1)
+                    .extensions("jpg")
+                    .time(1700000300L)
+                    .description("")
+                    .build());
         }
     }
 }

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/core/download/DownloadedArtworkServiceTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/core/download/DownloadedArtworkServiceTest.java
@@ -14,6 +14,7 @@ import top.sywyar.pixivdownload.core.appconfig.DownloadConfig;
 import top.sywyar.pixivdownload.core.asset.StagedFileDeletion;
 import top.sywyar.pixivdownload.core.asset.artwork.ArtworkFileLocator;
 import top.sywyar.pixivdownload.core.db.ArtworkRecord;
+import top.sywyar.pixivdownload.core.db.InsertArtworkArgument;
 import top.sywyar.pixivdownload.core.db.PixivDatabase;
 import top.sywyar.pixivdownload.i18n.AppMessages;
 import top.sywyar.pixivdownload.i18n.TestI18nBeans;
@@ -177,8 +178,7 @@ class DownloadedArtworkServiceTest {
             ArtworkRecord result = downloadedArtworkService.getDownloadedRecord(11111L, false);
 
             assertThat(result).isNull();
-            verify(pixivDatabase, never()).insertArtwork(anyLong(), anyString(), anyString(), anyInt(),
-                    anyString(), anyLong(), any(), any(), any(), anyString());
+            verify(pixivDatabase, never()).insertArtwork(any(InsertArtworkArgument.class));
         }
 
         @Test
@@ -188,8 +188,7 @@ class DownloadedArtworkServiceTest {
             when(pixivDatabase.getArtwork(22222L)).thenReturn(null);
 
             assertThat(downloadedArtworkService.getDownloadedRecord(22222L, true)).isNull();
-            verify(pixivDatabase, never()).insertArtwork(anyLong(), anyString(), anyString(), anyInt(),
-                    anyString(), anyLong(), any(), any(), any(), anyString());
+            verify(pixivDatabase, never()).insertArtwork(any(InsertArtworkArgument.class));
         }
 
         @Test
@@ -198,8 +197,7 @@ class DownloadedArtworkServiceTest {
             when(pixivDatabase.getArtwork(33333L)).thenReturn(null);
 
             assertThat(downloadedArtworkService.getDownloadedRecord(33333L, true)).isNull();
-            verify(pixivDatabase, never()).insertArtwork(anyLong(), anyString(), anyString(), anyInt(),
-                    anyString(), anyLong(), any(), any(), any(), anyString());
+            verify(pixivDatabase, never()).insertArtwork(any(InsertArtworkArgument.class));
         }
 
         @Test
@@ -214,8 +212,7 @@ class DownloadedArtworkServiceTest {
             when(pixivDatabase.getArtwork(44444L)).thenReturn(null);
 
             assertThat(downloadedArtworkService.getDownloadedRecord(44444L, true)).isNull();
-            verify(pixivDatabase, never()).insertArtwork(anyLong(), anyString(), anyString(), anyInt(),
-                    anyString(), anyLong(), any(), any(), any(), anyString());
+            verify(pixivDatabase, never()).insertArtwork(any(InsertArtworkArgument.class));
         }
 
         @Test
@@ -232,8 +229,7 @@ class DownloadedArtworkServiceTest {
             ArtworkRecord result = downloadedArtworkService.getDownloadedRecord(artworkId, true);
 
             assertThat(result).isSameAs(inserted);
-            verify(pixivDatabase).insertArtwork(artworkId, "", absolute, 1, "jpg",
-                    1700000200L, null, null, null, "");
+            verify(pixivDatabase).insertArtwork(recoveredArtwork(artworkId, absolute, 1, "jpg"));
         }
 
         @Test
@@ -251,8 +247,7 @@ class DownloadedArtworkServiceTest {
 
             downloadedArtworkService.getDownloadedRecord(artworkId, true);
 
-            verify(pixivDatabase).insertArtwork(artworkId, "", absolute, 3, "png",
-                    1700000200L, null, null, null, "");
+            verify(pixivDatabase).insertArtwork(recoveredArtwork(artworkId, absolute, 3, "png"));
         }
 
         @Test
@@ -270,8 +265,7 @@ class DownloadedArtworkServiceTest {
             downloadedArtworkService.getDownloadedRecord(artworkId, true);
 
             // 按页号升序拼接 extensions（p0=jpg, p1=png）
-            verify(pixivDatabase).insertArtwork(artworkId, "", absolute, 2, "jpg,png",
-                    1700000200L, null, null, null, "");
+            verify(pixivDatabase).insertArtwork(recoveredArtwork(artworkId, absolute, 2, "jpg,png"));
         }
 
         @Test
@@ -284,8 +278,7 @@ class DownloadedArtworkServiceTest {
             when(pixivDatabase.getArtwork(artworkId)).thenReturn(null);
 
             assertThat(downloadedArtworkService.getDownloadedRecord(artworkId, true)).isNull();
-            verify(pixivDatabase, never()).insertArtwork(anyLong(), anyString(), anyString(), anyInt(),
-                    anyString(), anyLong(), any(), any(), any(), anyString());
+            verify(pixivDatabase, never()).insertArtwork(any(InsertArtworkArgument.class));
         }
 
         @Test
@@ -298,8 +291,7 @@ class DownloadedArtworkServiceTest {
             when(pixivDatabase.getArtwork(artworkId)).thenReturn(null);
 
             assertThat(downloadedArtworkService.getDownloadedRecord(artworkId, true)).isNull();
-            verify(pixivDatabase, never()).insertArtwork(anyLong(), anyString(), anyString(), anyInt(),
-                    anyString(), anyLong(), any(), any(), any(), anyString());
+            verify(pixivDatabase, never()).insertArtwork(any(InsertArtworkArgument.class));
         }
 
         @Test
@@ -315,8 +307,7 @@ class DownloadedArtworkServiceTest {
 
             downloadedArtworkService.getDownloadedRecord(artworkId, true);
 
-            verify(pixivDatabase).insertArtwork(artworkId, "", absolute, 1, "jpg",
-                    1700000200L, null, null, null, "");
+            verify(pixivDatabase).insertArtwork(recoveredArtwork(artworkId, absolute, 1, "jpg"));
         }
     }
 
@@ -359,5 +350,18 @@ class DownloadedArtworkServiceTest {
         List<String> result = downloadedArtworkService.getDownloadedRecord();
 
         assertThat(result).containsExactly("1", "2", "3");
+    }
+
+    private static InsertArtworkArgument recoveredArtwork(long artworkId, String folder,
+                                                            int count, String extensions) {
+        return InsertArtworkArgument.builder()
+                .artworkId(artworkId)
+                .title("")
+                .folder(folder)
+                .count(count)
+                .extensions(extensions)
+                .time(1700000200L)
+                .description("")
+                .build();
     }
 }

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/core/metadata/CoreWorkQueryServiceTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/core/metadata/CoreWorkQueryServiceTest.java
@@ -23,6 +23,7 @@ import top.sywyar.pixivdownload.core.db.schema.DatabaseInitializer;
 import top.sywyar.pixivdownload.core.db.pathprefix.PathPrefixCodec;
 import top.sywyar.pixivdownload.core.db.pathprefix.PathPrefixMapper;
 import top.sywyar.pixivdownload.core.db.PixivDatabase;
+import top.sywyar.pixivdownload.core.db.InsertArtworkArgument;
 import top.sywyar.pixivdownload.core.db.PixivMapper;
 import top.sywyar.pixivdownload.core.db.TagDto;
 import top.sywyar.pixivdownload.i18n.TestI18nBeans;
@@ -112,7 +113,16 @@ class CoreWorkQueryServiceTest {
     }
 
     private void insertArtwork(long id, long time, Long authorId) {
-        pixivDatabase.insertArtwork(id, "作品" + id, "/p/" + id, 1, "jpg", time, 0, null, authorId, null);
+        pixivDatabase.insertArtwork(InsertArtworkArgument.builder()
+                .artworkId(id)
+                .title("作品" + id)
+                .folder("/p/" + id)
+                .count(1)
+                .extensions("jpg")
+                .time(time)
+                .xRestrict(0)
+                .authorId(authorId)
+                .build());
     }
 
     private void insertNovel(long id, long time, Long authorId, Long seriesId) {

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/core/metadata/sidecar/WorkMetaBridgeConsistencyTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/core/metadata/sidecar/WorkMetaBridgeConsistencyTest.java
@@ -21,6 +21,7 @@ import top.sywyar.pixivdownload.core.appconfig.DownloadConfig;
 import top.sywyar.pixivdownload.core.asset.StagedFileDeletion;
 import top.sywyar.pixivdownload.core.asset.artwork.ArtworkFileLocator;
 import top.sywyar.pixivdownload.core.db.PixivDatabase;
+import top.sywyar.pixivdownload.core.db.InsertArtworkArgument;
 import top.sywyar.pixivdownload.core.db.PixivMapper;
 import top.sywyar.pixivdownload.core.db.pathprefix.PathPrefixCodec;
 import top.sywyar.pixivdownload.core.db.pathprefix.PathPrefixMapper;
@@ -187,8 +188,17 @@ class WorkMetaBridgeConsistencyTest {
         @DisplayName("插画：捕获后 upload_time/is_original 列投影与 sidecar normalized 逐字段一致")
         void artworkColumnAndSidecarAgree() {
             long id = 7L;
-            pixivDatabase.insertArtwork(id, "作品", artworkDir(id).toString(), 1, "jpg",
-                    1000L, 0, false, null, null, 1L);
+            pixivDatabase.insertArtwork(InsertArtworkArgument.builder()
+                    .artworkId(id)
+                    .title("作品")
+                    .folder(artworkDir(id).toString())
+                    .count(1)
+                    .extensions("jpg")
+                    .time(1000L)
+                    .xRestrict(0)
+                    .isAi(false)
+                    .fileName(1L)
+                    .build());
 
             captureService.captureArtwork(id, json("{\"uploadDate\":\"" + UPLOAD_ISO + "\",\"isOriginal\":true,"
                     + "\"description\":\"d\"}"), null, "schedule");
@@ -237,7 +247,17 @@ class WorkMetaBridgeConsistencyTest {
         void artworkSoftDeleteKeepsSidecarButFiltersColumnRead() {
             long id = 8L;
             Path dir = artworkDir(id);
-            pixivDatabase.insertArtwork(id, "作品", dir.toString(), 1, "jpg", 1000L, 0, false, null, null, 1L);
+            pixivDatabase.insertArtwork(InsertArtworkArgument.builder()
+                    .artworkId(id)
+                    .title("作品")
+                    .folder(dir.toString())
+                    .count(1)
+                    .extensions("jpg")
+                    .time(1000L)
+                    .xRestrict(0)
+                    .isAi(false)
+                    .fileName(1L)
+                    .build());
             captureService.captureArtwork(id, json("{\"uploadDate\":\"" + UPLOAD_ISO + "\",\"isOriginal\":true}"),
                     null, "schedule");
             assertThat(Files.exists(dir.resolve(id + ".meta.json"))).isTrue();


### PR DESCRIPTION
## 变更内容

- 使用同包不可变 `InsertArtworkArgument` 参数对象封装 `PixivDatabase.insertArtwork` 的作品写入参数。
- 显式校验必填字段，并保持默认文件名模板 ID、软删除复位及 `INSERT OR IGNORE` 语义不变。
- 迁移下载历史、元数据恢复及相关测试调用点，移除旧位置参数重载。

## 验证

- [x] 已同步安全审计修改合入后的最新 `master`
- [x] 已完成参数边界、原有行为与无关 diff 的复审整改
- [x] 已运行 `mvn -B -ntp -pl pixivdownload-official-plugins -am compile '-Dexec.skip=true'`
- [x] 已运行 `mvn -B -ntp test '-Dexec.skip=true' '-Duser.language=en' '-Duser.country=US'`
- [x] 当前 head 的 required checks 已全部通过
- [x] CHANGELOG 已判断：纯内部重构，无用户可见变化，不更新

## 关联

无
