### PR TITLE
refactor(i18n): 收缩本地 hooks 为提前反馈

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,49 +1,6 @@
 #!/usr/bin/env bash
-# Local pre-commit hook: i18n gate against the Git INDEX snapshot, judged by the
-# TRUSTED Epoch 3 gate anchor (never by the staged/candidate checker itself).
-#
-# Contract (never bypassable by fixing the worktree without staging):
-#   1. If nothing is staged, exit fast (0).
-#   2. The local anchor must belong to Gate Epoch 3:
-#      a. pixiv.i18n.trustedGateEpoch must be exactly 3 and
-#         pixiv.i18n.trustedGateRef must resolve to a commit;
-#         otherwise fail closed (obsolete / uninitialized epochs are never migrated);
-#      b. when the Epoch 3 root tag (refs/tags/i18n-gate-epoch-3-root) exists locally,
-#         the trusted ref must descend from it.
-#   3. The checker/contract/policy are the LOCAL TRUSTED ANCHOR's snapshots:
-#      a. The trusted gate bundle (scripts/i18n + scripts/hooks) is materialized
-#         from the trusted commit via an isolated temp index; unstaged or staged
-#         worktree checker edits can never change the verdict.
-#   4. The trusted checker runs the hardcoded-language guard in index snapshot
-#      mode (lightweight) for every commit; the FULL index snapshot check runs
-#      when staged files touch the i18n surface.
-#   5. When the staged diff touches gate files (the trusted gate-surface.json
-#      manifest: scripts/i18n/**, scripts/hooks/**, scripts/ci/**,
-#      scripts/sync-shared-snippets.ps1, .github/workflows/quality-gate.yml,
-#      shared-snippets-check.yml, release.yml, nightly.yml, publish-plugins.yml,
-#      package.json, package-lock.json), the trusted gate contract validates the
-#      CANDIDATE INDEX as a black box: candidate checker behavior, required paths
-#      (fail closed on deletion), candidate policy (gateEpoch unchanged,
-#      contractVersion never lowered, enforcement start never moved later,
-#      protected branches / workflow jobs / workflow files / package scripts /
-#      external checks never reduced), the candidate quality-gate.yml, external
-#      workflow (shared snippets / release / nightly / publish) and package.json
-#      scripts contracts, candidate hooks, and the candidate contract's
-#      self-protection. The candidate checker is only ever the OBJECT of these
-#      tests; it can never approve itself.
-#   6. The check reads ONLY the Git index snapshot; unstaged fixes never count.
-#   7. Never generates or modifies staged files; never runs accept; propagates
-#      non-zero exit codes.
-#   8. No tar / rsync / zip: materialization uses read-tree + checkout-index
-#      with a dedicated GIT_INDEX_FILE. Temp dirs live in system temp and are
-#      removed on exit (trap EXIT).
-#
-# Security boundary (documented, not overstated): local Git hooks are a
-# development convenience gate. A user can always modify the hook, modify
-# .git/config, or use --no-verify, so this hook is not claimed to be
-# absolutely unbypassable. The real final gate is the GitHub Ruleset / branch
-# protection / required check, and a trusted workflow or checker must never be
-# approved by the same candidate commit that proposes it.
+# Local early feedback for the staged snapshot. GitHub's protected verifier is
+# authoritative; this hook only reuses the repository checkers before commit.
 set -euo pipefail
 
 root="$(git rev-parse --show-toplevel)"
@@ -56,8 +13,6 @@ run_without_local_git_env() (
     "$@"
 )
 
-docs_hint="see README (online docs: https://sywyar.github.io/PixivDownloader/#/zh-cn/development)"
-
 staged="$(git diff --cached --name-only 2>/dev/null || true)"
 if [ -z "$staged" ]; then
     echo "pre-commit: nothing staged, skipping i18n check"
@@ -65,154 +20,25 @@ if [ -z "$staged" ]; then
 fi
 
 if ! command -v node >/dev/null 2>&1; then
-    echo "pre-commit: node is required for the i18n gate but was not found in PATH." >&2
-    echo "pre-commit: install Node.js ($docs_hint) and re-run the commit." >&2
+    echo "pre-commit: node is required for repository checks." >&2
     exit 1
 fi
 
-# ---- 1. Current trust anchor: missing / invalid epoch -> fail closed ----
-epoch="$(git config --local --get pixiv.i18n.trustedGateEpoch || true)"
-trusted="$(git config --local --get pixiv.i18n.trustedGateRef || true)"
-if [ -z "$trusted" ] || ! printf '%s' "$epoch" | grep -Eq '^[2-9][0-9]*$'; then
-    echo "pre-commit: Your local gate anchor belongs to an obsolete or uninitialized epoch." >&2
-    echo "pre-commit: Run the explicit current root adoption command." >&2
-    echo "pre-commit: this is a local convenience gate; the final gate is the GitHub required check." >&2
-    exit 1
-fi
-if ! git rev-parse --verify --quiet "$trusted^{commit}" >/dev/null 2>&1; then
-    echo "pre-commit: trusted gate anchor $trusted does not resolve to a commit in this repository." >&2
-    echo "pre-commit: restore or explicitly re-adopt the current root." >&2
-    exit 1
-fi
-# 本地已安装当前 root tag 时，anchor 必须包含该 root。
-root_tag="i18n-gate-epoch-${epoch}-root"
-if git rev-parse --verify --quiet "refs/tags/${root_tag}^{commit}" >/dev/null 2>&1; then
-    root_sha="$(git rev-parse --verify --quiet "refs/tags/${root_tag}^{commit}")"
-    if ! git merge-base --is-ancestor "$root_sha" "$trusted" >/dev/null 2>&1; then
-        echo "pre-commit: trusted anchor $trusted does not descend from the Gate Epoch $epoch trust root $root_sha." >&2
-        exit 1
-    fi
-fi
-
-tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/pixiv-i18n-precommit.XXXXXX")"
-cleanup() {
-    if [ -n "${tmpdir:-}" ] && [ -d "$tmpdir" ]; then
-        rm -rf "$tmpdir" || true
-    fi
-}
-trap cleanup EXIT
-
-# ---- 2. 物化 trusted anchor 的 gate bundle（scripts/i18n + scripts/hooks + scripts/ci + sync 脚本） ----
-materialize_trusted_gate() {
-    local out="$1"
-    local paths
-    paths="$(git ls-tree -r --name-only "$trusted" -- \
-        scripts/i18n scripts/hooks scripts/ci scripts/sync-shared-snippets.ps1 \
-        .github/workflows/quality-gate.yml .github/workflows/shared-snippets-check.yml \
-        .github/workflows/release.yml .github/workflows/nightly.yml \
-        .github/workflows/publish-plugins.yml package.json package-lock.json)"
-    if [ -z "$paths" ]; then
-        echo "pre-commit: trusted anchor $trusted does not contain the i18n gate bundle (scripts/i18n, scripts/hooks)." >&2
-        exit 1
-    fi
-    mkdir -p "$out"
-    GIT_INDEX_FILE="$tmpdir/trusted-index" git read-tree "$trusted"
-    printf '%s\n' "$paths" | GIT_INDEX_FILE="$tmpdir/trusted-index" \
-        git -c core.autocrlf=false checkout-index --stdin --prefix="$out/"
-    if [ ! -f "$out/scripts/i18n/check.mjs" ]; then
-        echo "pre-commit: trusted gate bundle is incomplete (scripts/i18n/check.mjs missing at $trusted); fail closed." >&2
-        exit 1
-    fi
-    if [ ! -f "$out/scripts/hooks/pre-push-guard.sh" ]; then
-        echo "pre-commit: trusted gate bundle is incomplete (scripts/hooks/pre-push-guard.sh missing at $trusted); fail closed." >&2
-        exit 1
-    fi
-    if [ ! -f "$out/scripts/i18n/gate-policy.json" ]; then
-        echo "pre-commit: trusted gate bundle is incomplete (scripts/i18n/gate-policy.json missing at $trusted); fail closed." >&2
-        exit 1
-    fi
-    if [ ! -f "$out/scripts/i18n/gate-contract.mjs" ]; then
-        echo "pre-commit: trusted gate bundle is incomplete (scripts/i18n/gate-contract.mjs missing at $trusted); fail closed." >&2
-        exit 1
-    fi
-}
-
-# ---- 3. 表面 / gate 变更检测 ----
-if printf '%s\n' "$staged" | grep -Eq '(^|/)(i18n/|locales\.json$|.*\.properties$|.*[Ii]18n.*\.(java|js|mjs)$|pixiv-i18n\.js$|pixiv-lang-switcher\.js$|scripts/i18n/|scripts/hooks/|i18n-static/)'; then
-    surface_changed=1
-else
-    surface_changed=0
-fi
-
-materialize_trusted_gate "$tmpdir/trusted"
-trusted_policy_epoch="$(node -e 'const fs=require("fs");const p=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));process.stdout.write(String(p.gateEpoch||""))' "$tmpdir/trusted/scripts/i18n/gate-policy.json")"
-if [ "$trusted_policy_epoch" != "$epoch" ]; then
-    echo "pre-commit: configured epoch $epoch does not match trusted anchor policy epoch $trusted_policy_epoch; fail closed." >&2
-    exit 1
-fi
-
-# A next-epoch root may be committed exactly once after the previous trusted verifier issues an
-# external ticket. It binds both epochs, the exact trusted source, its parent and its staged tree.
-admission_source_epoch="$(git config --local --get pixiv.i18n.firstAdmissionSourceEpoch || true)"
-admission_target_epoch="$(git config --local --get pixiv.i18n.firstAdmissionTargetEpoch || true)"
-admission_trusted_source="$(git config --local --get pixiv.i18n.firstAdmissionTrustedSource || true)"
-admission_parent="$(git config --local --get pixiv.i18n.firstAdmissionParent || true)"
-admission_tree="$(git config --local --get pixiv.i18n.firstAdmissionTree || true)"
-candidate_epoch="$(git show :scripts/i18n/gate-policy.json 2>/dev/null | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(String(JSON.parse(s).gateEpoch||""))}catch{}})')"
-current_parent="$(git rev-parse HEAD)"
-current_tree="$(git write-tree)"
-next_epoch="$((epoch + 1))"
-if [ "$admission_source_epoch" = "$epoch" ] && [ "$admission_target_epoch" = "$next_epoch" ] \
-    && [ "$candidate_epoch" = "$next_epoch" ] && [ "$admission_trusted_source" = "$trusted" ] \
-    && [ "$admission_parent" = "$trusted" ] && [ "$admission_parent" = "$current_parent" ] \
-    && [ "$admission_tree" = "$current_tree" ]; then
-    prepared_root=1
-else
-    prepared_root=0
-fi
-
-# ---- 2.5 trusted verifier 必须满足执行中 policy.minimumTrustedVerifier（能力只增不减） ----
-baseline_source="$root"
-if [ "$prepared_root" = "1" ]; then
-    baseline_source="$tmpdir/trusted"
-fi
-if ! node -e 'const fs=require("fs"),path=require("path"),source=process.argv[1],base=process.argv[2],sourceFile=path.join(source,"scripts/i18n/gate-policy.json"),b=JSON.parse(fs.readFileSync(path.join(base,"scripts/i18n/gate-policy.json"),"utf8")),p=fs.existsSync(sourceFile)?JSON.parse(fs.readFileSync(sourceFile,"utf8")):{},m=p.minimumTrustedVerifier||b.minimumTrustedVerifier;if(!m||!Number.isInteger(m.contractVersion)||!Number.isInteger(m.schemaVersion)||!Array.isArray(m.requiredFiles)||!m.requiredFiles.length)process.exit(1);if(!Number.isInteger(b.contractVersion)||b.contractVersion<m.contractVersion||!Number.isInteger(b.schemaVersion)||b.schemaVersion<m.schemaVersion)process.exit(1);for(const rel of m.requiredFiles){if(typeof rel!=="string"||!fs.existsSync(path.join(base,...rel.split("/"))))process.exit(1)}' "$baseline_source" "$tmpdir/trusted"; then
-    echo "pre-commit: trusted gate anchor $trusted does not satisfy the executing policy.minimumTrustedVerifier; OUTDATED GATE VERIFIER; fail closed." >&2
-    echo "pre-commit: advance or explicitly adopt a current Gate Epoch verifier." >&2
-    exit 1
-fi
-
-# gate 变更检测使用 trusted 的 gate-surface.json 单一清单（与 pre-push / contract / parity /
-# CI bootstrap 同一外围 Gate Surface）；baseline 已保证清单存在，不存在回退内置默认列表的路径。
-gate_re="$(node -e 'const fs=require("fs");const m=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));const esc=(p)=>p.replace(/[.*+?^${}()|[\]\\]/g,"\\$&");process.stdout.write((m.paths||[]).filter(p=>typeof p==="string").map(esc).map(p=>"^"+p+"(/|$)").join("|"))' "$tmpdir/trusted/scripts/ci/gate-surface.json")"
-if printf '%s\n' "$staged" | grep -Eq "$gate_re"; then
-    gate_changed=1
-else
-    gate_changed=0
-fi
-
-# ---- 4. trusted checker：轻量硬编码守卫总是执行（index 快照，不读工作树） ----
-echo "pre-commit: running trusted gate checker (hardcoded guard, index snapshot) from anchor $trusted..."
-node "$tmpdir/trusted/scripts/i18n/check.mjs" --repo-root "$root" --report-root "$root" \
+echo "pre-commit: checking the index snapshot..."
+node scripts/i18n/check.mjs --repo-root "$root" --report-root "$root" \
     --snapshot index --hardcoded-only
 
