### PR TITLE
refactor(plugin-api): 统一问卷站内信正文与加载生命周期

### DIFF
--- a/i18n/catalog-lock.json
+++ b/i18n/catalog-lock.json
@@ -34894,14 +34894,6 @@
       "locale": "en-US",
       "module": "pixivdownload-plugin-download-workbench",
       "baseName": "web/layout-feedback",
-      "key": "layout-feedback.embed-loading",
-      "acceptedSourceHash": "ddb93702c0f7c496cdd2f9a04349733de55272fdbcc750ee2feb0c187de67427",
-      "acceptedTranslationHash": "348758a3ce0974e2f96b3be35c813e7bdeb357f9c788fb074f2cb6c1596d3ac6"
-    },
-    {
-      "locale": "en-US",
-      "module": "pixivdownload-plugin-download-workbench",
-      "baseName": "web/layout-feedback",
       "key": "layout-feedback.embed-temporarily-unavailable",
       "acceptedSourceHash": "586e5690d4b61620049f432ba2c716a76c4fc961ddc54ee89d61b0d7bc9ac359",
       "acceptedTranslationHash": "3e5d2ab4f7aafe3a5691106e7bc2f6dec2521c8c16bf36ac15b65d74c5cbae44"
@@ -42518,14 +42510,6 @@
       "locale": "en-US",
       "module": "pixivdownload-plugin-multi-mode-decision-survey",
       "baseName": "web/multi-mode-decision-survey",
-      "key": "loading",
-      "acceptedSourceHash": "ddb93702c0f7c496cdd2f9a04349733de55272fdbcc750ee2feb0c187de67427",
-      "acceptedTranslationHash": "348758a3ce0974e2f96b3be35c813e7bdeb357f9c788fb074f2cb6c1596d3ac6"
-    },
-    {
-      "locale": "en-US",
-      "module": "pixivdownload-plugin-multi-mode-decision-survey",
-      "baseName": "web/multi-mode-decision-survey",
       "key": "other-placeholder",
       "acceptedSourceHash": "4f2a135460ace1af1236182d571f733e600626a57efadc3ad3b89d1360014e18",
       "acceptedTranslationHash": "5b29b720f216f08aa8d40d88b60462a36cb44179e586d8ae7a0f35b4bca32afd"
@@ -48097,6 +48081,14 @@
       "key": "plugin.summary",
       "acceptedSourceHash": "3cad64c6d67973098ce7f4e12feabe10e397ad599181b0986ad126c6b6b30b61",
       "acceptedTranslationHash": "0e76f0efbf372f430f3785853168c17ddb5fbc9f11e50ae6cc431e8fc698e3f3"
+    },
+    {
+      "locale": "en-US",
+      "module": "pixivdownload-plugin-posthog",
+      "baseName": "web/posthog",
+      "key": "survey.loading",
+      "acceptedSourceHash": "ddb93702c0f7c496cdd2f9a04349733de55272fdbcc750ee2feb0c187de67427",
+      "acceptedTranslationHash": "2f5897e0e4e5bd0da88d155d5152ded191ea29e7e7eaecf52d552b3f2d8d8d7f"
     },
     {
       "locale": "en-US",

--- a/pixivdownload-app/src/main/java/top/sywyar/pixivdownload/plugin/CorePlugin.java
+++ b/pixivdownload-app/src/main/java/top/sywyar/pixivdownload/plugin/CorePlugin.java
@@ -191,6 +191,7 @@ public class CorePlugin implements PixivFeaturePlugin {
                 WebRouteContribution.publicRoute("/js/pixiv-actions.js"),
                 WebRouteContribution.publicRoute("/js/pixiv-i18n.js"),
                 WebRouteContribution.publicRoute("/js/pixiv-lang-switcher.js"),
+                WebRouteContribution.publicRoute("/js/pixiv-survey-frame-bridge.js"),
                 WebRouteContribution.publicRoute("/js/pixiv-theme.js"),
                 WebRouteContribution.publicRoute("/maintenance.html"),
                 WebRouteContribution.publicRoute("/index/**"),

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/RouteAccessRegistryTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/RouteAccessRegistryTest.java
@@ -355,12 +355,13 @@ class RouteAccessRegistryTest {
     }
 
     @Test
-    @DisplayName("resolve：内置共享脚本 /js/pixiv-i18n.js 在 PUBLIC + VISITOR_AND_INVITED_GUEST 双声明下解析到 PUBLIC")
+    @DisplayName("resolve：调查 sandbox 所需共享脚本解析为 PUBLIC")
     void resolveBuiltInSharedScriptResolvesToPublic() {
         RouteAccessRegistry registry = new RouteAccessRegistry(new PluginRegistry(BuiltInPlugins.createAll()));
-        assertThat(registry.resolve("/js/pixiv-i18n.js", HttpMethod.GET))
-                .get().extracting(r -> r.route().accessPolicy())
-                .isEqualTo(AccessPolicy.PUBLIC);
+        assertThat(List.of("/js/pixiv-i18n.js", "/js/pixiv-survey-frame-bridge.js"))
+                .allSatisfy(path -> assertThat(registry.resolve(path, HttpMethod.GET))
+                        .get().extracting(r -> r.route().accessPolicy())
+                        .isEqualTo(AccessPolicy.PUBLIC));
     }
 
     @Test

--- a/pixivdownload-plugin-api/src/main/java/top/sywyar/pixivdownload/plugin/api/notification/SurveyInboxMessage.java
+++ b/pixivdownload-plugin-api/src/main/java/top/sywyar/pixivdownload/plugin/api/notification/SurveyInboxMessage.java
@@ -1,0 +1,134 @@
+package top.sywyar.pixivdownload.plugin.api.notification;
+
+import top.sywyar.pixivdownload.plugin.api.web.WebUiSlotContribution;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * 一封持久问卷站内信的纯值描述，并负责与现有 {@link WebUiSlotContribution} 稳定契约互转。
+ * <p>
+ * 标题与摘要保存 i18n key，HTML 正文由调查插件拥有的同源 {@link #contentUrl()} 提供；本契约不搬运
+ * 原始 HTML、资源句柄、插件 Bean 或 ClassLoader。调查插件通过 {@code uiSlots()} 发布转换后的槽位，
+ * 因此它是由发布插件负责 publication 生命周期的可选声明式展示贡献：贡献缺席、插件停用或卸载、
+ * publication 换代时，消息随活动槽位快照自然撤回。宿主只复制纯值快照，quiesce 不回调插件，
+ * 也没有需要等待排空的插件调用。通知能力缺席时贡献按 best-effort 忽略，不影响问卷页面与提交主流程。
+ * <p>
+ * 通知消费者可幂等保存消息、已读状态和不可用墓碑；撤回只隐藏活动消息并保留状态，复用同一
+ * {@code instanceKey} 时恢复原状态，变更实例键后创建新的未读消息。同源地址仍需在消费边界复验，
+ * 且发布插件必须为正文路由声明适当的访问级别（管理员问卷使用 {@code ADMIN}）。命中本目标和分类
+ * 但字段无效的槽位会被拒绝并抛出异常，供消费者记录可诊断信息；不能因使用本便利封装而信任任意
+ * metadata。
+ *
+ * @param messageKey    消息的稳定键；与 {@link #instanceKey()} 一起确定持久消息实例
+ * @param instanceKey   本轮问卷实例键；变更后产生新的未读消息
+ * @param contentUrl    调查插件自有 HTML 正文的同源绝对路径，可包含查询参数
+ * @param i18nNamespace 标题与摘要所属的 i18n namespace
+ * @param titleKey      站内信标题 i18n key
+ * @param bodyKey       站内信列表摘要 i18n key
+ * @param order         同类站内信的稳定排序值，越小越靠前
+ */
+public record SurveyInboxMessage(
+        String messageKey,
+        String instanceKey,
+        String contentUrl,
+        String i18nNamespace,
+        String titleKey,
+        String bodyKey,
+        int order
+) {
+
+    private static final String TARGET = "notification.inbox";
+    private static final String CATEGORY = "survey";
+    private static final String CATEGORY_KEY = "notification.category";
+    private static final String INSTANCE_KEY = "notification.instance-key";
+    private static final String CONTENT_URL_KEY = "notification.embed-url";
+    private static final String I18N_NAMESPACE_KEY = "notification.i18n-namespace";
+    private static final String TITLE_KEY = "notification.title-key";
+    private static final String BODY_KEY = "notification.body-key";
+    private static final int MAX_CONTENT_URL_BYTES = 8 * 1_024;
+    private static final Pattern MESSAGE_TOKEN = Pattern.compile("[a-z0-9][a-z0-9.-]{0,127}");
+    private static final Pattern I18N_TOKEN = Pattern.compile("[a-z0-9][a-z0-9.-]{0,159}");
+
+    public SurveyInboxMessage {
+        messageKey = token(messageKey, MESSAGE_TOKEN, "survey inbox message key");
+        instanceKey = token(instanceKey, MESSAGE_TOKEN, "survey inbox instance key");
+        contentUrl = contentUrl(contentUrl);
+        i18nNamespace = token(i18nNamespace, I18N_TOKEN, "survey inbox i18n namespace");
+        titleKey = token(titleKey, I18N_TOKEN, "survey inbox title key");
+        bodyKey = token(bodyKey, I18N_TOKEN, "survey inbox body key");
+    }
+
+    /** 编码为现有 UI 槽位贡献，保留原有 owner 与 publication 生命周期。 */
+    public WebUiSlotContribution toUiSlotContribution() {
+        return new WebUiSlotContribution(
+                messageKey,
+                TARGET,
+                null,
+                order,
+                Map.of(
+                        CATEGORY_KEY, CATEGORY,
+                        INSTANCE_KEY, instanceKey,
+                        CONTENT_URL_KEY, contentUrl,
+                        I18N_NAMESPACE_KEY, i18nNamespace,
+                        TITLE_KEY, titleKey,
+                        BODY_KEY, bodyKey));
+    }
+
+    /**
+     * 从活动 UI 槽位解码问卷站内信。非本目标或分类返回空；目标问卷字段缺失或不安全时抛出异常。
+     */
+    public static Optional<SurveyInboxMessage> fromUiSlotContribution(WebUiSlotContribution slot) {
+        if (slot == null || !TARGET.equals(slot.target())) {
+            return Optional.empty();
+        }
+        Map<String, String> metadata = slot.metadata();
+        if (!CATEGORY.equals(metadata.get(CATEGORY_KEY))) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(new SurveyInboxMessage(
+                    slot.slotId(),
+                    metadata.get(INSTANCE_KEY),
+                    metadata.get(CONTENT_URL_KEY),
+                    metadata.get(I18N_NAMESPACE_KEY),
+                    metadata.get(TITLE_KEY),
+                    metadata.get(BODY_KEY),
+                    slot.order()));
+        } catch (NullPointerException exception) {
+            throw new IllegalArgumentException("survey inbox contribution is incomplete", exception);
+        }
+    }
+
+    private static String token(String value, Pattern pattern, String field) {
+        String token = Objects.requireNonNull(value, field);
+        if (!pattern.matcher(token).matches()) {
+            throw new IllegalArgumentException(field + " is invalid");
+        }
+        return token;
+    }
+
+    private static String contentUrl(String value) {
+        String normalized = Objects.requireNonNull(value, "survey inbox content URL").trim();
+        if (normalized.getBytes(StandardCharsets.UTF_8).length > MAX_CONTENT_URL_BYTES
+                || normalized.indexOf('\0') >= 0 || normalized.indexOf('\\') >= 0) {
+            throw new IllegalArgumentException("survey inbox content URL is invalid");
+        }
+        try {
+            URI uri = new URI(normalized);
+            if (normalized.startsWith("/") && !normalized.startsWith("//")
+                    && !uri.isAbsolute() && uri.getRawAuthority() == null
+                    && uri.normalize().toString().equals(normalized)) {
+                return normalized;
+            }
+        } catch (URISyntaxException ignored) {
+            // 统一在下方拒绝。
+        }
+        throw new IllegalArgumentException("survey inbox content URL must be a same-origin absolute path");
+    }
+}

--- a/pixivdownload-plugin-api/src/test/java/top/sywyar/pixivdownload/plugin/api/notification/SurveyInboxMessageTest.java
+++ b/pixivdownload-plugin-api/src/test/java/top/sywyar/pixivdownload/plugin/api/notification/SurveyInboxMessageTest.java
@@ -1,0 +1,89 @@
+package top.sywyar.pixivdownload.plugin.api.notification;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import top.sywyar.pixivdownload.plugin.api.web.WebUiSlotContribution;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("问卷站内信封装契约")
+class SurveyInboxMessageTest {
+
+    @Test
+    @DisplayName("标题摘要与 HTML 正文地址通过现有 UI 槽位稳定往返")
+    void roundTripsThroughExistingUiSlotContribution() {
+        SurveyInboxMessage message = new SurveyInboxMessage(
+                "example.survey",
+                "campaign-v1",
+                "/example-survey/embed.html?pixivBridgeRead=pixiv_theme",
+                "example-survey",
+                "inbox-title",
+                "inbox-body",
+                20);
+
+        WebUiSlotContribution slot = message.toUiSlotContribution();
+
+        assertThat(slot.slotId()).isEqualTo("example.survey");
+        assertThat(slot.target()).isEqualTo("notification.inbox");
+        assertThat(slot.moduleUrl()).isNull();
+        assertThat(slot.order()).isEqualTo(20);
+        assertThat(slot.metadata()).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "notification.category", "survey",
+                "notification.instance-key", "campaign-v1",
+                "notification.embed-url", "/example-survey/embed.html?pixivBridgeRead=pixiv_theme",
+                "notification.i18n-namespace", "example-survey",
+                "notification.title-key", "inbox-title",
+                "notification.body-key", "inbox-body"));
+        assertThat(SurveyInboxMessage.fromUiSlotContribution(slot)).contains(message);
+    }
+
+    @Test
+    @DisplayName("封装与解码都拒绝外部 HTML 正文地址")
+    void rejectsExternalContentUrl() {
+        assertThatThrownBy(() -> new SurveyInboxMessage(
+                "example.survey", "campaign-v1", "https://evil.example/survey",
+                "example-survey", "inbox-title", "inbox-body", 20))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("same-origin");
+
+        WebUiSlotContribution unsafe = new WebUiSlotContribution(
+                "example.survey", "notification.inbox", null, 20,
+                Map.of(
+                        "notification.category", "survey",
+                        "notification.instance-key", "campaign-v1",
+                        "notification.embed-url", "https://evil.example/survey",
+                        "notification.i18n-namespace", "example-survey",
+                        "notification.title-key", "inbox-title",
+                        "notification.body-key", "inbox-body"));
+
+        assertThatThrownBy(() -> SurveyInboxMessage.fromUiSlotContribution(unsafe))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("same-origin");
+
+        WebUiSlotContribution incomplete = new WebUiSlotContribution(
+                "example.survey", "notification.inbox", null, 20,
+                Map.of(
+                        "notification.category", "survey",
+                        "notification.instance-key", "campaign-v1",
+                        "notification.embed-url", "/example-survey/embed.html",
+                        "notification.i18n-namespace", "example-survey",
+                        "notification.title-key", "inbox-title"));
+
+        assertThatThrownBy(() -> SurveyInboxMessage.fromUiSlotContribution(incomplete))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("incomplete");
+    }
+
+    @Test
+    @DisplayName("消息标识和 i18n 键必须使用规范 token")
+    void rejectsNonCanonicalTokens() {
+        assertThatThrownBy(() -> new SurveyInboxMessage(
+                "example.survey", " campaign-v1 ", "/example-survey/embed.html",
+                "example-survey", "inbox-title", "inbox-body", 20))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("instance key");
+    }
+}

--- a/pixivdownload-plugin-api/src/test/java/top/sywyar/pixivdownload/plugin/api/ownership/PluginApiOwnershipGuardTest.java
+++ b/pixivdownload-plugin-api/src/test/java/top/sywyar/pixivdownload/plugin/api/ownership/PluginApiOwnershipGuardTest.java
@@ -11,6 +11,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import top.sywyar.pixivdownload.plugin.api.gui.GuiConfigGroups;
 import top.sywyar.pixivdownload.plugin.api.gui.GuiOnboardingStepContribution;
+import top.sywyar.pixivdownload.plugin.api.notification.SurveyInboxMessage;
 import top.sywyar.pixivdownload.plugin.api.schema.ColumnMigrationSpec;
 import top.sywyar.pixivdownload.plugin.api.schema.PathColumnSpec;
 import top.sywyar.pixivdownload.plugin.api.schema.SchemaContribution;
@@ -173,9 +174,10 @@ class PluginApiOwnershipGuardTest {
                     "SchemaContribution", "TableSpec")),
             Map.entry("维护任务协议", types(API_PREFIX + "maintenance",
                     "MaintenanceContext", "MaintenanceProgressReporter", "MaintenanceTask")),
