### PR TITLE
fix(release): 修复 Environment 私钥在插件发布调用链中丢失

### DIFF
--- a/.github/actions/publish-official-plugins/action.yml
+++ b/.github/actions/publish-official-plugins/action.yml
@@ -1,0 +1,130 @@
+name: Publish official plugins
+description: Build, sign and publish official plugins and refresh the plugin market manifest
+
+inputs:
+  plugin_signing_private_key_pem_base64:
+    description: Base64-encoded PKCS#8 PEM private key for official plugin signatures
+    required: true
+  plugins_repo_token:
+    description: Token with write access to Sywyar/PixivDownloader-plugins
+    required: true
+  publish_args:
+    description: Optional plugin publication arguments; only -f is supported
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Set up JDK 17
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+      with:
+        distribution: temurin
+        java-version: '17'
+        cache: maven
+
+    - name: Build plugin signature tool
+      shell: powershell
+      run: .\mvnw.cmd "-pl" "pixivdownload-plugin-signature" "-am" "package" "-DskipTests" "-Dexec.skip=true"
+
+    - name: Prepare plugin signing private key
+      shell: powershell
+      env:
+        PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64: ${{ inputs.plugin_signing_private_key_pem_base64 }}
+      run: |
+        if ([string]::IsNullOrWhiteSpace($env:PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64)) {
+          throw "Missing release Environment secret PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64."
+        }
+        $signingDir = Join-Path $env:RUNNER_TEMP "pixivdownload-plugin-signing"
+        New-Item -ItemType Directory -Force -Path $signingDir | Out-Null
+        $privateKeyFile = Join-Path $signingDir "official-ed25519-private-key.pem"
+        try {
+          $privateKeyPemBase64 = ($env:PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64 -replace '\s', '')
+          try {
+            $privateKeyBytes = [System.Convert]::FromBase64String($privateKeyPemBase64)
+          } catch {
+            throw "Release Environment secret PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64 is not valid Base64."
+          }
+          [System.IO.File]::WriteAllBytes($privateKeyFile, $privateKeyBytes)
+          $privateKeyText = [System.IO.File]::ReadAllText($privateKeyFile, [System.Text.Encoding]::UTF8)
+          if ($privateKeyText.Contains("?")) {
+            throw "Prepared plugin signing private key contains '?' characters. Re-upload it as PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64 from the original PEM bytes."
+          }
+          [System.IO.File]::AppendAllText($env:GITHUB_ENV, "PLUGIN_SIGNING_PRIVATE_KEY_FILE=$privateKeyFile`n", (New-Object System.Text.UTF8Encoding($false)))
+        } catch {
+          Remove-Item -LiteralPath $privateKeyFile -Force -ErrorAction SilentlyContinue
+          throw
+        }
+
+    - name: Build and publish updated plugins
+      shell: powershell
+      env:
+        GH_TOKEN: ${{ inputs.plugins_repo_token }}
+        PUBLISH_PLUGIN_ARGS: ${{ inputs.publish_args }}
+        PLUGINS_REPO: Sywyar/PixivDownloader-plugins
+        PLUGIN_SIGNING_KEY_ID: pixivdownloader-official-root-2026-07
+      run: |
+        try {
+          $publishArgs = @{
+            Repo = $env:PLUGINS_REPO
+            OfficialKeyId = $env:PLUGIN_SIGNING_KEY_ID
+            PrivateKeyFile = $env:PLUGIN_SIGNING_PRIVATE_KEY_FILE
+          }
+          $inputTokens = @()
+          if (-not [string]::IsNullOrWhiteSpace($env:PUBLISH_PLUGIN_ARGS)) {
+            $inputTokens = @($env:PUBLISH_PLUGIN_ARGS -split '\s+' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+          }
+          $unsupportedTokens = @($inputTokens | Where-Object { $_ -notin @("-f", "-Force") })
+          if ($unsupportedTokens.Count -gt 0) {
+            throw "Unsupported publish_args value(s): $($unsupportedTokens -join ', '). Only -f is supported."
+          }
+          if (@($inputTokens | Where-Object { $_ -in @("-f", "-Force") }).Count -gt 0) {
+            $publishArgs["Force"] = $true
+          }
+          .\scripts\publish-plugin-releases.ps1 @publishArgs
+        } catch {
+          Remove-Item -LiteralPath $env:PLUGIN_SIGNING_PRIVATE_KEY_FILE -Force -ErrorAction SilentlyContinue
+          throw
+        }
+
+    - name: Generate market manifest.json
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ inputs.plugins_repo_token }}
+        PLUGINS_REPO: Sywyar/PixivDownloader-plugins
+        PLUGIN_SIGNING_KEY_ID: pixivdownloader-official-root-2026-07
+      run: |
+        try {
+          .\scripts\generate-market-manifest.ps1 `
+            -Repo $env:PLUGINS_REPO `
+            -CurationFile scripts/market-curation.json `
+            -OutputFile build/manifest.json `
+            -OfficialKeyId $env:PLUGIN_SIGNING_KEY_ID `
+            -PrivateKeyFile $env:PLUGIN_SIGNING_PRIVATE_KEY_FILE
+        } finally {
+          Remove-Item -LiteralPath $env:PLUGIN_SIGNING_PRIVATE_KEY_FILE -Force -ErrorAction SilentlyContinue
+        }
+
+    - name: Checkout plugins repo
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        repository: Sywyar/PixivDownloader-plugins
+        token: ${{ inputs.plugins_repo_token }}
+        path: plugins-repo
+
+    - name: Commit manifest.json to plugins repo
+      shell: powershell
+      run: |
+        Copy-Item build/manifest.json plugins-repo/manifest.json -Force
+        Copy-Item build/manifest.json.sig plugins-repo/manifest.json.sig -Force
+        Set-Location plugins-repo
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add manifest.json manifest.json.sig
+        $changed = git status --porcelain
+        if ($changed) {
+          git commit -m "chore: refresh plugin market manifest"
+          git push
+        } else {
+          Write-Host "manifest.json unchanged; nothing to commit"
+        }

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,9 +80,28 @@ jobs:
     needs: [resolve-version]
     if: needs.resolve-version.outputs.has_changes == 'true'
     uses: ./.github/workflows/publish-plugins.yml
+    with:
+      publish_in_caller: true
+
+  publish-plugin-artifacts:
+    needs: [resolve-version, publish-plugins]
+    if: needs.resolve-version.outputs.has_changes == 'true'
+    runs-on: windows-latest
+    environment: release
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Publish official plugins
+        uses: ./.github/actions/publish-official-plugins
+        with:
+          plugin_signing_private_key_pem_base64: ${{ secrets.PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64 }}
+          plugins_repo_token: ${{ secrets.PLUGINS_REPO_TOKEN }}
 
   build-jar:
-    needs: [resolve-version, publish-plugins]
+    needs: [resolve-version, publish-plugin-artifacts]
     if: needs.resolve-version.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     environment: release
@@ -291,7 +310,7 @@ jobs:
           path: build/out/*-setup.exe
 
   release-nightly:
-    needs: [resolve-version, publish-plugins, build-jar, build-windows-installer]
+    needs: [resolve-version, publish-plugins, publish-plugin-artifacts, build-jar, build-windows-installer]
     if: needs.resolve-version.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     environment: release

--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -11,6 +11,10 @@ on:
         description: 'Protected predecessor approved by the reusable quality gate'
         value: ${{ jobs.trusted-base.outputs.sha }}
     inputs:
+      publish_in_caller:
+        description: '由调用方在自己的 release Environment job 中执行实际发布'
+        required: true
+        type: boolean
       publish_args:
         description: '可选发布参数；填写 -f 时强制重编译并覆盖上传所有插件资产'
         required: false
@@ -27,10 +31,6 @@ on:
 # 本仓库只需读（checkout）；对分发仓库的写全部经 PAT，不靠默认 GITHUB_TOKEN。
 permissions:
   contents: read
-
-env:
-  PLUGINS_REPO: Sywyar/PixivDownloader-plugins
-  PLUGIN_SIGNING_KEY_ID: pixivdownloader-official-root-2026-07
 
 jobs:
   trusted-base:
@@ -84,108 +84,21 @@ jobs:
     environment: release
     steps:
       - name: Checkout main repo
+        if: inputs.publish_in_caller != true
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.sha }}
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+      - name: Publish official plugins
+        if: inputs.publish_in_caller != true
+        uses: ./.github/actions/publish-official-plugins
         with:
-          distribution: temurin
-          java-version: '17'
-          cache: maven
+          plugin_signing_private_key_pem_base64: ${{ secrets.PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64 }}
+          plugins_repo_token: ${{ secrets.PLUGINS_REPO_TOKEN }}
+          publish_args: ${{ inputs.publish_args || '' }}
 
-      - name: Build plugin signature tool
-        shell: powershell
-        run: .\mvnw.cmd "-pl" "pixivdownload-plugin-signature" "-am" "package" "-DskipTests" "-Dexec.skip=true"
-
-      - name: Prepare plugin signing private key
-        shell: powershell
-        env:
-          PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64: ${{ secrets.PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64 }}
+      - name: Complete delegated publication gate
+        if: inputs.publish_in_caller == true
+        shell: bash
         run: |
-          if ([string]::IsNullOrWhiteSpace($env:PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64)) {
-            throw "Missing release Environment secret PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64."
-          }
-          $signingDir = Join-Path $env:RUNNER_TEMP "pixivdownload-plugin-signing"
-          New-Item -ItemType Directory -Force -Path $signingDir | Out-Null
-          $privateKeyFile = Join-Path $signingDir "official-ed25519-private-key.pem"
-          $privateKeyPemBase64 = ($env:PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64 -replace '\s', '')
-          try {
-            $privateKeyBytes = [System.Convert]::FromBase64String($privateKeyPemBase64)
-          } catch {
-            throw "Release Environment secret PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64 is not valid Base64."
-          }
-          [System.IO.File]::WriteAllBytes($privateKeyFile, $privateKeyBytes)
-          $privateKeyText = [System.IO.File]::ReadAllText($privateKeyFile, [System.Text.Encoding]::UTF8)
-          if ($privateKeyText.Contains("?")) {
-            throw "Prepared plugin signing private key contains '?' characters. Re-upload it as PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64 from the original PEM bytes."
-          }
-          [System.IO.File]::AppendAllText($env:GITHUB_ENV, "PLUGIN_SIGNING_PRIVATE_KEY_FILE=$privateKeyFile`n", (New-Object System.Text.UTF8Encoding($false)))
-
-      - name: Build + publish updated plugins (per-plugin, version-gated or forced)
-        # 仅对「plugin.version 尚无对应 Release」的插件单独编译（mvn -pl <module> -am，不全量构建）并发布；
-        # 版本已发布的插件跳过、绝不重编译 / 重上传（不可变）。更新一个插件 = 只编译并发布这一个。
-        # 手动触发时 publish_args 填 -f 会强制每个插件都重编译，并先删除同名 Release 资产后重新上传。
-        # 布局偏好调查的四个公开客户端参数由 download-workbench 源码持有；官方插件发布脚本
-        # 只通过 tracked Maven profile 打开一个发行激活位，不读取 GitHub 变量或临时 properties。
-        shell: powershell
-        env:
-          GH_TOKEN: ${{ secrets.PLUGINS_REPO_TOKEN }}
-          PUBLISH_PLUGIN_ARGS: ${{ inputs.publish_args || '' }}
-        run: |
-          $publishArgs = @{
-            Repo = $env:PLUGINS_REPO
-            OfficialKeyId = $env:PLUGIN_SIGNING_KEY_ID
-            PrivateKeyFile = $env:PLUGIN_SIGNING_PRIVATE_KEY_FILE
-          }
-          $inputTokens = @()
-          if (-not [string]::IsNullOrWhiteSpace($env:PUBLISH_PLUGIN_ARGS)) {
-            $inputTokens = @($env:PUBLISH_PLUGIN_ARGS -split '\s+' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
-          }
-          $unsupportedTokens = @($inputTokens | Where-Object { $_ -notin @("-f", "-Force") })
-          if ($unsupportedTokens.Count -gt 0) {
-            throw "Unsupported publish_args value(s): $($unsupportedTokens -join ', '). Only -f is supported."
-          }
-          if (@($inputTokens | Where-Object { $_ -in @("-f", "-Force") }).Count -gt 0) {
-            $publishArgs["Force"] = $true
-          }
-          .\scripts\publish-plugin-releases.ps1 @publishArgs
-
-      - name: Generate market manifest.json (from published releases)
-        # 始终运行：从已发布的 Release 资产推导 sha256/size/downloadCount（不依赖本次是否构建），刷新清单。
-        # 使用 pwsh 而非 powershell：Windows PowerShell 5.1 的 ConvertTo-Json 会产生楼梯式缩进。
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ secrets.PLUGINS_REPO_TOKEN }}
-        run: >
-          .\scripts\generate-market-manifest.ps1
-          -Repo $env:PLUGINS_REPO
-          -CurationFile scripts/market-curation.json
-          -OutputFile build/manifest.json
-          -OfficialKeyId $env:PLUGIN_SIGNING_KEY_ID
-          -PrivateKeyFile $env:PLUGIN_SIGNING_PRIVATE_KEY_FILE
-
-      - name: Checkout plugins repo
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: Sywyar/PixivDownloader-plugins
-          token: ${{ secrets.PLUGINS_REPO_TOKEN }}
-          path: plugins-repo
-
-      - name: Commit manifest.json to plugins repo
-        shell: powershell
-        run: |
-          Copy-Item build/manifest.json plugins-repo/manifest.json -Force
-          Copy-Item build/manifest.json.sig plugins-repo/manifest.json.sig -Force
-          Set-Location plugins-repo
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add manifest.json manifest.json.sig
-          $changed = git status --porcelain
-          if ($changed) {
-            git commit -m "chore: refresh plugin market manifest"
-            git push
-          } else {
-            Write-Host "manifest.json unchanged; nothing to commit"
-          }
+          echo "Quality Gate passed; the caller will publish from its release Environment job."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,28 @@ jobs:
   publish-plugins:
     if: github.event_name == 'push'
     uses: ./.github/workflows/publish-plugins.yml