-# ---- 5. i18n 表面变化：trusted checker 完整 index 检查 ----
-if [ "$surface_changed" = "1" ]; then
-    echo "pre-commit: i18n files staged, running trusted gate checker (full index snapshot)..."
-    node "$tmpdir/trusted/scripts/i18n/check.mjs" --repo-root "$root" --report-root "$root" \
+if printf '%s\n' "$staged" \
+    | grep -Eq '(^|/)(i18n/|locales\.json$|.*\.properties$|.*[Ii]18n.*\.(java|js|mjs)$|pixiv-i18n\.js$|pixiv-lang-switcher\.js$|i18n-static/)'; then
+    node scripts/i18n/check.mjs --repo-root "$root" --report-root "$root" \
         --snapshot index
 fi
 
-# ---- 6. gate 文件变更：trusted contract 验证候选 index（candidate 不能自批准） ----
-if [ "$gate_changed" = "1" ]; then
-    if [ "$prepared_root" = "1" ]; then
-        echo "pre-commit: exact trusted first-admission Gate Epoch $candidate_epoch root candidate accepted for commit."
-    else
-        echo "pre-commit: gate files staged, running the trusted gate contract against the candidate index..."
-        run_without_local_git_env node "$tmpdir/trusted/scripts/i18n/gate-contract.mjs" \
-            --repo-root "$root" --report-root "$root" \
-            --candidate-snapshot index
-    fi
+gate_re="$(node -e 'const fs=require("fs");const m=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));const esc=(p)=>p.replace(/[.*+?^${}()|[\]\\]/g,"\\$&");process.stdout.write((m.paths||[]).filter(p=>typeof p==="string").map(esc).map(p=>"^"+p+"(/|$)").join("|"))' scripts/ci/gate-surface.json)"
+if printf '%s\n' "$staged" | grep -Eq "$gate_re"; then
+    echo "pre-commit: protected release surface staged, checking the index contract..."
+    run_without_local_git_env node scripts/i18n/gate-contract.mjs \
+        --repo-root "$root" --report-root "$root" --candidate-snapshot index
 fi
 
-echo "pre-commit: index snapshot i18n gate passed."
+echo "pre-commit: index snapshot checks passed."

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,64 +1,6 @@
 #!/usr/bin/env bash
-# Local pre-push hook: i18n gate + signature guard against the ACTUAL commits
-# being pushed (not the worktree), judged by the LOCAL TRUSTED EPOCH 4 ANCHOR.
-#
-# Git invokes pre-push with: $1 = remote name, $2 = remote URL; ref lines on
-# stdin: <local-ref> <local-sha> <remote-ref> <remote-sha>
-#
-# Trust model:
-# - The local anchor must belong to Gate Epoch 4 (pixiv.i18n.trustedGateEpoch == 4 +
-#   pixiv.i18n.trustedGateRef); obsolete / uninitialized epochs fail closed and are
-#   never migrated (no v1 / legacy / transition compatibility paths).
-# - When the Epoch 4 root tag (refs/tags/i18n-gate-epoch-4-root) exists locally,
-#   the trusted ref must descend from it.
-# - ALL pushed commits are checked by the TRUSTED anchor's checker, contract,
-#   policy and signature guard (materialized once from the trusted commit via
-#   an isolated temp index). A candidate ref's own checker/contract/guard is
-#   only ever the OBJECT of the trusted contract's black-box tests; it can
-#   never approve itself.
-# - When a pushed commit changes gate paths (scripts/i18n/**, scripts/hooks/**,
-#   scripts/ci/**, scripts/sync-shared-snippets.ps1, .github/workflows/*.yml in the
-#   gate surface, package.json, package-lock.json; the exact list comes from the
-#   trusted gate-surface.json manifest) relative to ANY parent, the trusted gate
-#   contract validates that commit (--candidate-ref). Intermediate commits that
-#   introduce a no-op checker fail even when a later commit fixes it; the branch
-#   tip's gate bundle is never the only thing checked.
-# - Enforcement boundary: only commits at/after the trusted policy's
-#   i18nEnforcementStartCommit run the i18n gate; a branch whose history does
-#   not include the enforcement root fails closed. Eligibility is decided PER
-#   COMMIT with `git merge-base --is-ancestor` (never by rev-list set
-#   inference). Tags pointing at pre-start history are exempt from the i18n
-#   gate but still run the signature guard.
-# - The final local tip of every ref line is ALWAYS checked, even when the
-#   computed range is empty (e.g. a non-fast-forward push after a remote
-#   advance): an empty range must never mean "nothing to check".
-# - Protected branches (trusted policy protectedBranches, e.g.
-#   refs/heads/master): the candidate tip must contain the current trusted
-#   anchor and the enforcement start; when the remote branch exists the push
-#   must be a fast-forward; force pushes (rewinding master to an old gate
-#   commit) are refused by default. Non-protected branches may rewrite history
-#   but still use the real remote state, check every actually-new commit, and
-#   always check the final tip.
-# - Real remote state: refs/remotes/<remote>/* are never trusted as remote
-#   truth. The hook queries the real remote (git ls-remote --heads --tags
-#   <remote_url>) and fetches needed refs into a unique temporary namespace
-#   refs/pixiv-i18n-prepush/<nonce>/; commit ranges are computed ONLY from
-#   that namespace (plus the server-provided remote sha from stdin). All temp
-#   refs are deleted on exit (including abnormal exit). If the remote cannot
-#   be queried or fetched, the hook conservatively scans ALL reachable commits
-#   of each pushed tip (never fewer checks).
-# - Commit SHAs are deduplicated by exact sha; every unique commit runs the
-#   trusted i18n check (when eligible) and the trusted signature guard, plus
-#   the trusted contract when it proposes gate changes.
-# - Deletions are skipped; refs that cannot be peeled to a commit are refused.
-# - Never invokes --no-verify; never pushes anything; no tar / rsync / zip.
-#
-# Security boundary (documented, not overstated): local Git hooks are a
-# development convenience gate. A user can always modify the hook, modify
-# .git/config, or use --no-verify, so this hook is not claimed to be
-# absolutely unbypassable. The real final gate is the GitHub Ruleset / branch
-# protection / required check, and a trusted workflow or checker must never be
-# approved by the same candidate commit that proposes it.
+# Local early feedback for refs being pushed. GitHub's protected verifier is
+# authoritative; this hook checks only each distinct pushed tip.
 set -euo pipefail
 
 root="$(git rev-parse --show-toplevel)"