-            Map.entry("通知模板贡献协议", types(API_PREFIX + "notification",
+            Map.entry("通知贡献协议", types(API_PREFIX + "notification",
                     "ImmutableNotificationTemplateCatalog", "NotificationTemplateCatalog",
-                    "NotificationTemplateContribution", "NotificationTemplateContributor")),
+                    "NotificationTemplateContribution", "NotificationTemplateContributor",
+                    "SurveyInboxMessage")),
             Map.entry("插件推流生命周期协议", types(API_PREFIX + "stream",
                     "PluginStream", "PluginStreamRegistrar")),
             Map.entry("插件运行期后台任务协议", types(API_PREFIX + "task",
@@ -240,7 +242,7 @@ class PluginApiOwnershipGuardTest {
             Map.entry("下载宿主控制协议", 7),
             Map.entry("插件自有 schema 声明", 7),
             Map.entry("维护任务协议", 3),
-            Map.entry("通知模板贡献协议", 4),
+            Map.entry("通知贡献协议", 5),
             Map.entry("插件推流生命周期协议", 2),
             Map.entry("插件运行期后台任务协议", 4),
             Map.entry("出站 HTTP 传输协议", 12),
@@ -414,6 +416,7 @@ class PluginApiOwnershipGuardTest {
                 PageSectionContribution.class,
                 DrilldownContribution.class,
                 WebUiSlotContribution.class,
+                SurveyInboxMessage.class,
                 GuiOnboardingStepContribution.class);
 
         ownerFreeContributions.forEach(type -> assertThat(Arrays.stream(type.getRecordComponents())

--- a/pixivdownload-plugin-download-workbench/src/main/java/top/sywyar/pixivdownload/download/DownloadWorkbenchPlugin.java
+++ b/pixivdownload-plugin-download-workbench/src/main/java/top/sywyar/pixivdownload/download/DownloadWorkbenchPlugin.java
@@ -2,6 +2,7 @@ package top.sywyar.pixivdownload.download;
 
 import top.sywyar.pixivdownload.plugin.api.download.type.DownloadAcquisitionMode;
 import top.sywyar.pixivdownload.plugin.api.download.type.DownloadTypeDescriptor;
+import top.sywyar.pixivdownload.plugin.api.notification.SurveyInboxMessage;
 import top.sywyar.pixivdownload.plugin.api.plugin.PixivFeaturePlugin;
 import top.sywyar.pixivdownload.plugin.api.plugin.PluginKind;
 import top.sywyar.pixivdownload.plugin.api.schedule.source.ScheduledSourceDescriptor;
@@ -21,7 +22,6 @@ import top.sywyar.pixivdownload.download.schedule.source.descriptor.PixivSchedul
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
@@ -45,6 +45,7 @@ public class DownloadWorkbenchPlugin implements PixivFeaturePlugin {
             "static/pixiv-layout-feedback/release-publication.properties";
     private static final String SURVEY_EMBED_URL = "/pixiv-layout-feedback/embed.html"
             + "?pixivBridgeGet=/api/i18n/meta"
+            + "&pixivBridgeGet=/api/i18n/messages/posthog"
             + "&pixivBridgeGet=/api/i18n/messages/layout-feedback"
             + "&pixivBridgeGet=/api/app/info"
             + "&pixivBridgeGet=/api/layout-feedback/state"
@@ -108,7 +109,11 @@ public class DownloadWorkbenchPlugin implements PixivFeaturePlugin {
                 WebRouteContribution.visitor("/pixiv-batch-alt.html"),
                 WebRouteContribution.visitor("/pixiv-batch-alt/**"),
                 WebRouteContribution.admin("/pixiv-layout-feedback/embed.html"),
-                WebRouteContribution.visitor("/pixiv-layout-feedback/**"),
+                WebRouteContribution.publicRoute("/pixiv-layout-feedback/pixiv-layout-feedback.css"),
+                WebRouteContribution.publicRoute("/pixiv-layout-feedback/release-activation.js"),
+                WebRouteContribution.publicRoute("/pixiv-layout-feedback/posthog-config.js"),
+                WebRouteContribution.publicRoute("/pixiv-layout-feedback/pixiv-layout-feedback.js"),
+                WebRouteContribution.publicRoute("/pixiv-layout-feedback/embed.js"),
                 new WebRouteContribution("/api/layout-feedback/state", AccessPolicy.VISITOR,
                         Set.of(HttpMethod.GET, HttpMethod.POST), false),
                 WebRouteContribution.admin("/api/schedule/**"),
@@ -185,18 +190,14 @@ public class DownloadWorkbenchPlugin implements PixivFeaturePlugin {
         if (!officialSurveyRelease()) {
             return List.of();
         }
-        return List.of(new WebUiSlotContribution(
+        return List.of(new SurveyInboxMessage(
                 "download-workbench.layout-survey",
-                "notification.inbox",
-                null,
-                10,
-                Map.of(
-                        "notification.category", "survey",
-                        "notification.instance-key", LayoutFeedbackIdentityDeriver.CAMPAIGN_VERSION,
-                        "notification.embed-url", SURVEY_EMBED_URL,
-                        "notification.i18n-namespace", "layout-feedback",
-                        "notification.title-key", "layout-feedback.inbox-title",
-                        "notification.body-key", "layout-feedback.inbox-body")));
+                LayoutFeedbackIdentityDeriver.CAMPAIGN_VERSION,
+                SURVEY_EMBED_URL,
+                "layout-feedback",
+                "layout-feedback.inbox-title",
+                "layout-feedback.inbox-body",
+                10).toUiSlotContribution());
     }
 
     @Override

--- a/pixivdownload-plugin-download-workbench/src/main/resources/i18n/web/layout-feedback.properties
+++ b/pixivdownload-plugin-download-workbench/src/main/resources/i18n/web/layout-feedback.properties
@@ -27,7 +27,6 @@ layout-feedback.handled-elsewhere=该布局调查已在其他标签页处理。
 layout-feedback.close=关闭
 layout-feedback.inbox-title=下载工作台布局偏好调查
 layout-feedback.inbox-body=可直接在站内信中选择你希望长期使用的默认布局，并提交可选建议。
-layout-feedback.embed-loading=正在加载调查…
 layout-feedback.embed-completed=该调查已完成或当前无需填写。
 layout-feedback.embed-unavailable=该调查已结束。
 layout-feedback.embed-temporarily-unavailable=调查暂时无法加载，请稍后重试。

--- a/pixivdownload-plugin-download-workbench/src/main/resources/i18n/web/layout-feedback_en.properties
+++ b/pixivdownload-plugin-download-workbench/src/main/resources/i18n/web/layout-feedback_en.properties
@@ -27,7 +27,6 @@ layout-feedback.handled-elsewhere=This layout survey was already handled in anot
 layout-feedback.close=Close
 layout-feedback.inbox-title=Download workbench layout survey
 layout-feedback.inbox-body=Choose the default layout you would prefer to keep using and optionally share suggestions directly in your inbox.
-layout-feedback.embed-loading=Loading survey...
 layout-feedback.embed-completed=This survey is complete or does not currently need a response.
 layout-feedback.embed-unavailable=This survey has ended.
 layout-feedback.embed-temporarily-unavailable=The survey is temporarily unavailable. Please try again later.

--- a/pixivdownload-plugin-download-workbench/src/main/resources/static/pixiv-layout-feedback/embed.html
+++ b/pixivdownload-plugin-download-workbench/src/main/resources/static/pixiv-layout-feedback/embed.html
@@ -8,6 +8,7 @@
     <meta name="referrer" content="no-referrer">
     <title>Layout survey</title>
     <link rel="stylesheet" href="/pixiv-layout-feedback/pixiv-layout-feedback.css">
+    <link rel="stylesheet" href="/pixiv-posthog/pixiv-posthog.css">
 </head>
 <body class="plf-embedded-page">
 <p id="layoutSurveyEmbedStatus" class="plf-embed-status" role="status" aria-live="polite"></p>

--- a/pixivdownload-plugin-download-workbench/src/main/resources/static/pixiv-layout-feedback/embed.js
+++ b/pixivdownload-plugin-download-workbench/src/main/resources/static/pixiv-layout-feedback/embed.js
@@ -14,6 +14,8 @@
 
     function showStatus(key, fallback) {
         if (!statusElement) return;
+        statusElement.classList.remove('pixiv-posthog-survey-loading');
+        statusElement.setAttribute('aria-busy', 'false');
         statusElement.hidden = false;
         statusElement.textContent = t(key, fallback);
     }
@@ -51,6 +53,10 @@
         var params = new URLSearchParams(global.location.search);
         notificationId = params.get('notificationId') || '';
         try {
+            var loading = global.PixivPostHog
+                    && typeof global.PixivPostHog.showSurveyLoading === 'function'
+                ? global.PixivPostHog.showSurveyLoading(statusElement, {lang: params.get('lang') || undefined})
+                : Promise.resolve();
             var bridge = await global.PixivSurveyFrameBridge.ready();
             storage = bridge.storage;
             if (global.PixivTheme) {
@@ -60,7 +66,7 @@
                 namespaces: ['layout-feedback'],
                 lang: params.get('lang') || undefined
             });
-            showStatus('embed-loading', '正在加载调查…');
+            await loading;
             watchCompletion();
             global.PixivLayoutFeedback.init({
                 page: 'embedded',
@@ -72,6 +78,8 @@
             var result = await global.PixivLayoutFeedback.openEmbedded();
             if (result && result.status === 'opened') {
                 opened = true;
+                statusElement.classList.remove('pixiv-posthog-survey-loading');
+                statusElement.setAttribute('aria-busy', 'false');
                 statusElement.hidden = true;
             } else if (result && result.status === 'removed') {
                 showStatus('embed-unavailable', '该调查已结束。');

--- a/pixivdownload-plugin-download-workbench/src/test/java/top/sywyar/pixivdownload/plugin/LayoutSurveyContractTest.java
+++ b/pixivdownload-plugin-download-workbench/src/test/java/top/sywyar/pixivdownload/plugin/LayoutSurveyContractTest.java
@@ -259,6 +259,7 @@ class LayoutSurveyContractTest {
                 .contains("frame-ancestors 'self'")
                 .contains("connect-src 'self' https://layout-survey.sywyar.top")
                 .contains("/js/pixiv-survey-frame-bridge.js")
+                .contains("/pixiv-posthog/pixiv-posthog.css")
                 .contains("/pixiv-layout-feedback/release-activation.js")
                 .contains("/pixiv-posthog/pixiv-posthog.js")
                 .contains("/pixiv-layout-feedback/posthog-config.js")
@@ -267,6 +268,7 @@ class LayoutSurveyContractTest {
         assertThat(embedJs)
                 .contains("openEmbedded()")
                 .contains("global.PixivSurveyFrameBridge.ready()")
+                .contains("global.PixivPostHog.showSurveyLoading")
                 .contains("storage: storage")
                 .contains("fetchImpl: global.fetch")
                 .contains("type: 'pixiv-survey-unavailable'")
@@ -275,19 +277,35 @@ class LayoutSurveyContractTest {
                 .doesNotContain("parent.postMessage");
         assertThat(pluginSource)
                 .contains("WebRouteContribution.admin(\"/pixiv-layout-feedback/embed.html\")")
+                .contains("new SurveyInboxMessage(")
                 .contains("LayoutFeedbackIdentityDeriver.CAMPAIGN_VERSION")
                 .contains("pixivBridgeGet=/api/layout-feedback/state")
+                .contains("pixivBridgeGet=/api/i18n/messages/posthog")
                 .contains("pixivBridgePost=/api/layout-feedback/state")
                 .contains("pixivBridgeRead=pixiv_theme")
-                .contains("\"notification.inbox\"")
-                .contains("\"notification.instance-key\", LayoutFeedbackIdentityDeriver.CAMPAIGN_VERSION")
-                .contains("\"notification.embed-url\", SURVEY_EMBED_URL")
-                .contains("\"notification.i18n-namespace\", \"layout-feedback\"");
+                .contains("SURVEY_EMBED_URL")
+                .contains("\"layout-feedback.inbox-title\"")
+                .contains("\"layout-feedback.inbox-body\"");
         assertThat(new top.sywyar.pixivdownload.download.DownloadWorkbenchPlugin().routes())
                 .filteredOn(route -> "/pixiv-layout-feedback/embed.html".equals(route.pathPattern()))
                 .singleElement()
                 .extracting(top.sywyar.pixivdownload.plugin.api.web.WebRouteContribution::accessPolicy)
                 .isEqualTo(top.sywyar.pixivdownload.plugin.api.web.AccessPolicy.ADMIN);
+        assertThat(new top.sywyar.pixivdownload.download.DownloadWorkbenchPlugin().routes())
+                .filteredOn(route -> route.pathPattern().startsWith("/pixiv-layout-feedback/")
+                        && !route.pathPattern().endsWith("embed.html"))
+                .extracting(top.sywyar.pixivdownload.plugin.api.web.WebRouteContribution::pathPattern)
+                .containsExactlyInAnyOrder(
+                        "/pixiv-layout-feedback/pixiv-layout-feedback.css",
+                        "/pixiv-layout-feedback/release-activation.js",
+                        "/pixiv-layout-feedback/posthog-config.js",
+                        "/pixiv-layout-feedback/pixiv-layout-feedback.js",
+                        "/pixiv-layout-feedback/embed.js");
+        assertThat(new top.sywyar.pixivdownload.download.DownloadWorkbenchPlugin().routes())
+                .filteredOn(route -> route.pathPattern().startsWith("/pixiv-layout-feedback/")
+                        && !route.pathPattern().endsWith("embed.html"))
+                .allSatisfy(route -> assertThat(route.accessPolicy())
+                        .isEqualTo(top.sywyar.pixivdownload.plugin.api.web.AccessPolicy.PUBLIC));
         var slots = new top.sywyar.pixivdownload.download.DownloadWorkbenchPlugin().uiSlots();
         if (!slots.isEmpty()) {
             assertThat(slots.get(0).metadata().get("notification.embed-url"))
@@ -349,7 +367,6 @@ class LayoutSurveyContractTest {
                 .contains("layout-feedback.close")
                 .contains("layout-feedback.inbox-title")
                 .contains("layout-feedback.inbox-body")
-                .contains("layout-feedback.embed-loading")
                 .contains("layout-feedback.embed-completed")
                 .contains("layout-feedback.embed-unavailable")
                 .contains("layout-feedback.embed-temporarily-unavailable");

--- a/pixivdownload-plugin-multi-mode-decision-survey/src/main/java/top/sywyar/pixivdownload/multimodesurvey/MultiModeDecisionSurveyPlugin.java
+++ b/pixivdownload-plugin-multi-mode-decision-survey/src/main/java/top/sywyar/pixivdownload/multimodesurvey/MultiModeDecisionSurveyPlugin.java
@@ -2,6 +2,7 @@ package top.sywyar.pixivdownload.multimodesurvey;
 
 import top.sywyar.pixivdownload.plugin.api.plugin.PixivFeaturePlugin;
 import top.sywyar.pixivdownload.plugin.api.plugin.PluginKind;
+import top.sywyar.pixivdownload.plugin.api.notification.SurveyInboxMessage;
 import top.sywyar.pixivdownload.plugin.api.web.I18nContribution;
 import top.sywyar.pixivdownload.plugin.api.web.StaticResourceContribution;
 import top.sywyar.pixivdownload.plugin.api.web.WebRouteContribution;
@@ -10,7 +11,6 @@ import top.sywyar.pixivdownload.plugin.api.web.WebUiSlotContribution;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 /** Inbox-only publisher for the official multi-user-mode decision survey. */
@@ -21,6 +21,7 @@ public class MultiModeDecisionSurveyPlugin implements PixivFeaturePlugin {
             "static/pixiv-multi-mode-decision-survey/release-publication.properties";
     private static final String SURVEY_EMBED_URL = "/pixiv-multi-mode-decision-survey/embed.html"
             + "?pixivBridgeGet=/api/i18n/meta"
+            + "&pixivBridgeGet=/api/i18n/messages/posthog"
             + "&pixivBridgeGet=/api/i18n/messages/multi-mode-decision-survey"
             + "&pixivBridgeGet=/api/multi-mode-decision-survey/identity"
             + "&pixivBridgeRead=pixiv_theme"
@@ -60,7 +61,11 @@ public class MultiModeDecisionSurveyPlugin implements PixivFeaturePlugin {
     @Override
     public List<WebRouteContribution> routes() {
         return List.of(
-                WebRouteContribution.admin("/pixiv-multi-mode-decision-survey/**"),
+                WebRouteContribution.admin("/pixiv-multi-mode-decision-survey/embed.html"),
+                WebRouteContribution.publicRoute("/pixiv-multi-mode-decision-survey/survey.css"),
+                WebRouteContribution.publicRoute("/pixiv-multi-mode-decision-survey/release-activation.js"),
+                WebRouteContribution.publicRoute("/pixiv-multi-mode-decision-survey/posthog-config.js"),
+                WebRouteContribution.publicRoute("/pixiv-multi-mode-decision-survey/survey.js"),
                 WebRouteContribution.admin("/api/multi-mode-decision-survey/identity"));
     }
 
@@ -81,18 +86,14 @@ public class MultiModeDecisionSurveyPlugin implements PixivFeaturePlugin {
         if (!officialRelease()) {
             return List.of();
         }
-        return List.of(new WebUiSlotContribution(
+        return List.of(new SurveyInboxMessage(
                 "multi-mode-decision-survey.inbox",
-                "notification.inbox",
-                null,
-                20,
-                Map.of(
-                        "notification.category", "survey",
-                        "notification.instance-key", MultiModeDecisionSurveyIdentityController.CAMPAIGN_VERSION,
-                        "notification.embed-url", SURVEY_EMBED_URL,
-                        "notification.i18n-namespace", ID,
-                        "notification.title-key", "inbox-title",
-                        "notification.body-key", "inbox-body")));
+                MultiModeDecisionSurveyIdentityController.CAMPAIGN_VERSION,
+                SURVEY_EMBED_URL,
+                ID,
+                "inbox-title",
+                "inbox-body",
+                20).toUiSlotContribution());
     }
 
     private static boolean officialRelease() {

--- a/pixivdownload-plugin-multi-mode-decision-survey/src/main/resources/i18n/web/multi-mode-decision-survey.properties
+++ b/pixivdownload-plugin-multi-mode-decision-survey/src/main/resources/i18n/web/multi-mode-decision-survey.properties
@@ -15,6 +15,5 @@ required=请选择一个选项。
 other-required=选择“其他”时请填写说明。
 submit-failed=提交失败，请稍后重试。
 completed=感谢反馈，您的回答已提交。
-loading=正在加载调查…
 unavailable=调查暂时无法加载，请稍后重试。
 ended=该调查已结束。

--- a/pixivdownload-plugin-multi-mode-decision-survey/src/main/resources/i18n/web/multi-mode-decision-survey_en.properties
+++ b/pixivdownload-plugin-multi-mode-decision-survey/src/main/resources/i18n/web/multi-mode-decision-survey_en.properties
@@ -15,6 +15,5 @@ required=Please select an option.
 other-required=Please add a description when selecting Other.
 submit-failed=Submission failed. Please try again later.
 completed=Thank you. Your response has been submitted.
-loading=Loading survey...
 unavailable=The survey is temporarily unavailable. Please try again later.
 ended=This survey has ended.

--- a/pixivdownload-plugin-multi-mode-decision-survey/src/main/resources/static/pixiv-multi-mode-decision-survey/embed.html
+++ b/pixivdownload-plugin-multi-mode-decision-survey/src/main/resources/static/pixiv-multi-mode-decision-survey/embed.html
@@ -8,6 +8,7 @@
     <meta name="referrer" content="no-referrer">
     <title>Multi-user mode decision survey</title>
     <link rel="stylesheet" href="/pixiv-multi-mode-decision-survey/survey.css">
+    <link rel="stylesheet" href="/pixiv-posthog/pixiv-posthog.css">
 </head>
 <body>
 <main id="multiModeDecisionSurvey" class="survey-status" role="status" aria-live="polite"></main>

--- a/pixivdownload-plugin-multi-mode-decision-survey/src/main/resources/static/pixiv-multi-mode-decision-survey/survey.js
+++ b/pixivdownload-plugin-multi-mode-decision-survey/src/main/resources/static/pixiv-multi-mode-decision-survey/survey.js
@@ -85,6 +85,7 @@
         function status(key, fallback) {
             root.className = 'survey-status';
             root.setAttribute('role', 'status');
+            root.setAttribute('aria-busy', 'false');
             root.textContent = t(key, fallback);
             reportHeight();
         }
@@ -162,6 +163,7 @@
         function renderForm(client, question, identity) {
             root.className = 'survey-card';
             root.removeAttribute('role');
+            root.setAttribute('aria-busy', 'false');
             root.textContent = '';
 
             var title = global.document.createElement('h2');
@@ -269,6 +271,10 @@
         }
 
         try {
+            var loading = global.PixivPostHog
+                    && typeof global.PixivPostHog.showSurveyLoading === 'function'
+                ? global.PixivPostHog.showSurveyLoading(root, {lang: params.get('lang') || undefined})
+                : Promise.resolve();
             var bridge = await global.PixivSurveyFrameBridge.ready();
             storage = bridge.storage;
             if (global.PixivTheme) {
@@ -278,7 +284,7 @@
                 namespaces: ['multi-mode-decision-survey'],
                 lang: params.get('lang') || undefined
             });
-            status('loading', '正在加载调查…');
+            await loading;
             if (global.PixivMultiModeDecisionSurveyOfficialRelease !== true
                     || !global.PixivPostHog || typeof global.PixivPostHog.createSurveyClient !== 'function'
                     || typeof global.PixivPostHog.captureSurveyWithAck !== 'function') {

--- a/pixivdownload-plugin-multi-mode-decision-survey/src/test/java/top/sywyar/pixivdownload/multimodesurvey/MultiModeDecisionSurveyPluginTest.java
+++ b/pixivdownload-plugin-multi-mode-decision-survey/src/test/java/top/sywyar/pixivdownload/multimodesurvey/MultiModeDecisionSurveyPluginTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MultiModeDecisionSurveyPluginTest {
 
     @Test
-    @DisplayName("只贡献管理员站内信资源并按发行激活位发布站内信")
+    @DisplayName("调查页面与身份保持管理员可见且 sandbox 静态资源可加载")
     void contributesOnlyAdminInboxSurveyAndDefaultsOff() throws Exception {
         Properties descriptor = new Properties();
         try (InputStream input = getClass().getResourceAsStream("/plugin.properties")) {
@@ -28,11 +28,20 @@ class MultiModeDecisionSurveyPluginTest {
         assertThat(new MultiModeDecisionSurveyPf4jPlugin()).isInstanceOf(PixivPluginProvider.class);
 
         MultiModeDecisionSurveyPlugin plugin = new MultiModeDecisionSurveyPlugin();
-        assertThat(plugin.routes()).allSatisfy(route ->
-                assertThat(route.accessPolicy()).isEqualTo(AccessPolicy.ADMIN));
         assertThat(plugin.routes()).extracting(route -> route.pathPattern()).containsExactly(
-                "/pixiv-multi-mode-decision-survey/**",
+                "/pixiv-multi-mode-decision-survey/embed.html",
+                "/pixiv-multi-mode-decision-survey/survey.css",
+                "/pixiv-multi-mode-decision-survey/release-activation.js",
+                "/pixiv-multi-mode-decision-survey/posthog-config.js",
+                "/pixiv-multi-mode-decision-survey/survey.js",
                 "/api/multi-mode-decision-survey/identity");
+        assertThat(plugin.routes()).filteredOn(route -> route.pathPattern().endsWith("embed.html")
+                        || route.pathPattern().startsWith("/api/"))
+                .allSatisfy(route -> assertThat(route.accessPolicy()).isEqualTo(AccessPolicy.ADMIN));
+        assertThat(plugin.routes()).filteredOn(route -> route.pathPattern().startsWith(
+                        "/pixiv-multi-mode-decision-survey/")
+                        && !route.pathPattern().endsWith("embed.html"))
+                .allSatisfy(route -> assertThat(route.accessPolicy()).isEqualTo(AccessPolicy.PUBLIC));
         assertThat(plugin.staticResources()).singleElement().satisfies(resource ->
                 assertThat(resource.publicPathPrefix()).isEqualTo("/pixiv-multi-mode-decision-survey/"));
         assertThat(plugin.i18n()).singleElement().satisfies(bundle ->
@@ -52,6 +61,7 @@ class MultiModeDecisionSurveyPluginTest {
                     .isEqualTo("multi-mode-decision-v1");
             assertThat(slots.get(0).metadata().get("notification.embed-url"))
                     .contains("pixivBridgeGet=/api/multi-mode-decision-survey/identity")
+                    .contains("pixivBridgeGet=/api/i18n/messages/posthog")
                     .contains("pixivBridgeRead=pixiv_theme")
                     .contains("pixivBridgeWrite=pixiv:multi-mode-decision-survey:state:v1");
         }
@@ -95,10 +105,13 @@ class MultiModeDecisionSurveyPluginTest {
         }
         assertThat(embed)
                 .contains("/js/pixiv-survey-frame-bridge.js")
+                .contains("/pixiv-posthog/pixiv-posthog.css")
                 .contains("/pixiv-multi-mode-decision-survey/posthog-config.js");
         assertThat(script)
                 .contains("global.PixivSurveyFrameBridge.ready()")
+                .contains("global.PixivPostHog.showSurveyLoading")
                 .contains("global.PixivSurveyFrameBridge.post({")
+                .doesNotContain("status('loading'")
                 .doesNotContain("parent.postMessage")
                 .doesNotContain("global.localStorage");
     }

--- a/pixivdownload-plugin-multi-mode-decision-survey/src/test/js/multi-mode-decision-survey.test.js
+++ b/pixivdownload-plugin-multi-mode-decision-survey/src/test/js/multi-mode-decision-survey.test.js
@@ -90,3 +90,11 @@ test('waits for remote acknowledgement before recording completion', () => {
     assert.match(source, /SUBMISSION_ID\.test\(body\.submissionId\)/);
     assert.doesNotMatch(source, /client\.capture\('survey sent'/);
 });
+
+test('uses the shared PostHog loading state instead of a survey-specific one', () => {
+    const source = fs.readFileSync(path.join(__dirname, '../../main/resources/static',
+        'pixiv-multi-mode-decision-survey', 'survey.js'), 'utf8');
+
+    assert.match(source, /PixivPostHog\.showSurveyLoading\(root/);
+    assert.doesNotMatch(source, /status\('loading'/);
+});

--- a/pixivdownload-plugin-notification/src/main/java/top/sywyar/pixivdownload/notificationbase/NotificationInboxService.java
+++ b/pixivdownload-plugin-notification/src/main/java/top/sywyar/pixivdownload/notificationbase/NotificationInboxService.java
@@ -1,10 +1,13 @@
 package top.sywyar.pixivdownload.notificationbase;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 import top.sywyar.pixivdownload.i18n.LocaleBundlePolicy;
 import top.sywyar.pixivdownload.notification.NotificationSeverity;
 import top.sywyar.pixivdownload.i18n.NamespaceMessageResolver;
 import top.sywyar.pixivdownload.plugin.api.notification.NotificationTemplateContribution;
+import top.sywyar.pixivdownload.plugin.api.notification.SurveyInboxMessage;
 import top.sywyar.pixivdownload.plugin.api.web.WebUiSlotCatalog;
 import top.sywyar.pixivdownload.plugin.api.web.WebUiSlotContribution;
 
@@ -28,13 +31,11 @@ import java.util.regex.Pattern;
 
 public class NotificationInboxService {
 
+    private static final Logger LOG = LoggerFactory.getLogger(NotificationInboxService.class);
     private static final int MAX_ACTION_URL_BYTES = 8 * 1_024;
     private static final int MAX_CONTENT_URL_BYTES = 2 * 1_024;
     private static final String CONTENT_HOST = "sywyar.github.io";
     private static final String REMOTE_ANNOUNCEMENT_ID_PREFIX = "remote-announcement:";
-    private static final String PERSISTENT_SURVEY_TARGET = "notification.inbox";
-    private static final Pattern SLOT_ID = Pattern.compile("[a-z0-9][a-z0-9.-]{0,127}");
-    private static final Pattern I18N_TOKEN = Pattern.compile("[a-z0-9][a-z0-9.-]{0,159}");
     private static final Pattern REMOTE_ANNOUNCEMENT_ID = Pattern.compile("[a-z0-9][a-z0-9-]{0,79}");
     private static final Pattern REMOTE_LOCALE_TAG = Pattern.compile("[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})+");
     private static final Pattern SHA256 = Pattern.compile("[0-9a-f]{64}");
@@ -361,9 +362,9 @@ public class NotificationInboxService {
 
     public synchronized void synchronizePersistentSurveys() {
         List<PersistentSurvey> active = uiSlots.uiSlots().stream()
-                .filter(slot -> PERSISTENT_SURVEY_TARGET.equals(slot.target()))
+                .map(NotificationInboxService::surveyInboxMessage)
+                .flatMap(Optional::stream)
                 .map(NotificationInboxService::persistentSurvey)
-                .filter(Objects::nonNull)
                 .sorted(java.util.Comparator.comparing(PersistentSurvey::id))
                 .toList();
         if (active.equals(persistentSurveys)) {
@@ -378,6 +379,17 @@ public class NotificationInboxService {
                     survey.embedUrl(), now, null));
         }
         persistentSurveys = active;
+    }
+
+    private static Optional<SurveyInboxMessage> surveyInboxMessage(WebUiSlotContribution slot) {
+        try {
+            return SurveyInboxMessage.fromUiSlotContribution(slot);
+        } catch (IllegalArgumentException exception) {
+            LOG.warn("[survey-inbox-contribution-invalid] Ignoring invalid survey inbox slot [{}]: {}",
+                    slot == null ? "<null>" : Objects.toString(slot.slotId(), "<null>"),
+                    exception.getMessage());
+            return Optional.empty();
+        }
     }
 
     int pruneRetentionPool() {
@@ -491,38 +503,12 @@ public class NotificationInboxService {
         return List.copyOf(candidates);
     }
 
-    private static PersistentSurvey persistentSurvey(WebUiSlotContribution slot) {
-        if (slot == null || !SLOT_ID.matcher(Objects.toString(slot.slotId(), "")).matches()) {
-            return null;
-        }
-        Map<String, String> metadata = slot.metadata();
-        if (!NotificationCategory.SURVEY.token().equals(metadata.get("notification.category"))) {
-            return null;
-        }
-        String instanceKey = metadata.get("notification.instance-key");
-        if (instanceKey == null || !SLOT_ID.matcher(instanceKey).matches()) {
-            return null;
-        }
-        String namespace = metadata.get("notification.i18n-namespace");
-        String titleKey = metadata.get("notification.title-key");
-        String bodyKey = metadata.get("notification.body-key");
-        if (!i18nToken(namespace) || !i18nToken(titleKey) || !i18nToken(bodyKey)) {
-            return null;
-        }
-        String embedUrl;
-        try {
-            embedUrl = safeEmbeddedContentUrl(metadata.get("notification.embed-url"));
-        } catch (IllegalArgumentException ignored) {
-            return null;
-        }
+    private static PersistentSurvey persistentSurvey(SurveyInboxMessage message) {
         return new PersistentSurvey(
-                NotificationMessage.PERSISTENT_SURVEY_ID_PREFIX + slot.slotId() + ":" + instanceKey,
-                slot.slotId(),
-                embedUrl, namespace, titleKey, bodyKey);
-    }
-
-    private static boolean i18nToken(String value) {
-        return value != null && I18N_TOKEN.matcher(value).matches();
+                NotificationMessage.PERSISTENT_SURVEY_ID_PREFIX
+                        + message.messageKey() + ":" + message.instanceKey(),
+                message.messageKey(),
+                message.contentUrl(), message.i18nNamespace(), message.titleKey(), message.bodyKey());
     }
 
     private static String safeEmbeddedContentUrl(String value) {

--- a/pixivdownload-plugin-notification/src/main/resources/static/pixiv-notifications/pixiv-notifications.js
+++ b/pixivdownload-plugin-notification/src/main/resources/static/pixiv-notifications/pixiv-notifications.js
@@ -84,14 +84,9 @@
     }
 
     function clearSelection(updateHistory) {
-        var selectedId = state.selectedId;
         state.selectedId = '';
         state.selectedMessage = null;
         var detail = resetDetail();
-        var selectedFrame = contentFrames.get(selectedId);
-        if (selectedFrame && selectedFrame.getAttribute('data-embedded-survey') === 'true') {
-            discardContentFrame(selectedId);
-        }
         if (emptyDetail) {
             detail.insertBefore(emptyDetail, contentFrameHost);
             if (pageI18n) pageI18n.apply(detail);
@@ -412,11 +407,6 @@
     }
 
     async function selectMessage(id, updateHistory) {
-        var previousFrame = contentFrames.get(state.selectedId);
-        if (state.selectedId !== id && previousFrame
-                && previousFrame.getAttribute('data-embedded-survey') === 'true') {
-            discardContentFrame(state.selectedId);
-        }
         state.selectedId = id;
         state.selectedMessage = state.messages.find(function (message) { return message.id === id; }) || null;
         renderList();

--- a/pixivdownload-plugin-notification/src/test/java/top/sywyar/pixivdownload/notificationbase/NotificationInboxServiceTest.java
+++ b/pixivdownload-plugin-notification/src/test/java/top/sywyar/pixivdownload/notificationbase/NotificationInboxServiceTest.java
@@ -1,8 +1,12 @@
 package top.sywyar.pixivdownload.notificationbase;
 
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import top.sywyar.pixivdownload.notification.NotificationSeverity;
+import top.sywyar.pixivdownload.plugin.api.notification.SurveyInboxMessage;
 import top.sywyar.pixivdownload.plugin.api.web.WebUiSlotContribution;
 
 import java.util.ArrayList;
@@ -353,11 +357,25 @@ class NotificationInboxServiceTest {
                         "notification.title-key", "layout-feedback.inbox-title",
                         "notification.body-key", "layout-feedback.inbox-body"));
 
-        new NotificationInboxService(
-                mapper, () -> 500, () -> 90, () -> List.of(unsafe),
-                (namespace, locale, key) -> java.util.Optional.empty(), locale -> locale);
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger)
+                LoggerFactory.getLogger(NotificationInboxService.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            new NotificationInboxService(
+                    mapper, () -> 500, () -> 90, () -> List.of(unsafe),
+                    (namespace, locale, key) -> java.util.Optional.empty(), locale -> locale);
 
-        assertThat(mapper.messages).isEmpty();
+            assertThat(mapper.messages).isEmpty();
+            assertThat(appender.list).extracting(ILoggingEvent::getFormattedMessage)
+                    .anySatisfy(message -> assertThat(message)
+                            .contains("survey-inbox-contribution-invalid", "unsafe.survey")
+                            .doesNotContain("https://evil.example"));
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
     }
 
     @Test
@@ -394,15 +412,14 @@ class NotificationInboxServiceTest {
     }
 
     private static WebUiSlotContribution surveySlot(String instanceKey, String embedUrl) {
-        return new WebUiSlotContribution(
-                "download-workbench.layout-survey", "notification.inbox", null, 10,
-                java.util.Map.of(
-                        "notification.category", "survey",
-                        "notification.instance-key", instanceKey,
-                        "notification.embed-url", embedUrl,
-                        "notification.i18n-namespace", "layout-feedback",
-                        "notification.title-key", "layout-feedback.inbox-title",
-                        "notification.body-key", "layout-feedback.inbox-body"));
+        return new SurveyInboxMessage(
+                "download-workbench.layout-survey",
+                instanceKey,
+                embedUrl,
+                "layout-feedback",
+                "layout-feedback.inbox-title",
+                "layout-feedback.inbox-body",
+                10).toUiSlotContribution();
     }
 
     static final class MemoryMapper implements NotificationInboxMapper {

--- a/pixivdownload-plugin-notification/src/test/js/notification-inbox-slot.test.js
+++ b/pixivdownload-plugin-notification/src/test/js/notification-inbox-slot.test.js
@@ -509,12 +509,22 @@ test('调查 iframe 通过共享 bridge 延迟挂载并携带当前语言', asyn
         id: 'survey', category: 'survey', title: 'Survey', embeddedContentUrl: '/survey/embed',
         deletable: false, readTime: 1
     });
-    const h = await pageHarness({messages: [survey], categoryUnreadCount: 0}, {surveyBridge: true});
+    const plain = pageMessage({id: 'plain', title: 'Plain'});
+    const h = await pageHarness({messages: [survey, plain], categoryUnreadCount: 0}, {surveyBridge: true});
     assert.equal(h.bridge.attachments.length, 0);
-    await h.document.getElementById('notificationList').children[0].emit('click');
+    const list = h.document.getElementById('notificationList');
+    await list.children[0].emit('click');
     assert.equal(h.bridge.attachments.length, 1);
     assert.match(h.bridge.attachments[0].source, /^\/survey\/embed\?notificationId=survey&lang=en-US$/);
-    assert.equal(h.bridge.attachments[0].frame.getAttribute('data-embedded-survey'), 'true');
+    const frame = h.bridge.attachments[0].frame;
+    assert.equal(frame.getAttribute('data-embedded-survey'), 'true');
+
+    await list.children[1].emit('click');
+    assert.equal(frame.hidden, true);
+    await list.children[0].emit('click');
+    assert.equal(h.document.querySelectorAll('.notification-detail-content-frame').length, 1);
+    assert.equal(h.document.querySelectorAll('.notification-detail-content-frame')[0], frame);
+    assert.equal(h.bridge.attachments.length, 1);
 });
 
 test('公告自动已读且当前分类全部已读使用对应 API', async () => {

--- a/pixivdownload-plugin-posthog/src/main/java/top/sywyar/pixivdownload/posthog/PostHogPlugin.java
+++ b/pixivdownload-plugin-posthog/src/main/java/top/sywyar/pixivdownload/posthog/PostHogPlugin.java
@@ -45,16 +45,15 @@ public class PostHogPlugin implements PixivFeaturePlugin {
 
     @Override
     public List<WebRouteContribution> routes() {
-        return List.of(
-                WebRouteContribution.visitor("/pixiv-posthog/**"),
-                WebRouteContribution.visitor("/vendor/posthog-js/**"));
+        return List.of(WebRouteContribution.publicRoute("/pixiv-posthog/**"));
     }
 
     @Override
     public List<StaticResourceContribution> staticResources() {
         return List.of(
                 new StaticResourceContribution("classpath:/static/pixiv-posthog/", "/pixiv-posthog/"),
-                new StaticResourceContribution("classpath:/static/vendor/posthog-js/", "/vendor/posthog-js/"));
+                new StaticResourceContribution(
+                        "classpath:/static/vendor/posthog-js/", "/pixiv-posthog/vendor/posthog-js/"));
     }
 
     @Override

--- a/pixivdownload-plugin-posthog/src/main/resources/i18n/web/posthog.properties
+++ b/pixivdownload-plugin-posthog/src/main/resources/i18n/web/posthog.properties
@@ -1,2 +1,3 @@
 plugin.name=PostHog 调查支持
 plugin.summary=为其它插件提供由调用方配置的隔离 PostHog 调查客户端。
+survey.loading=正在加载调查…

--- a/pixivdownload-plugin-posthog/src/main/resources/i18n/web/posthog_en.properties
+++ b/pixivdownload-plugin-posthog/src/main/resources/i18n/web/posthog_en.properties
@@ -1,2 +1,3 @@
 plugin.name=PostHog Survey Support
 plugin.summary=Provides caller-configured isolated PostHog survey clients for other plugins.
+survey.loading=Loading survey…

--- a/pixivdownload-plugin-posthog/src/main/resources/static/pixiv-posthog/pixiv-posthog.css
+++ b/pixivdownload-plugin-posthog/src/main/resources/static/pixiv-posthog/pixiv-posthog.css
@@ -1,0 +1,31 @@
+.pixiv-posthog-survey-loading {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-height: 72px;
+    margin: 0;
+    padding: 18px;
+    border: 1px solid var(--survey-line, var(--line, color-mix(in srgb, CanvasText 22%, transparent)));
+    border-radius: 12px;
+    background: var(--survey-panel, var(--surface, var(--card-bg, Canvas)));
+    color: var(--survey-muted, var(--muted, CanvasText));
+    font: 14px/1.6 system-ui, sans-serif;
+}
+
+.pixiv-posthog-survey-loading-spinner {
+    width: 18px;
+    height: 18px;
+    flex: 0 0 auto;
+    border: 2px solid color-mix(in srgb, currentColor 24%, transparent);
+    border-top-color: var(--survey-brand, var(--brand, Highlight));
+    border-radius: 50%;
+    animation: pixiv-posthog-survey-loading-spin .8s linear infinite;
+}
+
+@keyframes pixiv-posthog-survey-loading-spin {
+    to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .pixiv-posthog-survey-loading-spinner { animation: none; }
+}

--- a/pixivdownload-plugin-posthog/src/main/resources/static/pixiv-posthog/pixiv-posthog.js
+++ b/pixivdownload-plugin-posthog/src/main/resources/static/pixiv-posthog/pixiv-posthog.js
@@ -5,7 +5,7 @@
     var CAPTURE_ACK_TIMEOUT_MS = 15000;
     var UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
     var SDK_VERSION = '1.409.5';
-    var SDK_URL = '/vendor/posthog-js/' + SDK_VERSION + '/array.full.js';
+    var SDK_URL = '/pixiv-posthog/vendor/posthog-js/' + SDK_VERSION + '/array.full.js';
     var clients = Object.create(null);
     var sdkPromise = null;
     var ALLOWED_API_ORIGINS = Object.freeze([
@@ -22,6 +22,56 @@
         if (global.console && typeof global.console.warn === 'function') {
             try { global.console.warn(message); } catch (_) { /* best effort */ }
         }
+    }
+
+    function showSurveyLoading(root, options) {
+        options = options || {};
+        if (!root || !root.classList || !global.document) return Promise.resolve(false);
+        var document = root.ownerDocument || global.document;
+        var spinner = document.createElement('span');
+        spinner.className = 'pixiv-posthog-survey-loading-spinner';
+        spinner.setAttribute('aria-hidden', 'true');
+        var label = document.createElement('span');
+        label.className = 'pixiv-posthog-survey-loading-label';
+        label.textContent = '正在加载调查…';
+        root.textContent = '';
+        root.classList.add('pixiv-posthog-survey-loading');
+        root.setAttribute('role', 'status');
+        root.setAttribute('aria-live', 'polite');
+        root.setAttribute('aria-busy', 'true');
+        root.append(spinner, label);
+
+        function reportHeight() {
+            if (!global.PixivSurveyFrameBridge
+                    || typeof global.PixivSurveyFrameBridge.post !== 'function') return;
+            var bounds = typeof root.getBoundingClientRect === 'function'
+                ? root.getBoundingClientRect() : {height: 0};
+            var height = Math.ceil(Math.max(Number(root.scrollHeight) || 0, Number(bounds.height) || 0));
+            if (height > 0) {
+                global.PixivSurveyFrameBridge.post({type: 'pixiv-content-height', height: height});
+            }
+        }
+
+        if (!global.PixivSurveyFrameBridge
+                || typeof global.PixivSurveyFrameBridge.ready !== 'function') {
+            return Promise.resolve(true);
+        }
+        return global.PixivSurveyFrameBridge.ready().then(function () {
+            reportHeight();
+            if (!global.PixivI18n || typeof global.PixivI18n.create !== 'function') return null;
+            return global.PixivI18n.create({
+                namespaces: ['posthog'],
+                lang: typeof options.lang === 'string' && options.lang ? options.lang : undefined
+            });
+        }).then(function (i18n) {
+            if (i18n && root.classList.contains('pixiv-posthog-survey-loading')) {
+                label.textContent = i18n.t('posthog:survey.loading', '正在加载调查…');
+                reportHeight();
+            }
+            return true;
+        }).catch(function () {
+            return true;
+        });
     }
 
     function loadSdk() {
@@ -285,6 +335,7 @@
     }
 
     global.PixivPostHog = Object.freeze({
+        showSurveyLoading: showSurveyLoading,
         createSurveyClient: createSurveyClient,
         captureSurveyWithAck: captureSurveyWithAck
     });

--- a/pixivdownload-plugin-posthog/src/test/java/top/sywyar/pixivdownload/posthog/PostHogPf4jPluginTest.java
+++ b/pixivdownload-plugin-posthog/src/test/java/top/sywyar/pixivdownload/posthog/PostHogPf4jPluginTest.java
@@ -28,9 +28,9 @@ class PostHogPf4jPluginTest {
         assertThat(new PostHogPf4jPlugin()).isInstanceOf(PixivPluginProvider.class);
 
         PostHogPlugin plugin = new PostHogPlugin();
-        assertThat(plugin.routes()).allSatisfy(route -> assertThat(route.accessPolicy()).isEqualTo(AccessPolicy.VISITOR));
+        assertThat(plugin.routes()).allSatisfy(route -> assertThat(route.accessPolicy()).isEqualTo(AccessPolicy.PUBLIC));
         assertThat(plugin.routes()).extracting(route -> route.pathPattern())
-                .containsExactly("/pixiv-posthog/**", "/vendor/posthog-js/**");
+                .containsExactly("/pixiv-posthog/**");
         assertThat(plugin.staticResources()).hasSize(2);
         assertThat(plugin.i18n()).hasSize(1);
     }
@@ -45,14 +45,15 @@ class PostHogPf4jPluginTest {
         }
         assertThat(adapter)
                 .contains("var SDK_VERSION = '1.409.5'")
-                .contains("var SDK_URL = '/vendor/posthog-js/' + SDK_VERSION + '/array.full.js'")
-                .contains("ownerKey", "options.posthog", "createSurveyClient")
+                .contains("var SDK_URL = '/pixiv-posthog/vendor/posthog-js/' + SDK_VERSION + '/array.full.js'")
+                .contains("ownerKey", "options.posthog", "showSurveyLoading", "createSurveyClient")
                 .doesNotContain("phc_nBnHrYwgVVN6CvzAsQ5r4NxuSJyVPmceeHwwcpcgbG3k")
                 .doesNotContain("surveyId: '")
                 .doesNotContain("https://layout-survey.sywyar.top")
                 .doesNotContain("download-workbench.layout-feedback")
                 .contains("bootstrap = {distinctID: options.distinctId, isIdentifiedID: false}")
                 .doesNotContain("personalApiKey", "serviceAccountToken");
+        assertThat(getClass().getResource("/static/pixiv-posthog/pixiv-posthog.css")).isNotNull();
         assertThat(getClass().getResource("/static/vendor/posthog-js/1.409.5/array.full.js")).isNotNull();
         assertThat(getClass().getResource("/META-INF/licenses/posthog-js/LICENSE")).isNotNull();
         assertThat(getClass().getResource("/META-INF/licenses/posthog-js/SOURCE.txt")).isNotNull();

--- a/pixivdownload-plugin-posthog/src/test/js/pixiv-posthog.test.js
+++ b/pixivdownload-plugin-posthog/src/test/js/pixiv-posthog.test.js
@@ -95,6 +95,55 @@ async function main() {
     vm.runInContext(source, sandbox, {filename: 'pixiv-posthog.js'});
 
     const api = sandbox.PixivPostHog;
+    const posted = [];
+    const loadingDocument = {
+        createElement(tag) {
+            const classes = new Set();
+            return {
+                tagName: tag.toUpperCase(), attributes: {}, textContent: '', className: '',
+                classList: {
+                    add(value) { classes.add(value); },
+                    contains(value) { return classes.has(value); }
+                },
+                setAttribute(name, value) { this.attributes[name] = String(value); },
+                getAttribute(name) { return this.attributes[name] ?? null; }
+            };
+        }
+    };
+    const rootClasses = new Set();
+    const root = {
+        ownerDocument: loadingDocument, children: [], attributes: {}, textContent: '', scrollHeight: 72,
+        classList: {
+            add(value) { rootClasses.add(value); },
+            contains(value) { return rootClasses.has(value); }
+        },
+        setAttribute(name, value) { this.attributes[name] = String(value); },
+        getAttribute(name) { return this.attributes[name] ?? null; },
+        append(...children) { this.children.push(...children); },
+        getBoundingClientRect() { return {height: 72}; }
+    };
+    let loadingI18nOptions = null;
+    sandbox.document = loadingDocument;
+    sandbox.PixivSurveyFrameBridge = {
+        ready() { return Promise.resolve({}); },
+        post(message) { posted.push(message); return true; }
+    };
+    sandbox.PixivI18n = {
+        create(options) {
+            loadingI18nOptions = options;
+            return Promise.resolve({t() { return 'Loading survey…'; }});
+        }
+    };
+    assert.equal(await api.showSurveyLoading(root, {lang: 'en-US'}), true);
+    assert.equal(rootClasses.has('pixiv-posthog-survey-loading'), true);
+    assert.equal(root.getAttribute('aria-busy'), 'true');
+    assert.equal(root.children[0].className, 'pixiv-posthog-survey-loading-spinner');
+    assert.equal(root.children[1].textContent, 'Loading survey…');
+    assert.equal(loadingI18nOptions.lang, 'en-US');
+    assert.equal(String(loadingI18nOptions.namespaces), 'posthog');
+    assert.deepEqual(posted, [{type: 'pixiv-content-height', height: 72},
+        {type: 'pixiv-content-height', height: 72}]);
+
     const filter = event => event;
     const posthog = {
         projectToken: 'phc_owner_one',
@@ -296,7 +345,9 @@ async function main() {
     timeoutCallback();
     await assert.rejects(timedOut, /request aborted/);
     assert.strictEqual(timeoutCallback, null);
-    assert.deepStrictEqual(Object.keys(api), ['createSurveyClient', 'captureSurveyWithAck']);
+    assert.deepStrictEqual(Object.keys(api), [
+        'showSurveyLoading', 'createSurveyClient', 'captureSurveyWithAck'
+    ]);
     await testSynchronousLoadFailureCanRetry();
     console.log('pixiv-posthog.test.js: passed');
 }


### PR DESCRIPTION
## 变更内容

- 新增问卷站内信纯值封装，发布插件继续拥有正文与本地化资源
- 由通知插件同步长期问卷状态，并复用已加载的调查正文 iframe
- 由 PostHog 插件统一调查加载态、样式和共享浏览器资源
- 保持管理员正文入口、sandbox bridge allowlist 与插件缺席降级边界

## 验证

- [x] 已运行与风险相称的构建 / 测试 / gate
- [x] required checks 全部通过
- [x] CHANGELOG 已按现有未发布调查条目判断，无需重复更新