+    with:
+      publish_in_caller: true
+
+  publish-plugin-artifacts:
+    needs: publish-plugins
+    if: github.event_name == 'push'
+    runs-on: windows-latest
+    environment: release
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Publish official plugins
+        uses: ./.github/actions/publish-official-plugins
+        with:
+          plugin_signing_private_key_pem_base64: ${{ secrets.PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64 }}
+          plugins_repo_token: ${{ secrets.PLUGINS_REPO_TOKEN }}
 
   build-jar:
-    needs: publish-plugins
+    needs: publish-plugin-artifacts
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: release
@@ -288,7 +307,7 @@ jobs:
           path: build/out/*-setup.exe
 
   release:
-    needs: [publish-plugins, build-jar, build-windows-installer]
+    needs: [publish-plugins, publish-plugin-artifacts, build-jar, build-windows-installer]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment: release

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
@@ -1270,7 +1270,7 @@ class PluginReleaseScriptsTest {
         assertThat(nightly).contains("workflow_dispatch:");
         assertThat(releaseJob)
                 .contains(
-                        "needs: [resolve-version, publish-plugins, build-jar, build-windows-installer]",
+                        "needs: [resolve-version, publish-plugins, publish-plugin-artifacts, build-jar, build-windows-installer]",
                         "if: needs.resolve-version.outputs.has_changes == 'true'")
                 .doesNotContain("always()");
         assertThat(releaseStep).contains(

--- a/scripts/i18n/test/quality-gate-workflow.test.mjs
+++ b/scripts/i18n/test/quality-gate-workflow.test.mjs
@@ -44,16 +44,30 @@ test('Quality Gate：五个 required context 与完整触发面保持稳定', ()
 
 test('发布链：所有凭据与写权限只在 release Environment 的门禁后使用', () => {
     const publish = load('.github/workflows/publish-plugins.yml');
+    const publishAction = load('.github/actions/publish-official-plugins/action.yml');
     assert.equal(publish.jobs['quality-gate'].uses, './.github/workflows/quality-gate.yml');
     assert.equal(publish.jobs.publish.environment, 'release');
     assert.deepEqual(publish.jobs.publish.needs, 'quality-gate');
+    assert.equal(publish.on.workflow_call.inputs.publish_in_caller.required, true);
+    assert.equal(publishAction.runs.using, 'composite');
+    assert.equal(publishAction.inputs.plugin_signing_private_key_pem_base64.required, true);
+    assert.equal(publishAction.inputs.plugins_repo_token.required, true);
+    assert.deepEqual(secretNames(publishAction), []);
+    const directPublish = publish.jobs.publish.steps
+        .find((step) => step.uses === './.github/actions/publish-official-plugins');
+    assert.equal(directPublish.if, 'inputs.publish_in_caller != true');
+    assert.equal(publish.jobs.publish.steps.find((step) => step.name === 'Complete delegated publication gate')?.if,
+        'inputs.publish_in_caller == true');
 
     const release = load('.github/workflows/release.yml');
     const nightly = load('.github/workflows/nightly.yml');
     assert.equal(release.jobs['publish-plugins'].uses, './.github/workflows/publish-plugins.yml');
     assert.equal(nightly.jobs['publish-plugins'].uses, './.github/workflows/publish-plugins.yml');
-    for (const [doc, ids] of [[release, ['build-jar', 'build-windows-installer', 'release', 'create-draft-release']],
-        [nightly, ['build-jar', 'build-windows-installer', 'release-nightly']]]) {
+    assert.equal(release.jobs['publish-plugins'].with.publish_in_caller, true);
+    assert.equal(nightly.jobs['publish-plugins'].with.publish_in_caller, true);
+    for (const [doc, ids] of [[release, ['publish-plugin-artifacts', 'build-jar', 'build-windows-installer',
+        'release', 'create-draft-release']],
+        [nightly, ['publish-plugin-artifacts', 'build-jar', 'build-windows-installer', 'release-nightly']]]) {
         for (const id of ids) assert.equal(doc.jobs[id].environment, 'release');
     }
 
@@ -69,6 +83,19 @@ test('发布链：所有凭据与写权限只在 release Environment 的门禁�
         'PLUGINS_REPO_TOKEN', 'PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64',
     ]);
     for (const doc of [release, nightly]) {
+        const job = doc.jobs['publish-plugin-artifacts'];
+        assert.ok((Array.isArray(job.needs) ? job.needs : [job.needs]).includes('publish-plugins'));
+        assert.deepEqual(secretNames(job).sort(), [
+            'PLUGINS_REPO_TOKEN', 'PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64',
+        ]);
+        assert.equal(job.steps.find((step) => step.uses === './.github/actions/publish-official-plugins')
+            ?.name, 'Publish official plugins');
+    }
+    assert.equal(release.jobs['build-jar'].needs, 'publish-plugin-artifacts');
+    assert.deepEqual(nightly.jobs['build-jar'].needs, ['resolve-version', 'publish-plugin-artifacts']);
+    assert.ok(release.jobs.release.needs.includes('publish-plugin-artifacts'));
+    assert.ok(nightly.jobs['release-nightly'].needs.includes('publish-plugin-artifacts'));
+    for (const doc of [release, nightly]) {
         for (const [id, job] of Object.entries(doc.jobs)) {
             assert.equal(secretNames(job).includes('PIXIVDOWNLOAD_PLUGIN_CREDENTIAL_MASTER_KEY_BASE64'),
                 id === 'build-jar');
@@ -80,7 +107,7 @@ test('发布链：所有凭据与写权限只在 release Environment 的门禁�
 
 test('发布链：仅接受 Base64 私钥且不存在失败绕过', () => {
     for (const rel of ['.github/workflows/release.yml', '.github/workflows/nightly.yml',
-        '.github/workflows/publish-plugins.yml']) {
+        '.github/workflows/publish-plugins.yml', '.github/actions/publish-official-plugins/action.yml']) {
         const text = fs.readFileSync(path.join(ROOT, ...rel.split('/')), 'utf8');
         assert.doesNotMatch(text, /always\(\)|!cancelled\(\)|continue-on-error/);
         assert.doesNotMatch(text, /PLUGIN_SIGNING_PRIVATE_KEY_PEM(?:\s|:|\})/);
@@ -94,7 +121,8 @@ test('发布链：仅接受 Base64 私钥且不存在失败绕过', () => {
 
 test('Nightly：共享变更门禁以语义输出控制全部昂贵任务', () => {
     const nightly = load('.github/workflows/nightly.yml');
-    for (const id of ['publish-plugins', 'build-jar', 'build-windows-installer', 'release-nightly']) {
+    for (const id of ['publish-plugins', 'publish-plugin-artifacts', 'build-jar', 'build-windows-installer',
+        'release-nightly']) {
         assert.equal(nightly.jobs[id].if, "needs.resolve-version.outputs.has_changes == 'true'");
     }
     const resolveScripts = nightly.jobs['resolve-version'].steps.map((step) => step.run || '').join('\n');


### PR DESCRIPTION
## 变更内容

修复 Release 与 Nightly 复用插件发布工作流时无法读取 `release` Environment 私钥的问题。实际发布在调用方的 Environment job 中执行，并保持同一 SHA 的 Quality Gate 依赖。

## 验证

- [x] 已运行工作流契约聚焦测试
- [x] 已运行 `npm run test:i18n`
- [x] 已运行 `npm run i18n:check`
- [x] 已运行候选 trusted contract / parity 验证
- [x] 已运行 `PluginReleaseScriptsTest`
- [x] 当前远端 head 的 push CI 全部通过
- [x] PR merge candidate 的 required checks 全部通过
- [x] CHANGELOG 已判断为不适用

## 关联

无