@@ -71,147 +13,15 @@ run_without_local_git_env() (
     "$@"
 )
 
-remote_name="${1:-}"
-remote_url="${2:-}"
-if [ -z "$remote_name" ]; then
-    echo "pre-push: missing remote name argument ($# args received)." >&2
-    exit 1
-fi
-
-docs_hint="see README (online docs: https://sywyar.github.io/PixivDownloader/#/zh-cn/development)"
 zero="0000000000000000000000000000000000000000"
+saw_ref=0
+tips=()
 
-if ! command -v node >/dev/null 2>&1; then
-    echo "pre-push: node is required for the i18n gate but was not found in PATH." >&2
-    echo "pre-push: install Node.js ($docs_hint) and re-run the push." >&2
-    exit 1
-fi
-
-# ---- 1. Current trust anchor: missing / invalid epoch -> fail closed ----
-epoch="$(git config --local --get pixiv.i18n.trustedGateEpoch || true)"
-trusted="$(git config --local --get pixiv.i18n.trustedGateRef || true)"
-if [ -z "$trusted" ] || ! printf '%s' "$epoch" | grep -Eq '^[2-9][0-9]*$'; then
-    echo "pre-push: Your local gate anchor belongs to an obsolete or uninitialized epoch." >&2
-    echo "pre-push: Run the explicit current root adoption command." >&2
-    echo "pre-push: this is a local convenience gate; the final gate is the GitHub required check." >&2
-    exit 1
-fi
-if ! git rev-parse --verify --quiet "$trusted^{commit}" >/dev/null 2>&1; then
-    echo "pre-push: trusted gate anchor $trusted does not resolve to a commit in this repository." >&2
-    echo "pre-push: restore or explicitly re-adopt the current root." >&2
-    exit 1
-fi
-# 本地已安装当前 root tag 时，anchor 必须包含该 root
-root_tag="i18n-gate-epoch-${epoch}-root"
-if git rev-parse --verify --quiet "refs/tags/${root_tag}^{commit}" >/dev/null 2>&1; then
-    root_sha="$(git rev-parse --verify --quiet "refs/tags/${root_tag}^{commit}")"
-    if ! git merge-base --is-ancestor "$root_sha" "$trusted" >/dev/null 2>&1; then
-        echo "pre-push: trusted anchor $trusted does not descend from the Gate Epoch $epoch trust root $root_sha." >&2
-        exit 1
-    fi
-fi
-
-tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/pixiv-i18n-prepush.XXXXXX")"
-nonce="$$-$(date +%s)-$RANDOM"
-ns="refs/pixiv-i18n-prepush/$nonce"
-cleanup() {
-    if [ -n "$ns" ]; then
-        git for-each-ref --format='%(refname)' "$ns/" 2>/dev/null | while read -r r; do
-            git update-ref -d "$r" >/dev/null 2>&1 || true
-        done
-    fi
-    if [ -n "${tmpdir:-}" ] && [ -d "$tmpdir" ]; then
-        rm -rf "$tmpdir" || true
-    fi
-}
-trap cleanup EXIT
-
-# ---- 2. 物化 trusted anchor 的 gate bundle（一次） ----
-trusted_dir="$tmpdir/trusted"
-trusted_paths="$(git ls-tree -r --name-only "$trusted" -- \
-    scripts/i18n scripts/hooks scripts/ci scripts/sync-shared-snippets.ps1 \
-    .github/workflows/quality-gate.yml .github/workflows/shared-snippets-check.yml \
-    .github/workflows/release.yml .github/workflows/nightly.yml \
-    .github/workflows/publish-plugins.yml package.json package-lock.json)"
-if [ -z "$trusted_paths" ]; then
-    echo "pre-push: trusted anchor $trusted does not contain the i18n gate bundle (scripts/i18n, scripts/hooks)." >&2
-    exit 1
-fi
-mkdir -p "$trusted_dir"
-GIT_INDEX_FILE="$tmpdir/trusted-index" git read-tree "$trusted"
-printf '%s\n' "$trusted_paths" | GIT_INDEX_FILE="$tmpdir/trusted-index" \
-    git -c core.autocrlf=false checkout-index --stdin --prefix="$trusted_dir/"
-if [ ! -f "$trusted_dir/scripts/i18n/check.mjs" ]; then
-    echo "pre-push: trusted gate bundle is incomplete (scripts/i18n/check.mjs missing at $trusted); fail closed." >&2
-    exit 1
-fi
-if [ ! -f "$trusted_dir/scripts/hooks/pre-push-guard.sh" ]; then
-    echo "pre-push: trusted gate bundle is incomplete (scripts/hooks/pre-push-guard.sh missing at $trusted); fail closed." >&2
-    exit 1
-fi
-if [ ! -f "$trusted_dir/scripts/i18n/gate-policy.json" ]; then
-    echo "pre-push: trusted gate bundle is incomplete (scripts/i18n/gate-policy.json missing at $trusted); fail closed." >&2
-    echo "pre-push: current anchors always carry the gate policy; obsolete epochs are not migrated." >&2
-    exit 1
-fi
-if [ ! -f "$trusted_dir/scripts/i18n/gate-contract.mjs" ]; then
-    echo "pre-push: trusted gate bundle is incomplete (scripts/i18n/gate-contract.mjs missing at $trusted); fail closed." >&2
-    echo "pre-push: current anchors always carry the gate contract; obsolete epochs are not migrated." >&2
-    exit 1
-fi
-trusted_policy_epoch="$(node -e 'const fs=require("fs");const p=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));process.stdout.write(String(p.gateEpoch||""))' "$trusted_dir/scripts/i18n/gate-policy.json")"
-if [ "$trusted_policy_epoch" != "$epoch" ]; then
-    echo "pre-push: configured epoch $epoch does not match trusted anchor policy epoch $trusted_policy_epoch; fail closed." >&2
-    exit 1
-fi
-start="$(node -e 'const fs=require("fs");const p=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));process.stdout.write(p.i18nEnforcementStartCommit)' "$trusted_dir/scripts/i18n/gate-policy.json")"
-protected_list="$(node -e 'const fs=require("fs");const p=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));const list=(p.protectedBranches||[]).filter((r)=>typeof r==="string"&&r.startsWith("refs/heads/"));process.stdout.write(list.join("\n"))' "$trusted_dir/scripts/i18n/gate-policy.json")"
-if ! git rev-parse --verify --quiet "$start^{commit}" >/dev/null 2>&1; then
-    echo "pre-push: i18n enforcement start $start (from the trusted policy) does not resolve in this repository; fail closed." >&2
-    exit 1
-fi
-
-# ---- 2.5 trusted verifier 必须满足执行中 policy.minimumTrustedVerifier（能力只增不减） ----
-if ! node -e 'const fs=require("fs"),path=require("path"),source=process.argv[1],base=process.argv[2],sourceFile=path.join(source,"scripts/i18n/gate-policy.json"),b=JSON.parse(fs.readFileSync(path.join(base,"scripts/i18n/gate-policy.json"),"utf8")),p=fs.existsSync(sourceFile)?JSON.parse(fs.readFileSync(sourceFile,"utf8")):{},m=p.minimumTrustedVerifier||b.minimumTrustedVerifier;if(!m||!Number.isInteger(m.contractVersion)||!Number.isInteger(m.schemaVersion)||!Array.isArray(m.requiredFiles)||!m.requiredFiles.length)process.exit(1);if(!Number.isInteger(b.contractVersion)||b.contractVersion<m.contractVersion||!Number.isInteger(b.schemaVersion)||b.schemaVersion<m.schemaVersion)process.exit(1);for(const rel of m.requiredFiles){if(typeof rel!=="string"||!fs.existsSync(path.join(base,...rel.split("/"))))process.exit(1)}' "$root" "$trusted_dir"; then
-    echo "pre-push: trusted gate anchor $trusted does not satisfy the executing policy.minimumTrustedVerifier; OUTDATED GATE VERIFIER; fail closed." >&2
-    echo "pre-push: advance or explicitly adopt a current Gate Epoch verifier." >&2
-    exit 1
-fi
-
-# gate 变更检测使用 trusted 的 gate-surface.json 单一清单（与 pre-commit / contract / parity /
-# CI bootstrap 同一外围 Gate Surface）；baseline 已保证清单存在，不存在回退内置默认列表的路径。
-gate_re="$(node -e 'const fs=require("fs");const m=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));const esc=(p)=>p.replace(/[.*+?^${}()|[\]\\]/g,"\\$&");process.stdout.write((m.paths||[]).filter(p=>typeof p==="string").map(esc).map(p=>"^"+p+"(/|$)").join("|"))' "$trusted_dir/scripts/ci/gate-surface.json")"
-
-# ---- 3. 真实远端状态：ls-remote + 临时 namespace fetch（refs/remotes 不作数） ----
-remote_refs="$tmpdir/remote-refs"
-remote_ok=0
-if git ls-remote --heads --tags "$remote_url" > "$remote_refs" 2>/dev/null; then
-    if [ -s "$remote_refs" ]; then
-        if git fetch --no-tags "$remote_url" \
-            "+refs/heads/*:$ns/heads/*" "+refs/tags/*:$ns/tags/*" >/dev/null 2>&1; then
-            remote_ok=1
-        else
-            echo "pre-push: warning: cannot fetch real remote refs from $remote_url; conservatively scanning all reachable commits." >&2
-        fi
-    else
-        remote_ok=1
-    fi
-else
-    echo "pre-push: warning: cannot query remote $remote_url (ls-remote failed); conservatively scanning all reachable commits." >&2
-fi
-
-# ---- 4. 逐 ref 计算 commit 范围 + i18n 资格 ----
-pairs="$tmpdir/pairs"
-: > "$pairs"
-
-# stdin 先行落盘：真实 ref 行与"完全空 stdin"需要区分
-ref_lines="$tmpdir/ref-lines"
-cat > "$ref_lines" || true
-
-while read -r local_ref local_sha remote_ref remote_sha; do
+while read -r local_ref local_sha remote_ref remote_sha extra; do
     [ -n "$local_ref" ] || continue
-    if [ -z "$local_sha" ] || [ -z "$remote_ref" ] || [ -z "$remote_sha" ]; then
-        echo "pre-push: malformed ref line (expected 4 fields): $local_ref $local_sha $remote_ref $remote_sha" >&2
+    saw_ref=1
+    if [ -z "$local_sha" ] || [ -z "$remote_ref" ] || [ -z "$remote_sha" ] || [ -n "${extra:-}" ]; then
+        echo "pre-push: malformed ref line (expected 4 fields)." >&2
         exit 1
     fi
     if [ "$local_sha" = "$zero" ]; then
@@ -220,201 +30,44 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     fi
     commit_sha="$(git rev-parse --verify "$local_sha^{commit}" 2>/dev/null || true)"
     if [ -z "$commit_sha" ]; then
-        echo "pre-push: refusing to push $remote_ref: $local_sha is not a commit (or an annotated tag pointing at one)." >&2
-        echo "pre-push: non-commit refs cannot be scanned by the i18n gate; fix or drop the ref." >&2
+        echo "pre-push: $local_ref does not resolve to a commit." >&2
         exit 1
     fi
+    duplicate=0
+    for existing in "${tips[@]}"; do
+        [ "$existing" = "$commit_sha" ] && duplicate=1
+    done
+    [ "$duplicate" = "1" ] || tips+=("$commit_sha")
+done
 
-    # enforcement 边界：branch 必须包含 enforcement root（fail closed）；tag 可豁免 i18n（guard 仍执行）
-    eligible=1
-    if [ "${local_ref#refs/tags/}" != "$local_ref" ]; then
-        if ! git merge-base --is-ancestor "$start" "$commit_sha" >/dev/null 2>&1; then
-            eligible=0
-            echo "pre-push: tag $local_ref points at pre-enforcement history; i18n gate skipped (signature guard still runs)." >&2
-        fi
-    else
-        if ! git merge-base --is-ancestor "$start" "$commit_sha" >/dev/null 2>&1; then
-            echo "pre-push: FAILED — $local_ref: branch history does not include the i18n enforcement root $start." >&2
-            echo "pre-push: old pre-i18n history cannot be pushed through a normal branch; use a tag or rebase onto the enforcement root." >&2
-            exit 1
-        fi
-    fi
-
-    # 保护分支（trusted policy protectedBranches，如 refs/heads/master）：
-    # candidate tip 必须包含当前 trusted anchor 与 enforcement start；
-    # remote 分支已存在时必须 fast-forward；默认拒绝 force push（禁止把 master 回退到旧 gate commit）。
-    is_protected=0
-    if [ -n "$protected_list" ]; then
-        while read -r p; do
-            [ "$p" = "$remote_ref" ] && is_protected=1
-        done <<< "$protected_list"
-    fi
-    if [ "$is_protected" = "1" ]; then
-        if ! git merge-base --is-ancestor "$trusted" "$commit_sha" >/dev/null 2>&1; then
-            echo "pre-push: FAILED — $remote_ref is protected; the candidate tip $commit_sha does not contain the current trusted gate anchor $trusted." >&2
-            echo "pre-push: rewinding a protected branch to an old gate commit is refused." >&2
-            exit 1
-        fi
-        if ! git merge-base --is-ancestor "$start" "$commit_sha" >/dev/null 2>&1; then
-            echo "pre-push: FAILED — $remote_ref is protected; the candidate tip $commit_sha does not contain the i18n enforcement start $start." >&2
-            exit 1
-        fi
-        if [ "$remote_sha" != "$zero" ]; then
-            ff_base="$remote_sha"
-            if ! git cat-file -e "$remote_sha^{commit}" >/dev/null 2>&1; then
-                # server 提供的 remote sha 不在本地：用真实远端状态（临时 namespace）判定
-                ff_base="$(awk -v ref="$remote_ref" '$2==ref {print $1; exit}' "$remote_refs")"
-            fi
-            if [ -z "$ff_base" ] || ! git cat-file -e "$ff_base^{commit}" >/dev/null 2>&1; then
-                echo "pre-push: FAILED — $remote_ref is protected and its current remote tip cannot be resolved locally; refusing a blind push." >&2
-                exit 1
-            fi
-            if ! git merge-base --is-ancestor "$ff_base" "$commit_sha" >/dev/null 2>&1; then
-                echo "pre-push: FAILED — $remote_ref is protected; refusing a non-fast-forward (force) push from $ff_base to $commit_sha." >&2
-                echo "pre-push: rewinding the protected branch to an old gate commit is refused." >&2
-                exit 1
-            fi
-        fi
-    fi
-
-    # baseline：优先 server 提供的 remote sha（对象在本地）；否则用真实远端状态；否则保守全扫
-    baseline=""
-    if [ "$remote_sha" != "$zero" ] && git cat-file -e "$remote_sha^{commit}" >/dev/null 2>&1; then
-        baseline="$remote_sha"
-    else
-        if [ "$remote_sha" != "$zero" ]; then
-            echo "pre-push: remote sha $remote_sha for $remote_ref is not present locally; resolving the real remote state." >&2
-        fi
-        real_sha="$(awk -v ref="$remote_ref" '$2==ref {print $1; exit}' "$remote_refs")"
-        if [ -n "$real_sha" ] && git cat-file -e "$real_sha^{commit}" >/dev/null 2>&1; then
-            baseline="$real_sha"
-        fi
-    fi
-
-    if [ -n "$baseline" ]; then
-        range="$(git rev-list --reverse "$baseline..$local_sha" 2>/dev/null)"
-    elif [ "$remote_ok" = "1" ]; then
-        exclusions="$(git for-each-ref --format='%(refname)' "$ns/")"
-        if [ -n "$exclusions" ]; then
-            range="$(git rev-list --reverse "$commit_sha" --not $exclusions 2>/dev/null)"
-        else
-            range="$(git rev-list --reverse "$commit_sha")"
-        fi
-    else
-        range="$(git rev-list --reverse "$commit_sha")"
-    fi
-    # 逐 commit 资格：只有 enforcement start 真正是该 commit 祖先时（merge-base --is-ancestor）
-    # 才运行新 i18n checker；更早历史（含旧 tag 目标）只跑 signature guard。
-    while read -r sha; do
-        [ -n "$sha" ] || continue
-        flag=0
-        if [ "$eligible" = "1" ] && git merge-base --is-ancestor "$start" "$sha" >/dev/null 2>&1; then
-            flag=1
-        fi
-        printf '%s %s\n' "$sha" "$flag" >> "$pairs"
-    done <<< "$range"
-    # 最终 tip 始终检查（13.1）：无论 range 是否为空，local tip 都必须进入待检查集合
-    tip_flag=0
-    if [ "$eligible" = "1" ] && git merge-base --is-ancestor "$start" "$commit_sha" >/dev/null 2>&1; then
-        tip_flag=1
-    fi
-    printf '%s %s\n' "$commit_sha" "$tip_flag" >> "$pairs"
-done < "$ref_lines"
-
-# 完全空 stdin（git 在全部 ref 已 up-to-date 时不给任何 ref 行）≠ 无事可查：
-# 用真实远端状态保守检查 HEAD（可多检查，不能少检查）。删除分支推送仍有 ref 行，不受影响。
-if [ ! -s "$pairs" ] && [ ! -s "$ref_lines" ]; then
-    echo "pre-push: no ref lines from git (refs up-to-date); conservatively checking HEAD against the real remote state..." >&2
+if [ "$saw_ref" = "0" ]; then
     head_sha="$(git rev-parse --verify --quiet 'HEAD^{commit}' 2>/dev/null || true)"
-    if [ -n "$head_sha" ]; then
-        if [ "$remote_ok" = "1" ]; then
-            exclusions="$(git for-each-ref --format='%(refname)' "$ns/")"
-            if [ -n "$exclusions" ]; then
-                range="$(git rev-list --reverse "$head_sha" --not $exclusions 2>/dev/null)"
-            else
-                range="$(git rev-list --reverse "$head_sha")"
-            fi
-        else
-            range="$(git rev-list --reverse "$head_sha")"
-        fi
-        while read -r sha; do
-            [ -n "$sha" ] || continue
-            flag=0
-            if git merge-base --is-ancestor "$start" "$sha" >/dev/null 2>&1; then
-                flag=1
-            fi
-            printf '%s %s\n' "$sha" "$flag" >> "$pairs"
-        done <<< "$range"
-        tip_flag=0
-        if git merge-base --is-ancestor "$start" "$head_sha" >/dev/null 2>&1; then
-            tip_flag=1
-        fi
-        printf '%s %s\n' "$head_sha" "$tip_flag" >> "$pairs"
-    fi
+    [ -z "$head_sha" ] || tips+=("$head_sha")
 fi
 
-if [ ! -s "$pairs" ]; then
+if [ "${#tips[@]}" = "0" ]; then
     echo "pre-push: no commits to verify"
     exit 0
 fi
 
-# ---- 5. 精确 SHA 去重（同一 commit 多 ref 只检一次；eligible=1 优先） ----
-sort -k1,1 -k2,2nr "$pairs" | awk '!seen[$1]++' > "$pairs.dedup"
-count="$(wc -l < "$pairs.dedup" | tr -d ' ')"
-echo "pre-push: verifying $count pushed commit(s) against the trusted i18n gate (anchor $(git rev-parse --short "$trusted")) and signature guard (remote '$remote_name', $remote_url)..."
+if ! command -v node >/dev/null 2>&1; then
+    echo "pre-push: node is required for repository checks." >&2
+    exit 1
+fi
 
-    index=0
-    while read -r sha eligible; do
-        index=$((index + 1))
-        contract=0
-        if [ "$eligible" = "1" ]; then
-            parents="$(git rev-list --parents -n 1 "$sha" 2>/dev/null || true)"
-            rest="${parents#* }"
-            if [ -z "$rest" ]; then
-                contract=1
-            else
-                for p in $rest; do
-                    if git diff-tree --no-commit-id --name-only -r "$p" "$sha" 2>/dev/null \
-                        | grep -Eq "$gate_re"; then
-                        contract=1
-                        break
-                    fi
-                done
-            fi
-        fi
-        if [ "$contract" = "1" ] && ! git cat-file -e "$sha:scripts/i18n/gate-policy.json" >/dev/null 2>&1; then
-            contract=0
-        fi
+gate_re="$(node -e 'const fs=require("fs");const m=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));const esc=(p)=>p.replace(/[.*+?^${}()|[\]\\]/g,"\\$&");process.stdout.write((m.paths||[]).filter(p=>typeof p==="string").map(esc).map(p=>"^"+p+"(/|$)").join("|"))' scripts/ci/gate-surface.json)"
 
-        echo "pre-push: [$index/$count] checking commit $sha (trusted gate)..."
-        if [ "$eligible" = "1" ]; then
-            if ! node "$trusted_dir/scripts/i18n/check.mjs" --repo-root "$root" --report-root "$root" \
-                --snapshot ref --ref "$sha" >"$tmpdir/check-$sha.log" 2>&1; then
-                echo "pre-push: FAILED — commit $sha does not pass the i18n gate (trusted checker from anchor $trusted)." >&2
-                echo "pre-push: full diagnostics:" >&2
-                cat "$tmpdir/check-$sha.log" >&2
-                echo "pre-push: report: build/reports/i18n/report.json (snapshotRef=$sha)" >&2
-                echo "pre-push: run locally: node scripts/i18n/check.mjs --snapshot ref --ref $sha" >&2
-                exit 1
-            fi
-        fi
-        if ! bash "$trusted_dir/scripts/hooks/pre-push-guard.sh" --repo-root "$root" --ref "$sha" \
-            >"$tmpdir/guard-$sha.log" 2>&1; then
-            echo "pre-push: FAILED — commit $sha does not pass the signature guard (guard from anchor $trusted)." >&2
-            cat "$tmpdir/guard-$sha.log" >&2
-            exit 1
-        fi
-        if [ "$contract" = "1" ]; then
-            echo "pre-push: commit $sha proposes gate changes; running the trusted gate contract..."
-            if ! run_without_local_git_env node "$trusted_dir/scripts/i18n/gate-contract.mjs" \
-                --repo-root "$root" --report-root "$root" \
-                --candidate-ref "$sha" >"$tmpdir/contract-$sha.log" 2>&1; then
-                echo "pre-push: FAILED — commit $sha does not pass the trusted gate contract (candidate gate cannot self-approve)." >&2
-                cat "$tmpdir/contract-$sha.log" >&2
-                echo "pre-push: report: build/reports/i18n/contract.json (candidateRef=$sha)" >&2
-                exit 1
-            fi
-        fi
-    done < "$pairs.dedup"
+for sha in "${tips[@]}"; do
+    echo "pre-push: checking tip $sha..."
+    node scripts/i18n/check.mjs --repo-root "$root" --report-root "$root" \
+        --snapshot ref --ref "$sha"
+    bash scripts/hooks/pre-push-guard.sh --repo-root "$root" --ref "$sha"
+    if git diff-tree --root --no-commit-id --name-only -r -m "$sha" \
+        | grep -Eq "$gate_re"; then
+        echo "pre-push: protected release surface changed, checking the tip contract..."
+        run_without_local_git_env node scripts/i18n/gate-contract.mjs \
+            --repo-root "$root" --report-root "$root" --candidate-ref "$sha"
+    fi
+done
 
-echo "pre-push: all $count pushed commit(s) pass the i18n gate and the signature guard."
+echo "pre-push: pushed tip checks passed."

--- a/scripts/i18n/test/hooks-hardening.test.mjs
+++ b/scripts/i18n/test/hooks-hardening.test.mjs
@@ -1,12 +1,9 @@
 'use strict';
 /**
- * i18n 门禁加固回归测试（第二批）：
+ * i18n 门禁加固回归测试：
  * - accept：核心库 runAcceptCore 与 CLI 边界策略分离；CI=true 拒绝危险参数；
  * - disabled 语言拒绝 accept / 不进 bootstrap / prune 清理历史条目；
  * - --bootstrap --force 重建完整基线（不保留 orphan / candidate / disabled / 已删 key / 未知 locale）；
- * - pre-commit 不可变 checker：工作树 / 暂存 checker 篡改都不改变 HEAD checker 判定；
- * - pre-push：双远端新分支漏检、checker 来自待推送 ref tip、tag / force push / 多 ref 去重、
- *   remote SHA 不在本地、失败输出包含真实诊断、无 tar / 无 --remotes=*；
  * - doctor：Windows 平台 bash 检查（存在 / 缺失 / 语法错误）；
  * - docs：tracked Markdown 相对链接目标存在；hooks 不引用不存在的本地文档；
  * - snapshot-cli：materialize-index / materialize-ref / materialize-paths。
@@ -28,8 +25,7 @@ import staleLock from '../lib/stale-lock.mjs';
 const SCRIPTS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const REPO_ROOT = path.resolve(SCRIPTS_DIR, '..', '..');
 
-// pre-push/pre-commit 内的 trusted contract 使用 yaml：fixture 仓库没有 node_modules，
-// 通过 NODE_PATH 指向真实仓库的 node_modules（与 CI 的 npm ci 等价），子进程继承该环境。
+// 临时 verifier fixture 使用 yaml；通过 NODE_PATH 复用当前仓库锁定的依赖。
 process.env.NODE_PATH = process.env.NODE_PATH || path.join(REPO_ROOT, 'node_modules');
 
 const CATALOG = `{
@@ -50,7 +46,6 @@ const CATALOG = `{
 const APP_I18N = path.join('pixivdownload-app', 'src', 'main', 'resources', 'i18n');
 const GOOD_ZH = 'greeting=你好 {name}\ntitle=作品标题\n';
 const GOOD_EN = 'greeting=Hello {name}\ntitle=Artwork title\n';
-const BAD_EN = 'greeting=Hello {wrong}\ntitle=Artwork title\n';
 const GOOD_JA = 'greeting=こんにちは {name}\ntitle=タイトル\n';
 
 function git(args, cwd, opts = {}) {
@@ -59,10 +54,6 @@ function git(args, cwd, opts = {}) {
         throw new Error('git ' + args.join(' ') + ' failed: ' + (result.stderr || result.stdout));
     }
     return result;
-}
-
-function bash(args, cwd, opts = {}) {
-    return spawnSync('bash', args, { cwd, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, ...opts });
 }
 
 function hasBash() {
@@ -141,15 +132,6 @@ function writeBundles(root, zh, en) {
 function writeExtra(root, rel, content) {
     fs.writeFileSync(path.join(root, APP_I18N, 'web', rel), content, 'utf8');
     runGenerate(root);
-}
-
-function commitAll(root, message, opts = {}) {
-    git(['add', '-A'], root);
-    if (opts.bypass) {
-        git(['-c', 'core.hooksPath=/dev/null', 'commit', '-q', '-m', message], root);
-    } else {
-        git(['commit', '-q', '-m', message], root);
-    }
 }
 
 function cleanRepo(root) {
@@ -316,392 +298,6 @@ test('--bootstrap --force：重建完整基线，只保留当前 supported 的�
     } finally {
         cleanRepo(root);
     }
-});
-
-// ---------------------------------------------------------------------------
-// pre-commit：不可变 checker
-// ---------------------------------------------------------------------------
-
-function tamperChecker(root, body) {
-    fs.writeFileSync(path.join(root, 'scripts', 'i18n', 'check.mjs'), body, 'utf8');
-}
-
-const EXIT_ZERO_CHECKER = '#!/usr/bin/env node\nprocess.exit(0);\n';
-
-test('pre-commit：index 坏翻译 + 工作树 checker 篡改为 exit 0 → 必须失败（trusted checker 判定）', () => {
-    if (!hasBash()) {
-        test.skip('bash 不可用');
-        return;
-    }
-    const root = makeGitRepo();
-    try {
-        writeBundles(root, GOOD_ZH, BAD_EN);
-        git(['add', '-A'], root);
-        // 篡改工作树 check.mjs（不暂存）——不得改变判定
-        tamperChecker(root, EXIT_ZERO_CHECKER);
-        const result = bash(['scripts/hooks/pre-commit'], root);
-        assert.notEqual(result.status, 0, 'index 是坏翻译，工作树篡改 checker 不得放行');
-        assert.match(result.stdout + result.stderr, /trusted gate checker/);
-        assert.match(result.stdout + result.stderr, /I18N CHECK FAILED|FAILED/);
-        // 工作树篡改仍在（pre-commit 不得修改文件）
-        assert.equal(fs.readFileSync(path.join(root, 'scripts', 'i18n', 'check.mjs'), 'utf8'), EXIT_ZERO_CHECKER);
-    } finally {
-        cleanRepo(root);
-    }
-});
-
-test('pre-commit：index 暂存 exit-0 checker + 坏翻译 → trusted checker 仍然失败', () => {
-    if (!hasBash()) {
-        test.skip('bash 不可用');
-        return;
-    }
-    const root = makeGitRepo();
-    try {
-        tamperChecker(root, EXIT_ZERO_CHECKER);
-        writeBundles(root, GOOD_ZH, BAD_EN);
-        git(['add', '-A'], root); // 坏翻译 + 篡改 checker 一起暂存
-        const result = bash(['scripts/hooks/pre-commit'], root);
-        assert.notEqual(result.status, 0, '暂存 exit-0 checker 不得让坏翻译通过');
-        assert.match(result.stdout + result.stderr, /trusted gate checker/);
-    } finally {
-        cleanRepo(root);
-    }
-});
-
-test('pre-commit：trusted checker 与 gate contract 都正常 → 通过；i18n 表面变化触发完整检查', () => {
-    if (!hasBash()) {
-        test.skip('bash 不可用');
-        return;
-    }
-    const root = makeGitRepo();
-    try {
-        writeBundles(root, GOOD_ZH + 'status=状态\n', GOOD_EN + 'status=Status\n');
-        runGenerate(root);
-        const accept = runAcceptCore(root, { locale: 'en-US' });
-        assert.equal(accept.ok, true);
-        git(['add', '-A'], root);
-        const result = bash(['scripts/hooks/pre-commit'], root);
-        assert.equal(result.status, 0, result.stdout + result.stderr);
-        assert.match(result.stdout, /trusted gate checker/);
-    } finally {
-        cleanRepo(root);
-    }
-});
-
-test('pre-commit：合法 gate 升级（暂存合法增强的 checker）→ trusted contract 通过', () => {
-    if (!hasBash()) {
-        test.skip('bash 不可用');
-        return;
-    }
-    const root = makeGitRepo();
-    try {
-        // 在 check.mjs 末尾追加一行无副作用注释（checker 行为不变，contract 必须通过）
-        const checkerPath = path.join(root, 'scripts', 'i18n', 'check.mjs');
-        const original = fs.readFileSync(checkerPath, 'utf8');
-        fs.writeFileSync(checkerPath, original + '\n// staged enhancement\n', 'utf8');
-        // 同时暂存一个普通业务文件变化，触发 pre-commit（checker 变化 → trusted contract 必须运行）
-        fs.mkdirSync(path.join(root, 'pixivdownload-app', 'src', 'main', 'resources', 'static', 'js'), { recursive: true });
-        fs.writeFileSync(path.join(root, 'pixivdownload-app', 'src', 'main', 'resources', 'static', 'js', 'x.js'),
-            'var x = 1;\n', 'utf8');
-        git(['add', '-A'], root);
-        const result = bash(['scripts/hooks/pre-commit'], root);
-        assert.equal(result.status, 0, result.stdout + result.stderr);
-        assert.match(result.stdout, /GATE CONTRACT OK|running the trusted gate contract/);
-    } finally {
-        cleanRepo(root);
-    }
-});
-
-// ---------------------------------------------------------------------------
-// pre-push：ref / remote 处理
-// ---------------------------------------------------------------------------
-
-test('pre-push：双远端 —— upstream 已有坏 commit、origin 没有；推 origin 拦截、推 upstream 只检增量', () => {
-    if (!hasBash()) {
-        test.skip('bash 不可用');
-        return;
-    }
-    const root = makeGitRepo();
-    const upstream = path.join(os.tmpdir(), 'pixiv bare upstream ' + Date.now());
-    const origin = path.join(os.tmpdir(), 'pixiv bare origin ' + Date.now());
-    try {
-        fs.mkdirSync(upstream);
-        fs.mkdirSync(origin);
-        git(['init', '-q', '--bare', upstream], root);
-        git(['init', '-q', '--bare', origin], root);
-        git(['remote', 'add', 'upstream', upstream], root);
-        git(['remote', 'add', 'origin', origin], root);
-
-        // A = 坏 commit，先以「无 hooks 的远端机器」身份进入 upstream
-        writeBundles(root, GOOD_ZH, BAD_EN);
-        commitAll(root, 'A bad', { bypass: true });
-        const seed = git(['-c', 'core.hooksPath=/dev/null', 'push', 'upstream', 'master'], root, { allowFailure: true });
-        assert.equal(seed.status, 0, seed.stdout + seed.stderr);
-        // B = 修复 commit（仅本地）
-        writeBundles(root, GOOD_ZH, GOOD_EN);
-        commitAll(root, 'B good', { bypass: true });
-
-        // 推 origin：origin 没有任何 tracking ref → 保守检查全部可达 → 命中 A
-        const pushOrigin = git(['push', 'origin', 'master'], root, { allowFailure: true });
-        assert.notEqual(pushOrigin.status, 0, 'A 不在 origin 上，pre-push 必须拦截');
-        assert.match(pushOrigin.stdout + pushOrigin.stderr, /does not pass the i18n gate/);
-        assert.match(pushOrigin.stdout + pushOrigin.stderr, /I18N CHECK FAILED|missing key|placeholder/);
-
-        // 推 upstream：目标 remote 参数生效 → remote_sha=A 已知 → 只检增量 {B}
-        const pushUpstream = git(['push', 'upstream', 'master'], root, { allowFailure: true });
-        assert.equal(pushUpstream.status, 0, pushUpstream.stdout + pushUpstream.stderr);
-        assert.match(pushUpstream.stdout + pushUpstream.stderr, /all \d+ pushed commit/);
-
-        // 新分支（origin 上不存在、包含 A）→ 仍必须拦截
-        git(['checkout', '-q', '-b', 'feature'], root);
-        const pushFeature = git(['push', 'origin', 'feature'], root, { allowFailure: true });
-        assert.notEqual(pushFeature.status, 0, '新分支包含 origin 不可达的坏 commit，必须拦截');
-        assert.match(pushFeature.stdout + pushFeature.stderr, /does not pass the i18n gate/);
-
-        // origin 必须没有任何更新
-        const lsRemote = git(['ls-remote', origin], root);
-        assert.equal(lsRemote.stdout.trim(), '');
-    } finally {
-        cleanRepo(root);
-        fs.rmSync(upstream, { recursive: true, force: true });
-        fs.rmSync(origin, { recursive: true, force: true });
-    }
-});
-
-test('pre-push：candidate tip checker = exit(0)（自批准尝试）→ 必须失败；候选 checker 只作为被检查对象', () => {
-    if (!hasBash()) {
-        test.skip('bash 不可用');
-        return;
-    }
-    const root = makeGitRepo();
-    const remote = path.join(os.tmpdir(), 'pixiv bare remote ' + Date.now());
-    try {
-        fs.mkdirSync(remote);
-        git(['init', '-q', '--bare', remote], root);
-        git(['remote', 'add', 'origin', remote], root);
-
-        // 分支 other：tip 的 checker 被篡改为 exit 0 且历史含坏翻译
-        git(['checkout', '-q', '-b', 'other'], root);
-        tamperChecker(root, EXIT_ZERO_CHECKER);
-        writeBundles(root, GOOD_ZH, BAD_EN);
-        commitAll(root, 'tampered checker + bad translation', { bypass: true });
-
-        // 停留在 master（HEAD 是正常 checker）推送 other → 必须失败：
-        // 候选 ref 自带 no-op checker 不能自我批准（trusted anchor checker/contract 判定）
-        git(['checkout', '-q', 'master'], root);
-        const push = git(['push', 'origin', 'other'], root, { allowFailure: true });
-        assert.notEqual(push.status, 0, '篡改后的分支 checker 必须不能放行: ' + push.stdout + push.stderr);
-        assert.match(push.stdout + push.stderr, /trusted gate/);
-        assert.match(push.stdout + push.stderr, /does not pass the i18n gate|GATE CONTRACT FAILED/);
-
-        // 对照组：分支 other2 用正常 checker + 坏翻译 → 同样被 trusted checker 拦截
-        git(['checkout', '-q', 'other'], root);
-        git(['checkout', '-q', '-b', 'other2'], root);
-        git(['checkout', '-q', 'master'], root);
-        git(['branch', '-D', 'other'], root);
-        // 在 other2 上恢复 master 的真实 checker（此前 other 分支篡改了它），并写入不同的坏翻译
-        git(['checkout', '-q', 'other2'], root);
-        git(['checkout', 'master', '--', 'scripts/i18n/check.mjs'], root);
-        writeBundles(root, GOOD_ZH, 'greeting=Hello {wrong2}\ntitle=Artwork title\n');
-        commitAll(root, 'good checker + bad translation', { bypass: true });
-        const blocked = git(['push', 'origin', 'other2'], root, { allowFailure: true });
-        assert.notEqual(blocked.status, 0, '正常 checker 的分支坏翻译必须被拦截');
-        assert.match(blocked.stdout + blocked.stderr, /does not pass the i18n gate/);
-    } finally {
-        cleanRepo(root);
-        fs.rmSync(remote, { recursive: true, force: true });
-    }
-});
-
-test('pre-push：candidate tip contract = exit(0)（自批准尝试）→ trusted contract 必须拒绝', () => {
-    if (!hasBash()) {
-        test.skip('bash 不可用');
-        return;
-    }
-    const root = makeGitRepo();
-    const remote = path.join(os.tmpdir(), 'pixiv bare remote ' + Date.now());
-    try {
-        fs.mkdirSync(remote);
-        git(['init', '-q', '--bare', remote], root);
-        git(['remote', 'add', 'origin', remote], root);
-
-        // 分支 noopc：candidate gate-contract.mjs = exit(0)（checker 正常、翻译合法）
-        git(['checkout', '-q', '-b', 'noopc'], root);
-        fs.writeFileSync(path.join(root, 'scripts', 'i18n', 'gate-contract.mjs'),
-            '#!/usr/bin/env node\nprocess.exit(0);\n', 'utf8');
-        commitAll(root, 'noop contract', { bypass: true });
-        git(['checkout', '-q', 'master'], root);
-
-        const push = git(['push', 'origin', 'noopc'], root, { allowFailure: true });
-        assert.notEqual(push.status, 0, 'no-op contract 必须被 trusted contract 拒绝（不能保护下一次升级）');
-        assert.match(push.stdout + push.stderr, /does not pass the trusted gate contract|GATE CONTRACT FAILED/);
-    } finally {
-        cleanRepo(root);
-        fs.rmSync(remote, { recursive: true, force: true });
-    }
-});
-
-test('pre-push：candidate signature guard = exit(0) + 标记 commit → trusted guard 仍发现', () => {
-    if (!hasBash()) {
-        test.skip('bash 不可用');
-        return;
-    }
-    const root = makeGitRepo();
-    const remote = path.join(os.tmpdir(), 'pixiv bare remote ' + Date.now());
-    try {
-        fs.mkdirSync(remote);
-        git(['init', '-q', '--bare', remote], root);
-        git(['remote', 'add', 'origin', remote], root);
-
-        // 分支 noguard：candidate pre-push-guard.sh = exit(0) + 新增标记（动态拼接，测试源不含字面量，
-        // 避免 signature guard 自身扫描测试文件时误报——guard 只豁免 scripts/i18n/test/hooks.test.mjs）
-        git(['checkout', '-q', '-b', 'noguard'], root);
-        fs.writeFileSync(path.join(root, 'scripts', 'hooks', 'pre-push-guard.sh'),
-            '#!/usr/bin/env bash\nexit 0\n', 'utf8');
-        const badJavaDir = path.join(root, 'pixivdownload-app', 'src', 'main', 'java');
-        fs.mkdirSync(badJavaDir, { recursive: true });
-        const marker = 'DouyinXBogus' + 'Signer';
-        fs.writeFileSync(path.join(badJavaDir, 'Bad.java'),
-            'class Bad { String s = "' + marker + '"; }\n', 'utf8');
-        commitAll(root, 'guard noop + marker', { bypass: true });
-        git(['checkout', '-q', 'master'], root);
-
-        const push = git(['push', 'origin', 'noguard'], root, { allowFailure: true });
-        assert.notEqual(push.status, 0, 'candidate guard no-op 不得放行标记 commit');
-        assert.match(push.stdout + push.stderr, /does not pass the signature guard|reverse-engineered/);
-    } finally {
-        cleanRepo(root);
-        fs.rmSync(remote, { recursive: true, force: true });
-    }
-});
-
-test('pre-push：annotated tag / 多 ref / 同一 commit 多 ref 去重 / 非保护分支 force push', () => {
-    if (!hasBash()) {
-        test.skip('bash 不可用');
-        return;
-    }
-    const root = makeGitRepo();
-    const remote = path.join(os.tmpdir(), 'pixiv bare remote ' + Date.now());
-    try {
-        fs.mkdirSync(remote);
-        git(['init', '-q', '--bare', remote], root);
-        git(['remote', 'add', 'origin', remote], root);
-
-        // 合法演进：新增 key 并 accept（正常 pre-commit 路径提交）
-        writeBundles(root, GOOD_ZH + 'status=状态\n', GOOD_EN + 'status=Status\n');
-        runGenerate(root);
-        assert.equal(runAcceptCore(root, { locale: 'en-US' }).ok, true);
-        commitAll(root, 'add status key');
-
-        git(['tag', 'light'], root);
-        git(['tag', '-a', 'annotated', '-m', 'annotated tag'], root);
-
-        // 多 ref：master + 两个 tag（lightweight 与 annotated），annotated 需 peel 到 commit
-        const multi = git(['push', 'origin', 'master', 'light', 'annotated'], root, { allowFailure: true });
-        assert.equal(multi.status, 0, multi.stdout + multi.stderr);
-        assert.match(multi.stdout + multi.stderr, /all \d+ pushed commit/);
-
-        // 非保护分支 force push：改写历史后强制推送（新提交合法）→ 允许
-        git(['checkout', '-q', '-b', 'dev'], root);
-        git(['reset', '-q', '--hard', 'HEAD~1'], root);
-        fs.writeFileSync(path.join(root, APP_I18N, 'web', 'common.properties'),
-            GOOD_ZH + 'status2=状态二\n', 'utf8');
-        fs.writeFileSync(path.join(root, APP_I18N, 'web', 'common_en.properties'),
-            GOOD_EN + 'status2=Status two\n', 'utf8');
-        runGenerate(root);
-        assert.equal(runAcceptCore(root, { locale: 'en-US' }).ok, true);
-        commitAll(root, 'rewritten history', { bypass: true });
-        const forced = git(['push', 'origin', 'dev', '--force'], root, { allowFailure: true });
-        assert.equal(forced.status, 0, '非保护分支的合法 force push 必须通过: ' + forced.stdout + forced.stderr);
-        assert.match(forced.stdout + forced.stderr, /all \d+ pushed commit/);
-
-        // protected master 的 force push 必须被拒绝（见 hooks.test.mjs 的 protected master 专项）
-        const masterForce = git(['push', 'origin', 'master', '--force'], root, { allowFailure: true });
-        assert.equal(masterForce.status, 0, masterForce.stdout + masterForce.stderr);
-    } finally {
-        cleanRepo(root);
-        fs.rmSync(remote, { recursive: true, force: true });
-    }
-});
-
-test('pre-push：remote SHA 不在本地 object database → 回退目标 remote tracking refs，保守不放过', () => {
-    if (!hasBash()) {
-        test.skip('bash 不可用');
-        return;
-    }
-    const root = makeGitRepo();
-    const remote = path.join(os.tmpdir(), 'pixiv bare remote ' + Date.now());
-    const clone = path.join(os.tmpdir(), 'pixiv clone ' + Date.now());
-    try {
-        fs.mkdirSync(remote);
-        git(['init', '-q', '--bare', remote], root);
-        git(['remote', 'add', 'origin', remote], root);
-        const first = git(['push', 'origin', 'master'], root, { allowFailure: true });
-        assert.equal(first.status, 0, first.stdout + first.stderr);
-
-        // 第二台机器（clone）在远端 master 上推进一个未知 commit（无 hooks）
-        git(['clone', '-q', remote, clone], root);
-        git(['config', 'user.email', 't@example.com'], clone);
-        git(['config', 'user.name', 'test'], clone);
-        writeBundles(clone, GOOD_ZH, BAD_EN);
-        git(['add', '-A'], clone);
-        git(['-c', 'core.hooksPath=/dev/null', 'commit', '-q', '-m', 'remote-only bad'], clone);
-        const remoteAdvance = git(['-c', 'core.hooksPath=/dev/null', 'push', 'origin', 'master'], clone, { allowFailure: true });
-        assert.equal(remoteAdvance.status, 0, remoteAdvance.stdout + remoteAdvance.stderr);
-
-        // 本地 fetch 建立 tracking refs（origin/master = 远端新 tip）
-        git(['fetch', '-q', 'origin'], root);
-        // 第二台机器继续推进一个未知 commit（bad）——本地只有旧 tracking refs
-        writeBundles(clone, GOOD_ZH, GOOD_EN);
-        git(['add', '-A'], clone);
-        git(['-c', 'core.hooksPath=/dev/null', 'commit', '-q', '-m', 'remote-only good'], clone);
-        writeBundles(clone, GOOD_ZH, BAD_EN);
-        git(['add', '-A'], clone);
-        git(['-c', 'core.hooksPath=/dev/null', 'commit', '-q', '-m', 'remote-only bad2'], clone);
-        const remoteAdvance2 = git(['-c', 'core.hooksPath=/dev/null', 'push', 'origin', 'master'], clone, { allowFailure: true });
-        assert.equal(remoteAdvance2.status, 0, remoteAdvance2.stdout + remoteAdvance2.stderr);
-
-        // 本地基于旧基线提交一个合法 commit；推送时 remote_sha 是未知的远端 commit。
-        // pre-push 先从真实远端 fetch 对象到临时 namespace 再准确计算基线（9.4）：
-        // 本地提交不在远端 tip 之后 → protected master 拒绝盲推；不得漏检或崩溃。
-        const remoteTipBefore = git(['ls-remote', remote], root).stdout.trim();
-        fs.writeFileSync(path.join(root, APP_I18N, 'web', 'common.properties'),
-            GOOD_ZH + 'status3=状态三\n', 'utf8');
-        fs.writeFileSync(path.join(root, APP_I18N, 'web', 'common_en.properties'),
-            GOOD_EN + 'status3=Status three\n', 'utf8');
-        runGenerate(root);
-        assert.equal(runAcceptCore(root, { locale: 'en-US' }).ok, true);
-        commitAll(root, 'local good');
-        const push = git(['push', 'origin', 'master'], root, { allowFailure: true });
-        assert.notEqual(push.status, 0,
-            '本地落后远端时 protected master 必须拒绝盲推: ' + push.stdout + push.stderr);
-        assert.match(push.stdout + push.stderr,
-            /fetch first|\[rejected\]|\[remote rejected\]|protected branch|non-fast-forward|protected/,
-            'pre-push 必须基于真实远端状态完成判定: ' + push.stdout + push.stderr);
-        // 远端必须没有任何更新（本地落后远端）
-        const lsRemote = git(['ls-remote', remote], root);
-        assert.equal(lsRemote.stdout.trim(), remoteTipBefore);
-    } finally {
-        cleanRepo(root);
-        cleanRepo(clone);
-        fs.rmSync(remote, { recursive: true, force: true });
-    }
-});
-
-test('pre-push / pre-commit：不依赖 tar；不使用 --remotes=*；不从 remote_ref 推导 remote 名；输出含真实诊断', () => {
-    for (const hook of ['pre-commit', 'pre-push']) {
-        const content = fs.readFileSync(path.join(REPO_ROOT, 'scripts', 'hooks', hook), 'utf8')
-            // 去掉注释（hook 文档头允许提到这些工具名），只检查真实命令用法
-            .split('\n').filter((line) => !/^\s*#/.test(line)).join('\n');
-        assert.doesNotMatch(content, /(git archive|\btar\s|\brsync\s|\bzip\s|\bpython\w*[\s.]|\bpowershell\w*[\s.])/i,
-            hook + ' 不得依赖 tar / rsync / zip / Python / PowerShell');
-        assert.doesNotMatch(content, /--remotes=\*/i, hook + ' 不得使用 --remotes=*');
-        assert.doesNotMatch(content, /remote_ref%%\/\*/i, hook + ' 不得从 remote_ref 推导 remote 名');
-    }
-    const prePush = fs.readFileSync(path.join(REPO_ROOT, 'scripts', 'hooks', 'pre-push'), 'utf8');
-    assert.match(prePush, /remote_name="\$\{1:-\}"/, 'pre-push 必须从 $1 读取 remote name');
-    const preCommit = fs.readFileSync(path.join(REPO_ROOT, 'scripts', 'hooks', 'pre-commit'), 'utf8');
-    assert.doesNotMatch(preCommit, /remote_name=/, 'pre-commit 不涉及 remote 处理');
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/i18n/test/hooks.test.mjs
+++ b/scripts/i18n/test/hooks.test.mjs
@@ -36,6 +36,16 @@ test('hooks：提前反馈面复用可信发布核心检查器', () => {
     assert.match(prePush, /gate-surface\.json/);
     assert.match(preCommit, /gate-contract\.mjs/);
     assert.match(prePush, /gate-contract\.mjs/);
+    for (const hook of [preCommit, prePush]) {
+        assert.doesNotMatch(hook, /trustedGateEpoch|trustedGateRef|git\s+ls-remote|refs\/pixiv-i18n-prepush/);
+    }
+});
+
+test('hooks：shell 语法有效', () => {
+    for (const hook of ['pre-commit', 'pre-push']) {
+        const result = spawnSync('bash', ['-n', `scripts/hooks/${hook}`], { cwd: ROOT, encoding: 'utf8' });
+        assert.equal(result.status, 0, result.stderr);
+    }
 });
 
 test('pre-commit：无暂存内容快速通过', () => {
@@ -48,6 +58,26 @@ test('pre-commit：无暂存内容快速通过', () => {
         const result = spawnSync('bash', ['scripts/hooks/pre-commit'], { cwd: root, encoding: 'utf8' });
         assert.equal(result.status, 0, result.stderr);
         assert.match(result.stdout, /nothing staged/);
+    } finally {
+        clean(root);
+    }
+});
+
+test('pre-push：仅删除 ref 时不运行候选检查', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv pre-push deletion '));
+    try {
+        spawnSync('git', ['init', '-q'], { cwd: root });
+        const hookDir = path.join(root, 'scripts/hooks');
+        fs.mkdirSync(hookDir, { recursive: true });
+        fs.copyFileSync(path.join(ROOT, 'scripts/hooks/pre-push'), path.join(hookDir, 'pre-push'));
+        const result = spawnSync('bash', ['scripts/hooks/pre-push', 'origin', 'unused'], {
+            cwd: root,
+            encoding: 'utf8',
+            input: `refs/heads/topic ${'0'.repeat(40)} refs/heads/topic ${'1'.repeat(40)}\n`,
+        });
+        assert.equal(result.status, 0, result.stderr);
+        assert.match(result.stdout, /skipping deletion/);
+        assert.match(result.stdout, /no commits to verify/);
     } finally {
         clean(root);
     }


### PR DESCRIPTION
## 变更内容

将本地 pre-commit 与 pre-push hooks 收缩为复用现有检查器的提前反馈层，移除本地 anchor 物化、远端 ref 扫描和逐提交可信链。

## 验证

- [x] `bash -n scripts/hooks/pre-commit scripts/hooks/pre-push`
- [x] `node --test scripts/i18n/test/hooks.test.mjs scripts/i18n/test/hooks-hardening.test.mjs`
- [x] `npm run test:i18n`
- [x] `npm run i18n:check`
- [x] 可信发布核心 contract 已验证当前提交
- [x] 工作分支精确 SHA 的 push Quality Gate 已全部通过
- [x] PR required checks 全部通过
- [x] CHANGELOG 已判断：内部重构，无需更新
