### PR TITLE
fix(release): 升级可信发布门禁至 Epoch 5

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -109,14 +109,26 @@ jobs:
         run: |
           GATE_DIR="$RUNNER_TEMP/trusted-gate"
           mkdir -p "$GATE_DIR"
+          if git cat-file -e "$BASE_SHA:scripts/ci/release-gate-policy.json" 2>/dev/null; then
+            GATE_EPOCH=5
+            git show "$BASE_SHA:scripts/ci/release-gate-policy.json" > "$RUNNER_TEMP/gate-policy.json"
+            node -e 'const p=require(process.argv[1]); console.log(p.protectedCore.join("\n"))' "$RUNNER_TEMP/gate-policy.json" > "$RUNNER_TEMP/gate-files.txt"
+          else
+            GATE_EPOCH=4
+            git show "$BASE_SHA:scripts/i18n/gate-policy.json" > "$RUNNER_TEMP/gate-policy.json"
+            node -e 'const p=require(process.argv[1]); console.log(p.minimumTrustedVerifier.requiredFiles.join("\n"))' "$RUNNER_TEMP/gate-policy.json" > "$RUNNER_TEMP/gate-files.txt"
+          fi
           while IFS= read -r rel; do
             mkdir -p "$GATE_DIR/$(dirname "$rel")"
             git show "$BASE_SHA:$rel" > "$GATE_DIR/$rel"
-          done < <(node -e 'const p=require("./scripts/i18n/gate-policy.json"); console.log(p.minimumTrustedVerifier.requiredFiles.join("\n"))')
+          done < "$RUNNER_TEMP/gate-files.txt"
+          echo "GATE_EPOCH=$GATE_EPOCH" >> "$GITHUB_ENV"
           echo "GATE_DIR=$GATE_DIR" >> "$GITHUB_ENV"
       - name: Run trusted signature guard
         run: |
-          if [ "$GATE_MODE" = "ROOT_ADMISSION" ]; then
+          if [ "$GATE_EPOCH" = "5" ]; then
+            node "$GATE_DIR/scripts/ci/release-gate-verifier.mjs" --repo-root . --trusted-ref "$BASE_SHA" --candidate-ref "$CANDIDATE_SHA" --signature
+          elif [ "$GATE_MODE" = "ROOT_ADMISSION" ]; then
             node scripts/ci/gate-parity.mjs --repo-root . --candidate-ref "$CANDIDATE_SHA" --invariants --signature
           else
             node "$GATE_DIR/scripts/ci/gate-parity.mjs" --repo-root . --trusted-dir "$GATE_DIR" --trusted-ref "$BASE_SHA" --candidate-ref "$CANDIDATE_SHA" --signature
@@ -168,14 +180,26 @@ jobs:
         run: |
           GATE_DIR="$RUNNER_TEMP/trusted-gate"
           mkdir -p "$GATE_DIR"
+          if git cat-file -e "$BASE_SHA:scripts/ci/release-gate-policy.json" 2>/dev/null; then
+            GATE_EPOCH=5
+            git show "$BASE_SHA:scripts/ci/release-gate-policy.json" > "$RUNNER_TEMP/gate-policy.json"
+            node -e 'const p=require(process.argv[1]); console.log(p.protectedCore.join("\n"))' "$RUNNER_TEMP/gate-policy.json" > "$RUNNER_TEMP/gate-files.txt"
+          else
+            GATE_EPOCH=4
+            git show "$BASE_SHA:scripts/i18n/gate-policy.json" > "$RUNNER_TEMP/gate-policy.json"
+            node -e 'const p=require(process.argv[1]); console.log(p.minimumTrustedVerifier.requiredFiles.join("\n"))' "$RUNNER_TEMP/gate-policy.json" > "$RUNNER_TEMP/gate-files.txt"
+          fi
           while IFS= read -r rel; do
             mkdir -p "$GATE_DIR/$(dirname "$rel")"
             git show "$BASE_SHA:$rel" > "$GATE_DIR/$rel"
-          done < <(node -e 'const p=require("./scripts/i18n/gate-policy.json"); console.log(p.minimumTrustedVerifier.requiredFiles.join("\n"))')
+          done < "$RUNNER_TEMP/gate-files.txt"
+          echo "GATE_EPOCH=$GATE_EPOCH" >> "$GITHUB_ENV"
           echo "GATE_DIR=$GATE_DIR" >> "$GITHUB_ENV"
       - name: Verify trusted release contract
         run: |
-          if [ "$GATE_MODE" = "ROOT_ADMISSION" ]; then
+          if [ "$GATE_EPOCH" = "5" ]; then
+            node "$GATE_DIR/scripts/ci/release-gate-verifier.mjs" --repo-root . --trusted-ref "$BASE_SHA" --candidate-ref "$CANDIDATE_SHA"
+          elif [ "$GATE_MODE" = "ROOT_ADMISSION" ]; then
             node scripts/ci/gate-parity.mjs --repo-root . --candidate-ref "$CANDIDATE_SHA" --invariants
           else
             node "$GATE_DIR/scripts/ci/gate-parity.mjs" --repo-root . --trusted-dir "$GATE_DIR" --trusted-ref "$BASE_SHA" --candidate-ref "$CANDIDATE_SHA"

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
@@ -666,31 +666,32 @@ class PluginReleaseScriptsTest {
 
         Pattern usesPattern = Pattern.compile(
                 "(?m)^\\s*uses:\\s*([^\\s#]+)(?:\\s+#\\s*(\\S+))?\\s*$");
-        for (String name : List.of(
-                "quality-gate.yml",
-                "shared-snippets-check.yml",
-                "release.yml",
-                "nightly.yml",
-                "publish-plugins.yml")) {
-            Matcher matcher = usesPattern.matcher(workflow(name));
-            int externalActions = 0;
-            while (matcher.find()) {
-                String target = matcher.group(1);
-                if (target.startsWith("./")) {
-                    continue;
+        int externalActions = 0;
+        try (var workflowFiles = Files.list(repoRoot().resolve(".github").resolve("workflows"))) {
+            for (Path file : workflowFiles
+                    .filter(path -> path.getFileName().toString().matches(".*\\.ya?ml"))
+                    .sorted()
+                    .toList()) {
+                String name = file.getFileName().toString();
+                Matcher matcher = usesPattern.matcher(Files.readString(file, StandardCharsets.UTF_8));
+                while (matcher.find()) {
+                    String target = matcher.group(1);
+                    if (target.startsWith("./")) {
+                        continue;
+                    }
+                    externalActions++;
+                    int separator = target.lastIndexOf('@');
+                    assertThat(separator).as("%s external action %s", name, target).isGreaterThan(0);
+                    assertThat(target.substring(separator + 1))
+                            .as("%s external action %s must use a full commit SHA", name, target)
+                            .matches("[0-9a-f]{40}");
+                    assertThat(matcher.group(2))
+                            .as("%s external action %s must keep a readable version comment", name, target)
+                            .matches(ACTION_VERSION_COMMENT_PATTERN);
                 }
-                externalActions++;
-                int separator = target.lastIndexOf('@');
-                assertThat(separator).as("%s external action %s", name, target).isGreaterThan(0);
-                assertThat(target.substring(separator + 1))
-                        .as("%s external action %s must use a full commit SHA", name, target)
-                        .matches("[0-9a-f]{40}");
-                assertThat(matcher.group(2))
-                        .as("%s external action %s must keep a readable version comment", name, target)
-                        .matches(ACTION_VERSION_COMMENT_PATTERN);
             }
-            assertThat(externalActions).as("%s external actions", name).isPositive();
         }
+        assertThat(externalActions).as("external actions across all workflows").isPositive();
 
         String dependabot = Files.readString(repoRoot().resolve(".github/dependabot.yml"), StandardCharsets.UTF_8);
         assertThat(dependabot).contains(

--- a/scripts/ci/doctor-github-ruleset.mjs
+++ b/scripts/ci/doctor-github-ruleset.mjs
@@ -16,7 +16,7 @@
  * 摘要列表对象不含 conditions 之外的 rules / bypass_actors 完整语义，
  * 因此必须逐个 follow detail endpoint 后再检查（doctor 的退出码以此为准）。
  *
- * 期望不变量声明：scripts/ci/github-ruleset-invariants.json（仓库内愿望清单，不是远端事实）。
+ * 期望不变量声明：scripts/ci/release-gate-policy.json（仓库内愿望清单，不是远端事实）。
  *
  * 凭据：GITHUB_TOKEN 或 GH_TOKEN（需要 repo metadata + rulesets read 权限）。
  * 无 token / API 不可用时明确输出 CANNOT VERIFY 并以退出码 2 结束——绝不静默 pass。
@@ -34,14 +34,28 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const OWN_DIR = path.dirname(fileURLToPath(import.meta.url));
-const INVARIANTS_REL = path.posix.join('github-ruleset-invariants.json');
+const POLICY_REL = path.posix.join('release-gate-policy.json');
 
 export function loadInvariants() {
-    const file = path.join(OWN_DIR, INVARIANTS_REL);
+    const file = path.join(OWN_DIR, POLICY_REL);
     if (!fs.existsSync(file)) {
-        throw new Error('missing scripts/ci/github-ruleset-invariants.json');
+        throw new Error('missing scripts/ci/release-gate-policy.json');
     }
-    return JSON.parse(fs.readFileSync(file, 'utf8'));
+    const policy = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const rules = policy.ruleset;
+    return {
+        branch: policy.protectedBranch,
+        master: {
+            requiredChecks: rules.requiredChecks,
+            requireStrict: rules.requireStrict,
+            requirePullRequest: rules.requirePullRequest,
+            requiredApprovals: rules.minimumApprovals,
+            allowBypass: rules.allowBypass,
+            allowDeletion: rules.allowDeletion,
+            allowNonFastForward: rules.allowNonFastForward,
+        },
+        roots: rules.roots,
+    };
 }
 
 function parseArgs(argv) {
@@ -89,85 +103,67 @@ function isTagRulesetFor(rs, ref) {
         && rs.conditions.ref_name.include.includes(ref);
 }
 
-/**
- * 审核单个 master ruleset detail（detail 才含 rules / bypass_actors 完整语义）。
- */
-function auditMasterDetail(detail, invariants, problems, report) {
-    const name = detail.name;
-    report.push('master ruleset: ' + name + ' (enforcement: ' + detail.enforcement + ')');
-    if (detail.enforcement !== 'active') {
-        problems.push('master ruleset ' + name + ' is not active (enforcement: ' + detail.enforcement + ')');
+function active(details, label, problems, report) {
+    for (const detail of details) {
+        report.push(label + ': ' + detail.name + ' (enforcement: ' + detail.enforcement + ')');
     }
-    const rules = Array.isArray(detail.rules) ? detail.rules : [];
-    const statusRule = rules.find((r) => r && r.type === 'required_status_checks');
-    if (statusRule) {
-        const parameters = statusRule.parameters && typeof statusRule.parameters === 'object'
-            ? statusRule.parameters : {};
-        // detail 字段：rules[].parameters.required_status_checks[]（每项有 context）；
-        // 不存在 required_checks 之类旧字段，不要读错键
-        const checks = Array.isArray(parameters.required_status_checks)
-            ? parameters.required_status_checks : [];
-        const checkNames = checks.map((c) => (c && typeof c.context === 'string' ? c.context : ''));
-        for (const expected of invariants.requiredChecks) {
-            if (!checkNames.includes(expected)) {
-                problems.push('master ruleset ' + name + ' misses required check "' + expected
-                    + '" (found: ' + (checkNames.join(', ') || 'none') + ')');
-            }
-        }
-        if (parameters.strict_required_status_checks_policy !== true) {
-            problems.push('master ruleset ' + name + ' has strict_required_status_checks_policy disabled'
-                + ' (Require branches to be up to date before merging must be on)');
-        }
-    } else {
-        problems.push('master ruleset ' + name + ' has no required_status_checks rule');
-    }
-    const pullRequestRule = rules.find((r) => r && r.type === 'pull_request');
-    if (invariants.requirePullRequest) {
-        if (!pullRequestRule) {
-            problems.push('master ruleset ' + name + ' has no pull_request rule');
-        } else {
-            const approvals = pullRequestRule.parameters?.required_approving_review_count;
-            if (approvals !== invariants.requiredApprovals) {
-                problems.push('master ruleset ' + name + ' requires ' + approvals
-                    + ' approvals instead of ' + invariants.requiredApprovals);
-            }
+    const enabled = details.filter((detail) => detail.enforcement === 'active');
+    if (enabled.length === 0) problems.push(`no active ${label}`);
+    return enabled;
+}
+
+/** GitHub layers all active matching Rulesets, so audit their combined protection. */
+function auditMaster(details, invariants, problems, report) {
+    const enabled = active(details, 'master ruleset', problems, report);
+    const rules = enabled.flatMap((detail) => Array.isArray(detail.rules) ? detail.rules : []);
+    const statusRules = rules.filter((rule) => rule?.type === 'required_status_checks');
+    const checks = statusRules.flatMap((rule) => Array.isArray(rule.parameters?.required_status_checks)
+        ? rule.parameters.required_status_checks : []);
+    for (const expected of invariants.requiredChecks) {
+        const found = checks.filter((check) => check?.context === expected);
+        if (found.length === 0) {
+            problems.push(`master Rulesets miss required check "${expected}"`);
         }
     }
-    for (const expectedRule of ['deletion', 'non_fast_forward']) {
-        const present = rules.some((r) => r && r.type === expectedRule);
-        const shouldDisable = expectedRule === 'deletion'
-            ? !invariants.allowDeletion : !invariants.allowNonFastForward;
-        if (shouldDisable && !present) {
-            problems.push('master ruleset ' + name + ' does not block ' + expectedRule);
+    if (invariants.requireStrict && !statusRules.some((rule) =>
+        rule.parameters?.strict_required_status_checks_policy === true)) {
+        problems.push('master Rulesets have strict_required_status_checks_policy disabled');
+    }
+    const pullRules = rules.filter((rule) => rule?.type === 'pull_request');
+    if (invariants.requirePullRequest && pullRules.length === 0) {
+        problems.push('master Rulesets have no pull_request rule');
+    } else if (invariants.requirePullRequest) {
+        const approvals = Math.max(...pullRules.map((rule) =>
+            Number(rule.parameters?.required_approving_review_count) || 0));
+        if (approvals < invariants.requiredApprovals) {
+            problems.push(`master Rulesets require ${approvals} approvals instead of at least ${invariants.requiredApprovals}`);
         }
     }
-    const bypassActors = Array.isArray(detail.bypass_actors) ? detail.bypass_actors : [];
-    if (bypassActors.length > 0 && !invariants.allowBypass) {
-        problems.push('master ruleset ' + name + ' has bypass actors while allowBypass=false: '
-            + bypassActors.map((a) => (a.actor_type + ':' + (a.actor_id || '?')
-                + ':' + (a.bypass_mode || '?'))).join(', '));
+    for (const [type, allowed] of [['deletion', invariants.allowDeletion],
+        ['non_fast_forward', invariants.allowNonFastForward]]) {
+        if (!allowed && !rules.some((rule) => rule?.type === type)) {
+            problems.push(`master Rulesets do not block ${type}`);
+        }
+    }
+    const bypass = enabled.flatMap((detail) => Array.isArray(detail.bypass_actors)
+        ? detail.bypass_actors.map((actor) => ({ detail, actor })) : []);
+    if (!invariants.allowBypass && bypass.length > 0) {
+        problems.push('master Rulesets have bypass actors while allowBypass=false: '
+            + bypass.map(({ detail, actor }) => `${detail.name}:${actor.actor_type}:${actor.actor_id || '?'}:${actor.bypass_mode || '?'}`).join(', '));
     }
 }
 
-/**
- * 审核单个 root tag ruleset detail。
- */
-function auditTagDetail(detail, invariants, problems, report) {
-    const name = detail.name;
-    report.push('root tag ruleset: ' + name + ' (enforcement: ' + detail.enforcement + ')');
-    if (detail.enforcement !== 'active') {
-        problems.push('root tag ruleset ' + name + ' is not active');
+function auditTag(details, invariants, problems, report) {
+    const enabled = active(details, 'root tag ruleset', problems, report);
+    const rules = enabled.flatMap((detail) => Array.isArray(detail.rules) ? detail.rules : []);
+    if (!invariants.allowDeletion && !rules.some((rule) => rule?.type === 'deletion')) {
+        problems.push('root tag Rulesets do not block deletion');
     }
-    const rules = Array.isArray(detail.rules) ? detail.rules : [];
-    if (!rules.some((r) => r && r.type === 'deletion') && !invariants.allowDeletion) {
-        problems.push('root tag ruleset ' + name + ' does not block deletion');
+    if (!invariants.allowNonFastForward && !rules.some((rule) => rule?.type === 'non_fast_forward')) {
+        problems.push('root tag Rulesets do not block non-fast-forward updates');
     }
-    if (!rules.some((r) => r && r.type === 'non_fast_forward') && !invariants.allowNonFastForward) {
-        problems.push('root tag ruleset ' + name + ' does not block non-fast-forward updates');
-    }
-    const bypassActors = Array.isArray(detail.bypass_actors) ? detail.bypass_actors : [];
-    if (bypassActors.length > 0 && !invariants.allowBypass) {
-        problems.push('root tag ruleset ' + name + ' has bypass actors while allowBypass=false');
+    if (!invariants.allowBypass && enabled.some((detail) => detail.bypass_actors?.length > 0)) {
+        problems.push('root tag Rulesets have bypass actors while allowBypass=false');
     }
 }
 
@@ -186,9 +182,8 @@ export async function runDoctor({ fetchJson, token, repo, baseUrl, invariants })
     const report = [];
     const base = baseUrl || process.env.GITHUB_API_URL || 'https://api.github.com';
     const masterInvariants = invariants.master;
-    const tagInvariants = Object.entries(invariants)
-        .filter(([name, value]) => /^i18n-gate-epoch-[2-9][0-9]*-root$/.test(name)
-            && value && typeof value === 'object');
+    const branchRef = invariants.branch || 'refs/heads/master';
+    const tagInvariants = Object.entries(invariants.roots || {});
 
     // 1. list endpoint：只提供摘要（id / name / target / conditions / enforcement）
     let list;
@@ -241,32 +236,28 @@ export async function runDoctor({ fetchJson, token, repo, baseUrl, invariants })
         if (fetched.error) {
             return { exitCode: 2, problems, report, cannotVerify: fetched.error };
         }
-        if (isBranchRulesetFor(fetched.detail, 'refs/heads/master')) {
+        if (isBranchRulesetFor(fetched.detail, branchRef)) {
             masterMatches.push(fetched.detail);
         }
-        for (const [name] of tagInvariants) {
-            if (isTagRulesetFor(fetched.detail, 'refs/tags/' + name)) {
-                tagMatches.get(name).push(fetched.detail);
+        for (const [ref] of tagInvariants) {
+            if (isTagRulesetFor(fetched.detail, ref)) {
+                tagMatches.get(ref).push(fetched.detail);
             }
         }
     }
 
     if (masterMatches.length === 0) {
-        problems.push('no branch ruleset covers refs/heads/master');
+        problems.push('no branch ruleset covers ' + branchRef);
     } else {
-        for (const detail of masterMatches) {
-            auditMasterDetail(detail, masterInvariants, problems, report);
-        }
+        auditMaster(masterMatches, masterInvariants, problems, report);
     }
 
-    for (const [name, expected] of tagInvariants) {
-        const matches = tagMatches.get(name);
+    for (const [ref, expected] of tagInvariants) {
+        const matches = tagMatches.get(ref);
         if (matches.length === 0) {
-            problems.push('no tag ruleset covers refs/tags/' + name);
+            problems.push('no tag ruleset covers ' + ref);
         } else {
-            for (const detail of matches) {
-                auditTagDetail(detail, expected, problems, report);
-            }
+            auditTag(matches, expected, problems, report);
         }
     }
 
@@ -336,8 +327,8 @@ async function main() {
         process.exitCode = 1;
         return;
     }
-    console.log('doctor-github-ruleset: VERIFIED — master and all declared root-tag rulesets match'
-        + ' scripts/ci/github-ruleset-invariants.json.');
+    console.log('doctor-github-ruleset: VERIFIED — master and all declared root-tag Rulesets match'
+        + ' scripts/ci/release-gate-policy.json.');
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/ci/gate-contract.mjs
+++ b/scripts/ci/gate-contract.mjs
@@ -1,8 +1,60 @@
 #!/usr/bin/env node
 'use strict';
 
+import { execFileSync, spawnSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const cliArgs = process.argv.slice(2);
+const repoIndex = cliArgs.indexOf('--repo-root');
+const dispatchRoot = path.resolve(repoIndex >= 0 ? cliArgs[repoIndex + 1] : process.cwd());
+
 if (process.argv.length === 3 && process.argv[2] === '--version') {
-    console.log('gate-contract 5');
-} else {
+    console.log('gate-contract 6');
+} else if (configuredEpoch(dispatchRoot) !== '5') {
     await import('../i18n/gate-contract.mjs');
+} else {
+    const args = cliArgs;
+    const value = (name) => {
+        const index = args.indexOf(name);
+        return index >= 0 ? args[index + 1] : null;
+    };
+    const repo = path.resolve(value('--repo-root') || process.cwd());
+    const trusted = git(repo, ['config', '--local', '--get', 'pixiv.release.trustedGateRef']);
+    let candidate = value('--candidate-ref');
+    if (!candidate && value('--candidate-snapshot') === 'index') {
+        const tree = git(repo, ['write-tree']);
+        candidate = git(repo, ['commit-tree', tree, '-p', trusted], {
+            GIT_AUTHOR_NAME: 'PixivDownloader Gate', GIT_AUTHOR_EMAIL: 'gate@localhost',
+            GIT_COMMITTER_NAME: 'PixivDownloader Gate', GIT_COMMITTER_EMAIL: 'gate@localhost',
+        }, 'local staged snapshot\n');
+    }
+    if (!candidate) throw new Error('--candidate-ref or --candidate-snapshot index is required');
+    const candidateSha = git(repo, ['rev-parse', '--verify', `${candidate}^{commit}`]);
+    const trustedSha = git(repo, ['rev-parse', '--verify', `${trusted}^{commit}`]);
+    const ownRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+    const verifyArgs = [path.join(ownRoot, 'scripts', 'ci', 'release-gate-verifier.mjs'),
+        '--repo-root', repo, '--candidate-ref', candidateSha];
+    if (candidateSha === trustedSha) verifyArgs.push('--invariants');
+    else verifyArgs.push('--trusted-ref', trustedSha);
+    const result = spawnSync(process.execPath, verifyArgs,
+        { cwd: repo, stdio: 'inherit', windowsHide: true });
+    if (result.status !== 0) process.exit(result.status || 1);
+    console.log(`GATE CONTRACT OK (candidate ${candidateSha})`);
+}
+
+function git(root, args, env = {}, input) {
+    return execFileSync('git', args, {
+        cwd: root, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], input,
+        env: { ...process.env, ...env },
+    }).trim();
+}
+
+function configuredEpoch(root) {
+    try {
+        return git(root, ['config', '--local', '--get', 'pixiv.release.trustedGateEpoch']);
+    } catch {
+        return '';
+    }
 }

--- a/scripts/ci/gate-surface.json
+++ b/scripts/ci/gate-surface.json
@@ -4,18 +4,18 @@
   "paths": [
     "scripts/i18n/check.mjs",
     "scripts/ci/gate-contract.mjs",
+    "scripts/ci/gate-surface.json",
     "scripts/ci/gate-invariants.json",
     "scripts/ci/gate-parity.mjs",
     "scripts/ci/github-ruleset-invariants.json",
+    "scripts/ci/release-gate-policy.json",
+    "scripts/ci/release-gate-trust.mjs",
+    "scripts/ci/release-gate-verifier.mjs",
     "scripts/ci/resolve-trusted-base.mjs",
     "scripts/i18n/gate-contract.mjs",
     "scripts/i18n/gate-policy.json",
     "scripts/i18n/trust-gate.mjs",
     "scripts/ci/trust-gate.mjs",
-    ".github/workflows/quality-gate.yml",
-    ".github/workflows/shared-snippets-check.yml",
-    ".github/workflows/release.yml",
-    ".github/workflows/nightly.yml",
-    ".github/workflows/publish-plugins.yml"
+    ".github/workflows"
   ]
 }

--- a/scripts/ci/release-gate-policy.json
+++ b/scripts/ci/release-gate-policy.json
@@ -1,0 +1,128 @@
+{
+  "schemaVersion": 1,
+  "gateEpoch": 5,
+  "contractVersion": 6,
+  "rootTag": "refs/tags/release-gate-epoch-5-root",
+  "protectedBranch": "refs/heads/master",
+  "protectedCore": [
+    "scripts/ci/release-gate-trust.mjs",
+    "scripts/ci/release-gate-verifier.mjs",
+    "scripts/ci/resolve-trusted-base.mjs"
+  ],
+  "qualityGate": {
+    "workflow": ".github/workflows/quality-gate.yml",
+    "workflowName": "Quality Gate",
+    "requiredJobs": [
+      "java-tests",
+      "javascript-tests",
+      "signature-guard",
+      "trusted-gate-contract",
+      "i18n-check"
+    ],
+    "requiredTriggers": [
+      "push",
+      "pull_request",
+      "merge_group",
+      "workflow_dispatch",
+      "workflow_call"
+    ],
+    "allowedPushExclusions": [
+      "gh-pages"
+    ]
+  },
+  "workflows": {
+    ".github/workflows/shared-snippets-check.yml": {
+      "workflowName": "Shared Snippet Drift Check",
+      "requiredJobs": [
+        "check-shared-snippets"
+      ],
+      "requiredTriggers": [
+        "push",
+        "pull_request",
+        "workflow_dispatch"
+      ]
+    },
+    ".github/workflows/release.yml": {
+      "workflowName": "Release",
+      "requiredJobs": [
+        "validate-release-tag",
+        "draft-quality-gate",
+        "publish-plugins",
+        "publish-plugin-artifacts",
+        "build-jar",
+        "build-windows-installer",
+        "release",
+        "create-draft-release"
+      ],
+      "requiredTriggers": [
+        "push",
+        "workflow_dispatch"
+      ]
+    },
+    ".github/workflows/nightly.yml": {
+      "workflowName": "Nightly Build",
+      "requiredJobs": [
+        "resolve-version",
+        "publish-plugins",
+        "publish-plugin-artifacts",
+        "build-jar",
+        "build-windows-installer",
+        "release-nightly"
+      ],
+      "requiredTriggers": [
+        "schedule",
+        "workflow_dispatch"
+      ]
+    },
+    ".github/workflows/publish-plugins.yml": {
+      "workflowName": "Publish plugins",
+      "requiredJobs": [
+        "quality-gate",
+        "publish"
+      ],
+      "requiredTriggers": [
+        "workflow_call",
+        "workflow_dispatch"
+      ]
+    }
+  },
+  "releaseEnvironment": "release",
+  "ruleset": {
+    "requiredChecks": [
+      "java-tests",
+      "javascript-tests",
+      "signature-guard",
+      "trusted-gate-contract",
+      "i18n-check",
+      "check-shared-snippets"
+    ],
+    "requireStrict": true,
+    "requirePullRequest": true,
+    "minimumApprovals": 0,
+    "allowBypass": false,
+    "allowDeletion": false,
+    "allowNonFastForward": false,
+    "roots": {
+      "refs/tags/i18n-gate-epoch-2-root": {
+        "allowDeletion": false,
+        "allowNonFastForward": false,
+        "allowBypass": false
+      },
+      "refs/tags/i18n-gate-epoch-3-root": {
+        "allowDeletion": false,
+        "allowNonFastForward": false,
+        "allowBypass": false
+      },
+      "refs/tags/i18n-gate-epoch-4-root": {
+        "allowDeletion": false,
+        "allowNonFastForward": false,
+        "allowBypass": false
+      },
+      "refs/tags/release-gate-epoch-5-root": {
+        "allowDeletion": false,
+        "allowNonFastForward": false,
+        "allowBypass": false
+      }
+    }
+  }
+}

--- a/scripts/ci/release-gate-trust.mjs
+++ b/scripts/ci/release-gate-trust.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+'use strict';
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+const EPOCH = 5;
+const ROOT_TAG = 'refs/tags/release-gate-epoch-5-root';
+const POLICY = 'scripts/ci/release-gate-policy.json';
+const REF_KEY = 'pixiv.release.trustedGateRef';
+const EPOCH_KEY = 'pixiv.release.trustedGateEpoch';
+const OLD_REF_KEY = 'pixiv.i18n.trustedGateRef';
+const OLD_EPOCH_KEY = 'pixiv.i18n.trustedGateEpoch';
+const SHA = /^[0-9a-f]{40}$/;
+
+function fail(message) {
+    throw new Error(message);
+}
+
+function git(root, args, options = {}) {
+    const result = execFileSync('git', args, {
+        cwd: root, encoding: options.encoding === null ? null : 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'], maxBuffer: 128 * 1024 * 1024,
+    });
+    return Buffer.isBuffer(result) ? result : result.trim();
+}
+
+function config(root, key) {
+    try { return git(root, ['config', '--local', '--get', key]) || null; } catch { return null; }
+}
+
+function commit(root, ref) {
+    try {
+        const value = git(root, ['rev-parse', '--verify', `${ref}^{commit}`]);
+        return SHA.test(value) ? value : null;
+    } catch { return null; }
+}
+
+function ancestor(root, older, newer) {
+    try { git(root, ['merge-base', '--is-ancestor', older, newer]); return true; } catch { return false; }
+}
+
+function clean(root) {
+    if (git(root, ['status', '--porcelain'])) fail('trust commands require a clean worktree');
+}
+
+function materialize(root, ref, files) {
+    const out = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv-release-gate-core-'));
+    try {
+        for (const rel of files) {
+            const target = path.join(out, ...rel.split('/'));
+            fs.mkdirSync(path.dirname(target), { recursive: true });
+            fs.writeFileSync(target, git(root, ['show', `${ref}:${rel}`], { encoding: null }));
+        }
+        return out;
+    } catch (error) {
+        fs.rmSync(out, { recursive: true, force: true });
+        throw error;
+    }
+}
+
+function run(root, script, args) {
+    const result = spawnSync(process.execPath, [script, '--repo-root', root, ...args], {
+        cwd: root, encoding: 'utf8', stdio: ['ignore', 'inherit', 'inherit'],
+        maxBuffer: 128 * 1024 * 1024, windowsHide: true,
+    });
+    if (result.status !== 0) fail('protected verifier rejected the candidate');
+}
+
+function setAnchor(root, sha) {
+    git(root, ['config', '--local', EPOCH_KEY, String(EPOCH)]);
+    git(root, ['config', '--local', REF_KEY, sha]);
+    if (config(root, EPOCH_KEY) !== String(EPOCH) || config(root, REF_KEY) !== sha) {
+        fail('trusted anchor verification failed');
+    }
+}
+
+function adopt(root, ref) {
+    if (process.env.CI === 'true') fail('root adoption is forbidden in CI');
+    clean(root);
+    const candidate = commit(root, ref);
+    const source = commit(root, config(root, OLD_REF_KEY));
+    const master = commit(root, 'refs/remotes/origin/master');
+    const rootTag = commit(root, ROOT_TAG);
+    if (config(root, OLD_EPOCH_KEY) !== '4' || !candidate || !source
+        || candidate !== master || candidate !== commit(root, 'HEAD') || candidate !== rootTag) {
+        fail('adoption requires the Epoch 4 anchor, protected master tip, HEAD and Epoch 5 root tag');
+    }
+    const parents = git(root, ['rev-list', '--parents', '-n', '1', candidate]).split(/\s+/u).slice(1);
+    if (parents.length !== 2 || parents[0] !== source || !ancestor(root, source, parents[1])) {
+        fail('Epoch 5 root must be a two-parent Merge commit from the Epoch 4 anchor');
+    }
+    const oldPolicy = JSON.parse(git(root, ['show', `${source}:scripts/i18n/gate-policy.json`]));
+    const oldCore = materialize(root, source, oldPolicy.minimumTrustedVerifier.requiredFiles);
+    try {
+        run(root, path.join(oldCore, 'scripts', 'ci', 'gate-parity.mjs'),
+            ['--trusted-dir', oldCore, '--trusted-ref', source, '--candidate-ref', candidate]);
+        run(root, path.join(oldCore, 'scripts', 'ci', 'gate-parity.mjs'),
+            ['--trusted-dir', oldCore, '--trusted-ref', source, '--candidate-ref', candidate,
+                '--signature']);
+    } finally {
+        fs.rmSync(oldCore, { recursive: true, force: true });
+    }
+    const policy = JSON.parse(git(root, ['show', `${candidate}:${POLICY}`]));
+    const newCore = materialize(root, candidate, policy.protectedCore);
+    try {
+        run(root, path.join(newCore, 'scripts', 'ci', 'release-gate-verifier.mjs'),
+            ['--candidate-ref', candidate, '--invariants']);
+    } finally {
+        fs.rmSync(newCore, { recursive: true, force: true });
+    }
+    setAnchor(root, candidate);
+    console.log(`release-gate-trust: Epoch 5 root adopted at ${candidate}`);
+}
+
+function advance(root, ref) {
+    if (process.env.CI === 'true') fail('trusted anchor advancement is forbidden in CI');
+    clean(root);
+    const current = commit(root, config(root, REF_KEY));
+    const candidate = commit(root, ref);
+    const master = commit(root, 'refs/remotes/origin/master');
+    const rootSha = commit(root, ROOT_TAG);
+    if (config(root, EPOCH_KEY) !== String(EPOCH) || !current || !candidate || !rootSha
+        || candidate !== master || candidate === current || !ancestor(root, rootSha, current)
+        || !ancestor(root, current, candidate)) {
+        fail('advance requires root <= current anchor < protected master tip');
+    }
+    const verifier = materialize(root, current, ['scripts/ci/release-gate-verifier.mjs']);
+    try {
+        run(root, path.join(verifier, 'scripts', 'ci', 'release-gate-verifier.mjs'),
+            ['--trusted-ref', current, '--candidate-ref', candidate]);
+    } finally {
+        fs.rmSync(verifier, { recursive: true, force: true });
+    }
+    setAnchor(root, candidate);
+    console.log(`release-gate-trust: trusted anchor advanced to ${candidate}`);
+}
+
+function show(root) {
+    console.log(`trustedGateEpoch=${config(root, EPOCH_KEY) || '<unset>'}`);
+    console.log(`trustedGateRef=${config(root, REF_KEY) || '<unset>'}`);
+    console.log(`root=${commit(root, ROOT_TAG) || '<missing>'}`);
+}
+
+function main() {
+    const args = process.argv.slice(2);
+    const root = git(process.cwd(), ['rev-parse', '--show-toplevel']);
+    if (args[0] === '--show') show(root);
+    else if (args[0] === '--adopt-root' && args[1] === '--ref' && args[2]) adopt(root, args[2]);
+    else if (args[0] === '--advance' && args[1] === '--ref' && args[2]) advance(root, args[2]);
+    else if (args[0] === '--version') console.log('release-gate-trust 5');
+    else fail('usage: release-gate-trust.mjs --show | --adopt-root --ref <commit> | --advance --ref <commit>');
+}
+
+try { main(); } catch (error) {
+    console.error(`release-gate-trust: ${error.message}`);
+    process.exitCode = 1;
+}

--- a/scripts/ci/release-gate-verifier.mjs
+++ b/scripts/ci/release-gate-verifier.mjs
@@ -1,0 +1,402 @@
+#!/usr/bin/env node
+'use strict';
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { createRequire } from 'node:module';
+
+const POLICY = 'scripts/ci/release-gate-policy.json';
+const ROOT_TAG = 'refs/tags/release-gate-epoch-5-root';
+const BRANCH = 'refs/heads/master';
+const CORE = [
+    'scripts/ci/release-gate-trust.mjs',
+    'scripts/ci/release-gate-verifier.mjs',
+    'scripts/ci/resolve-trusted-base.mjs',
+];
+const FLOOR = {
+    checks: ['java-tests', 'javascript-tests', 'signature-guard', 'trusted-gate-contract',
+        'i18n-check', 'check-shared-snippets'],
+    roots: ['refs/tags/i18n-gate-epoch-2-root', 'refs/tags/i18n-gate-epoch-3-root',
+        'refs/tags/i18n-gate-epoch-4-root', ROOT_TAG],
+    workflows: {
+        '.github/workflows/shared-snippets-check.yml': ['check-shared-snippets'],
+        '.github/workflows/release.yml': ['validate-release-tag', 'draft-quality-gate',
+            'publish-plugins', 'publish-plugin-artifacts', 'build-jar',
+            'build-windows-installer', 'release', 'create-draft-release'],
+        '.github/workflows/nightly.yml': ['resolve-version', 'publish-plugins',
+            'publish-plugin-artifacts', 'build-jar', 'build-windows-installer', 'release-nightly'],
+        '.github/workflows/publish-plugins.yml': ['quality-gate', 'publish'],
+    },
+};
+const SHA = /^[0-9a-f]{40}$/;
+
+function fail(message) {
+    throw new Error(message);
+}
+
+function git(repo, args, encoding = 'utf8') {
+    return execFileSync('git', ['-C', repo, ...args], {
+        encoding, windowsHide: true, stdio: ['ignore', 'pipe', 'pipe'],
+    });
+}
+
+function resolveCommit(repo, ref, label) {
+    const sha = git(repo, ['rev-parse', '--verify', `${ref}^{commit}`]).trim();
+    if (!SHA.test(sha)) fail(`${label} is not a commit: ${ref}`);
+    return sha;
+}
+
+function show(repo, ref, rel, encoding = 'utf8') {
+    try {
+        return git(repo, ['show', `${ref}:${rel}`], encoding);
+    } catch {
+        fail(`missing ${rel} at ${ref}`);
+    }
+}
+
+function json(repo, ref, rel) {
+    try {
+        return JSON.parse(show(repo, ref, rel));
+    } catch (error) {
+        if (error instanceof SyntaxError) fail(`invalid JSON in ${rel} at ${ref}: ${error.message}`);
+        throw error;
+    }
+}
+
+function same(a, b) {
+    return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function list(value) {
+    if (value === undefined || value === null) return [];
+    return Array.isArray(value) ? value.map(String) : [String(value)];
+}
+
+function requireSubset(less, more, label) {
+    const actual = new Set(more);
+    for (const item of less) if (!actual.has(item)) fail(`${label} removed ${item}`);
+}
+
+function exactIdentity(trusted, candidate, label) {
+    if (!same(trusted, candidate)) fail(`${label} changed and requires a new Gate Epoch`);
+}
+
+function validateRootPolicy(policy) {
+    if (policy.schemaVersion !== 1 || policy.gateEpoch !== 5 || policy.contractVersion !== 6) {
+        fail('Epoch 5 policy identity is invalid');
+    }
+    if (policy.rootTag !== ROOT_TAG || policy.protectedBranch !== BRANCH) {
+        fail('protected root or branch identity changed');
+    }
+    if (!same(policy.protectedCore, CORE)) fail('immutable core declaration differs from verifier');
+    if (policy.qualityGate?.workflow !== '.github/workflows/quality-gate.yml'
+        || policy.qualityGate?.workflowName !== 'Quality Gate') {
+        fail('Quality Gate identity is invalid');
+    }
+    requireSubset(['java-tests', 'javascript-tests', 'signature-guard',
+        'trusted-gate-contract', 'i18n-check'],
+        policy.qualityGate.requiredJobs, 'Quality Gate jobs');
+    requireSubset(['push', 'pull_request', 'merge_group', 'workflow_dispatch', 'workflow_call'],
+        policy.qualityGate.requiredTriggers, 'Quality Gate triggers');
+    for (const [rel, jobs] of Object.entries(FLOOR.workflows)) {
+        if (!policy.workflows?.[rel]) fail(`policy removed required workflow ${rel}`);
+        requireSubset(jobs, policy.workflows[rel].requiredJobs, `${rel} jobs`);
+    }
+    const rules = policy.ruleset || {};
+    const contexts = rules.requiredChecks || [];
+    if (!Array.isArray(contexts) || contexts.some((context) => typeof context !== 'string' || !context)
+        || new Set(contexts).size !== contexts.length) {
+        fail('Ruleset required check declarations are invalid or duplicated');
+    }
+    requireSubset(FLOOR.checks, contexts, 'Ruleset checks');
+    for (const root of FLOOR.roots) {
+        if (!rules.roots?.[root]) fail(`Ruleset policy removed historical root ${root}`);
+    }
+    if (rules.requireStrict !== true || rules.requirePullRequest !== true
+        || !Number.isInteger(rules.minimumApprovals) || rules.minimumApprovals < 0
+        || rules.allowBypass !== false || rules.allowDeletion !== false
+        || rules.allowNonFastForward !== false) {
+        fail('master Ruleset policy is weakened or invalid');
+    }
+    for (const [root, expected] of Object.entries(rules.roots || {})) {
+        if (!root.startsWith('refs/tags/') || expected.allowDeletion !== false
+            || expected.allowNonFastForward !== false || expected.allowBypass !== false) {
+            fail(`root Ruleset policy is weakened or invalid: ${root}`);
+        }
+    }
+    if (policy.releaseEnvironment !== 'release') fail('release Environment identity changed');
+}
+
+function validateMonotonic(trusted, candidate) {
+    validateRootPolicy(trusted);
+    validateRootPolicy(candidate);
+    for (const key of ['schemaVersion', 'gateEpoch', 'contractVersion', 'rootTag',
+        'protectedBranch', 'protectedCore', 'releaseEnvironment']) {
+        exactIdentity(trusted[key], candidate[key], `policy.${key}`);
+    }
+    for (const key of ['workflow', 'workflowName']) {
+        exactIdentity(trusted.qualityGate[key], candidate.qualityGate[key], `qualityGate.${key}`);
+    }
+    requireSubset(trusted.qualityGate.requiredJobs, candidate.qualityGate.requiredJobs,
+        'Quality Gate jobs');
+    requireSubset(trusted.qualityGate.requiredTriggers, candidate.qualityGate.requiredTriggers,
+        'Quality Gate triggers');
+    requireSubset(candidate.qualityGate.allowedPushExclusions,
+        trusted.qualityGate.allowedPushExclusions, 'Quality Gate push exclusions');
+    for (const [rel, spec] of Object.entries(trusted.workflows)) {
+        const next = candidate.workflows?.[rel];
+        if (!next) fail(`policy removed workflow ${rel}`);
+        exactIdentity(spec.workflowName, next.workflowName, `${rel} workflow name`);
+        requireSubset(spec.requiredJobs, next.requiredJobs, `${rel} jobs`);
+        requireSubset(spec.requiredTriggers, next.requiredTriggers, `${rel} triggers`);
+    }
+    const oldRules = trusted.ruleset;
+    const newRules = candidate.ruleset;
+    requireSubset(oldRules.requiredChecks, newRules.requiredChecks, 'Ruleset checks');
+    if (newRules.minimumApprovals < oldRules.minimumApprovals) {
+        fail('Ruleset minimum approvals decreased');
+    }
+    for (const key of ['requireStrict', 'requirePullRequest']) {
+        if (oldRules[key] === true && newRules[key] !== true) fail(`Ruleset ${key} was disabled`);
+    }
+    for (const key of ['allowBypass', 'allowDeletion', 'allowNonFastForward']) {
+        if (oldRules[key] === false && newRules[key] !== false) fail(`Ruleset ${key} was enabled`);
+    }
+    for (const [root, expected] of Object.entries(oldRules.roots)) {
+        if (!same(expected, newRules.roots?.[root])) fail(`historical root policy changed: ${root}`);
+    }
+}
+
+function parseWorkflow(YAML, repo, ref, rel) {
+    try {
+        const doc = YAML.parse(show(repo, ref, rel));
+        if (!doc || typeof doc !== 'object' || !doc.jobs || typeof doc.jobs !== 'object') {
+            fail(`${rel} is not a workflow document`);
+        }
+        return doc;
+    } catch (error) {
+        if (error.message?.startsWith(rel)) throw error;
+        fail(`invalid workflow ${rel}: ${error.message}`);
+    }
+}
+
+function triggers(doc) {
+    const value = doc.on ?? doc.true;
+    if (typeof value === 'string') return [value];
+    if (Array.isArray(value)) return value.map(String);
+    return value && typeof value === 'object' ? Object.keys(value) : [];
+}
+
+function permissionsWrite(permissions) {
+    if (permissions === 'write-all') return true;
+    return permissions && typeof permissions === 'object'
+        && Object.values(permissions).some((value) => value === 'write');
+}
+
+function environmentName(job) {
+    return typeof job.environment === 'string' ? job.environment : job.environment?.name;
+}
+
+function needs(job) {
+    return list(job.needs);
+}
+
+function dependsOn(jobs, id, roots, seen = new Set()) {
+    if (roots.has(id)) return true;
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return needs(jobs[id] || {}).some((dep) => dependsOn(jobs, dep, roots, seen));
+}
+
+function containsSecret(job) {
+    const expressions = JSON.stringify(job).match(/\$\{\{.*?\}\}/gu) || [];
+    return expressions.some((expression) => /\bsecrets\b/iu.test(expression)
+        || /\bgithub\s*(?:\.\s*token|\[\s*\\?['"]token\\?['"]\s*\])/iu.test(expression));
+}
+
+function localWorkflow(uses) {
+    return typeof uses === 'string' && uses.startsWith('./.github/workflows/') ? uses.slice(2) : null;
+}
+
+function validateActionPins(rel, doc) {
+    const uses = [];
+    for (const job of Object.values(doc.jobs)) {
+        if (job.uses) uses.push(job.uses);
+        for (const step of job.steps || []) if (step.uses) uses.push(step.uses);
+    }
+    for (const value of uses) {
+        if (typeof value !== 'string' || value.startsWith('./') || value.startsWith('docker://')) continue;
+        if (!/@[0-9a-f]{40}$/u.test(value)) fail(`${rel} uses an external action without a full SHA: ${value}`);
+    }
+}
+
+function validateQualityBootstrap(policy, doc) {
+    for (const id of ['signature-guard', 'trusted-gate-contract']) {
+        const body = (doc.jobs[id]?.steps || []).map((step) => String(step.run || '')).join('\n');
+        if (!body.includes('resolve-trusted-base.mjs') || !body.includes('git show "$BASE_SHA:$rel"')
+            || !body.includes('release-gate-verifier.mjs') || !body.includes('--candidate-ref')) {
+            fail(`Quality Gate job ${id} no longer executes the protected predecessor verifier`);
+        }
+    }
+    const signature = (doc.jobs['signature-guard']?.steps || [])
+        .map((step) => String(step.run || '')).join('\n');
+    if (!signature.includes('--signature')) fail('signature-guard no longer uses signature mode');
+}
+
+function workflowSecurityProblems(rel, doc, policy, providerPaths) {
+    const problems = [];
+    if (!Object.prototype.hasOwnProperty.call(doc, 'permissions') || doc.permissions === null) {
+        problems.push(`${rel} must declare top-level permissions`);
+    }
+    if (/"continue-on-error":true/u.test(JSON.stringify(doc))) {
+        problems.push(`${rel} contains continue-on-error: true`);
+    }
+    const jobs = doc.jobs;
+    const roots = new Set(Object.entries(jobs)
+        .filter(([, job]) => providerPaths.has(localWorkflow(job.uses)))
+        .map(([id]) => id));
+    for (const [id, job] of Object.entries(jobs)) {
+        if (job.secrets === 'inherit') problems.push(`${rel} job ${id} uses secrets: inherit`);
+        const condition = String(job.if || '');
+        if (/\b(?:always|failure|cancelled)\s*\(/iu.test(condition)) {
+            problems.push(`${rel} job ${id} can bypass a failed dependency`);
+        }
+        const provider = roots.has(id);
+        const sensitive = permissionsWrite(job.permissions === undefined ? doc.permissions : job.permissions)
+            || containsSecret(job) || environmentName(job) !== undefined;
+        if (!sensitive || provider) continue;
+        if (environmentName(job) !== policy.releaseEnvironment) {
+            problems.push(`${rel} job ${id} uses privileged capabilities outside the release Environment`);
+        }
+        if (!dependsOn(jobs, id, roots)) {
+            problems.push(`${rel} job ${id} can use privileged capabilities before Quality Gate success`);
+        }
+    }
+    return problems;
+}
+
+function validateWorkflows(repo, ref, policy) {
+    const require = createRequire(process.env.TRUSTED_GATE_PACKAGE_JSON || path.join(repo, 'package.json'));
+    let YAML;
+    try {
+        YAML = require('yaml');
+    } catch {
+        fail('the installed yaml dependency is required to inspect workflows');
+    }
+    const names = git(repo, ['ls-tree', '-r', '--name-only', ref, '--', '.github/workflows'])
+        .split(/\r?\n/u).filter((name) => /\.ya?ml$/u.test(name));
+    const docs = new Map(names.map((rel) => [rel, parseWorkflow(YAML, repo, ref, rel)]));
+    const required = new Map([[policy.qualityGate.workflow, policy.qualityGate],
+        ...Object.entries(policy.workflows)]);
+    for (const [rel, spec] of required) {
+        const doc = docs.get(rel);
+        if (!doc) fail(`missing required workflow ${rel}`);
+        if (doc.name !== spec.workflowName) fail(`${rel} workflow name changed`);
+        requireSubset(spec.requiredTriggers, triggers(doc), `${rel} triggers`);
+        requireSubset(spec.requiredJobs, Object.keys(doc.jobs), `${rel} jobs`);
+    }
+    const quality = docs.get(policy.qualityGate.workflow);
+    const push = (quality.on ?? quality.true)?.push;
+    if (!same(list(push?.['branches-ignore']), policy.qualityGate.allowedPushExclusions)) {
+        fail('Quality Gate push exclusions differ from policy');
+    }
+    validateQualityBootstrap(policy, quality);
+    const providerPaths = new Set([policy.qualityGate.workflow]);
+    let changed = true;
+    while (changed) {
+        changed = false;
+        for (const [rel, doc] of docs) {
+            if (providerPaths.has(rel) || !triggers(doc).includes('workflow_call')) continue;
+            const hasProvider = Object.values(doc.jobs)
+                .some((job) => providerPaths.has(localWorkflow(job.uses)));
+            if (hasProvider && workflowSecurityProblems(rel, doc, policy, providerPaths).length === 0) {
+                providerPaths.add(rel);
+                changed = true;
+            }
+        }
+    }
+    for (const [rel, doc] of docs) {
+        validateActionPins(rel, doc);
+        const problems = workflowSecurityProblems(rel, doc, policy, providerPaths);
+        if (problems.length > 0) fail(problems.join('\n'));
+    }
+}
+
+function validateCore(repo, trusted, candidate) {
+    for (const rel of CORE) {
+        const before = git(repo, ['ls-tree', trusted, '--', rel]).trim();
+        const after = git(repo, ['ls-tree', candidate, '--', rel]).trim();
+        if (!before || before !== after) fail(`immutable release gate core changed: ${rel}`);
+    }
+}
+
+function validateAncestry(repo, trusted, candidate) {
+    const root = resolveCommit(repo, ROOT_TAG, 'Epoch 5 root');
+    if (trusted === candidate) fail('trusted base must be a strict predecessor of the candidate');
+    for (const [ancestor, descendant, label] of [
+        [root, trusted, 'root to trusted base'],
+        [trusted, candidate, 'trusted base to candidate'],
+        [trusted, 'refs/remotes/origin/master', 'trusted base to protected branch'],
+    ]) {
+        const result = spawnSync('git', ['-C', repo, 'merge-base', '--is-ancestor', ancestor, descendant],
+            { windowsHide: true, stdio: 'ignore' });
+        if (result.status !== 0) fail(`invalid protected predecessor ancestry: ${label}`);
+    }
+}
+
+function validateSignatureBoundary(repo, candidate) {
+    const markers = ['DouyinX' + 'BogusSigner', 'DouyinA' + 'BogusSigner', 'Douyin' + 'Sm3',
+        'generateChrome' + 'Fingerprint', 'Dkdpgh4' + 'ZKs', 'Dkdpgh2' + 'Zms', 'ckdp1h4' + 'ZKs'];
+    const result = spawnSync('git', ['-C', repo, 'grep', '-nE', markers.join('|'), candidate, '--', '.',
+        ':(exclude)scripts/hooks/pre-push-guard.sh', ':(exclude)scripts/i18n/test/hooks.test.mjs'],
+    { encoding: 'utf8', windowsHide: true });
+    if (result.status === 0 && result.stdout.trim()) {
+        fail(`detected reverse-engineered Douyin signature code:\n${result.stdout.trim()}`);
+    }
+    if (result.status !== 0 && result.status !== 1) fail('cannot inspect signature boundary');
+}
+
+function parseArgs(argv) {
+    const out = { repo: '.', candidate: null, trusted: null, invariants: false,
+        signature: false, version: false };
+    for (let i = 0; i < argv.length; i += 1) {
+        const arg = argv[i];
+        if (arg === '--repo-root') out.repo = argv[++i];
+        else if (arg === '--candidate-ref') out.candidate = argv[++i];
+        else if (arg === '--trusted-ref') out.trusted = argv[++i];
+        else if (arg === '--invariants') out.invariants = true;
+        else if (arg === '--signature') out.signature = true;
+        else if (arg === '--version') out.version = true;
+        else fail(`unknown argument: ${arg}`);
+    }
+    return out;
+}
+
+function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.version) {
+        console.log('release-gate-verifier epoch=5 contract=6 schema=1');
+        return;
+    }
+    const repo = path.resolve(args.repo);
+    const candidate = resolveCommit(repo, args.candidate || 'HEAD', 'candidate');
+    const candidatePolicy = json(repo, candidate, POLICY);
+    validateRootPolicy(candidatePolicy);
+    if (!args.invariants) {
+        const trusted = resolveCommit(repo, args.trusted, 'trusted base');
+        validateMonotonic(json(repo, trusted, POLICY), candidatePolicy);
+        validateCore(repo, trusted, candidate);
+        validateAncestry(repo, trusted, candidate);
+    }
+    if (!args.signature) validateWorkflows(repo, candidate, candidatePolicy);
+    validateSignatureBoundary(repo, candidate);
+    console.log(`TRUSTED RELEASE GATE 5 OK (${candidate})`);
+}
+
+try {
+    main();
+} catch (error) {
+    console.error(`release-gate-verifier: ${error.message}`);
+    process.exitCode = 1;
+}

--- a/scripts/ci/test/doctor-github-ruleset.test.mjs
+++ b/scripts/ci/test/doctor-github-ruleset.test.mjs
@@ -24,13 +24,9 @@ const REQUIRED = invariants.master.requiredChecks;
 
 test('doctor：required contexts 与当前 trusted predecessor 声明一致', () => {
     assert.deepEqual(REQUIRED, [
-        'java-tests', 'javascript-tests',
-        'signature-guard', 'trusted-gate-contract',
+        'java-tests', 'javascript-tests', 'signature-guard', 'trusted-gate-contract',
         'i18n-check', 'check-shared-snippets',
     ]);
-    const policy = JSON.parse(fs.readFileSync(path.join(SCRIPTS_DIR, '..', 'i18n', 'gate-policy.json'), 'utf8'));
-    assert.equal(policy.requiredExternalCheckDefinitions[0].requiredContext,
-        'check-shared-snippets');
 });
 
 function validMasterDetail() {
@@ -59,13 +55,13 @@ function validMasterDetail() {
     };
 }
 
-function validTagDetail(epoch = 3) {
+function validTagDetail(ref = 'refs/tags/i18n-gate-epoch-3-root', id = 203) {
     return {
-        id: 200 + epoch,
-        name: `epoch${epoch}-root-protection`,
+        id,
+        name: `${ref.split('/').at(-1)}-protection`,
         enforcement: 'active',
         target: 'tag',
-        conditions: { ref_name: { include: [`refs/tags/i18n-gate-epoch-${epoch}-root`] } },
+        conditions: { ref_name: { include: [ref] } },
         rules: [
             { type: 'deletion', parameters: {} },
             { type: 'non_fast_forward', parameters: {} },
@@ -75,7 +71,9 @@ function validTagDetail(epoch = 3) {
 }
 
 function validTagDetails(epoch3 = validTagDetail()) {
-    return [validTagDetail(2), epoch3, validTagDetail(4)];
+    return [validTagDetail('refs/tags/i18n-gate-epoch-2-root', 202), epoch3,
+        validTagDetail('refs/tags/i18n-gate-epoch-4-root', 204),
+        validTagDetail('refs/tags/release-gate-epoch-5-root', 205)];
 }
 
 /** 摘要只含 id / name / target / enforcement；真实 API 的摘要 conditions 为 null（必须用 detail 分类）。 */
@@ -150,7 +148,8 @@ test('doctor：list endpoint 摘要 → 必须 follow detail endpoint（摘要�
     assert.ok(calls.some((u) => /\/rulesets\/202$/.test(u)), '必须请求 tag detail endpoint');
     assert.ok(calls.some((u) => /\/rulesets\/203$/.test(u)), '必须请求全部 tag detail endpoint');
     assert.ok(calls.some((u) => /\/rulesets\/204$/.test(u)), '必须请求当前 root detail endpoint');
-    assert.ok(calls.filter((u) => /\/rulesets\/\d+$/.test(u)).length >= 4,
+    assert.ok(calls.some((u) => /\/rulesets\/205$/.test(u)), '必须请求 Epoch 5 root detail endpoint');
+    assert.ok(calls.filter((u) => /\/rulesets\/\d+$/.test(u)).length >= 5,
         'list 之后必须逐个 follow detail（用 detail 的 conditions 分类）');
 });
 
@@ -159,20 +158,48 @@ test('doctor：master + root tag detail 完全正确 → success (exit 0)', asyn
     assert.equal(result.exitCode, 0, JSON.stringify(result.problems));
 });
 
+test('doctor：多个 master Ruleset 的有效保护按 GitHub 叠加语义聚合', async () => {
+    const first = validMasterDetail();
+    first.id = 101;
+    first.name = 'checks-a';
+    const second = validMasterDetail();
+    second.id = 102;
+    second.name = 'checks-b';
+    const checks = first.rules[0].parameters.required_status_checks;
+    first.rules = [
+        { ...first.rules[0], parameters: { ...first.rules[0].parameters,
+            required_status_checks: checks.slice(0, 3) } },
+        first.rules[1],
+    ];
+    second.rules = [
+        { ...second.rules[0], parameters: { ...second.rules[0].parameters,
+            strict_required_status_checks_policy: false,
+            required_status_checks: checks.slice(3) } },
+        second.rules[2], second.rules[3],
+    ];
+    const tags = validTagDetails();
+    const all = [first, second, ...tags];
+    const { fetchJson } = makeFetch(all.map(summaryOf),
+        Object.fromEntries(all.map((detail) => [detail.id, detail])));
+    const result = await runDoctor({ fetchJson, token: 't', repo: REPO, invariants });
+    assert.equal(result.exitCode, 0, JSON.stringify(result.problems));
+});
+
 test('doctor：声明多个 Epoch root 时逐个要求受保护 ruleset', async () => {
     const master = validMasterDetail();
-    const [epoch2, epoch3, epoch4] = validTagDetails();
+    const [epoch2, epoch3, epoch4, epoch5] = validTagDetails();
     const completeFetch = makeFetch(
-        [summaryOf(master), summaryOf(epoch2), summaryOf(epoch3), summaryOf(epoch4)],
-        { [master.id]: master, [epoch2.id]: epoch2, [epoch3.id]: epoch3, [epoch4.id]: epoch4 });
+        [summaryOf(master), summaryOf(epoch2), summaryOf(epoch3), summaryOf(epoch4), summaryOf(epoch5)],
+        { [master.id]: master, [epoch2.id]: epoch2, [epoch3.id]: epoch3,
+            [epoch4.id]: epoch4, [epoch5.id]: epoch5 });
     const complete = await runDoctor({
         fetchJson: completeFetch.fetchJson, token: 't', repo: REPO, invariants,
     });
     assert.equal(complete.exitCode, 0, JSON.stringify(complete.problems));
 
     const missingFetch = makeFetch(
-        [summaryOf(master), summaryOf(epoch2), summaryOf(epoch3)],
-        { [master.id]: master, [epoch2.id]: epoch2, [epoch3.id]: epoch3 });
+        [summaryOf(master), summaryOf(epoch2), summaryOf(epoch3), summaryOf(epoch5)],
+        { [master.id]: master, [epoch2.id]: epoch2, [epoch3.id]: epoch3, [epoch5.id]: epoch5 });
     const missing = await runDoctor({
         fetchJson: missingFetch.fetchJson, token: 't', repo: REPO, invariants,
     });
@@ -216,7 +243,7 @@ test('doctor：root tag 的 pull_request bypass 同样拒绝', async () => {
     ];
     const { result } = await doctorWith(validMasterDetail(), tag);
     assert.equal(result.exitCode, 1);
-    assert.ok(result.problems.some((p) => /root tag.*allowBypass=false/.test(p)));
+    assert.ok(result.problems.some((p) => /root tag Rulesets.*allowBypass=false/.test(p)));
 });
 
 test('doctor：required check 缺失 → violation (exit 1)', async () => {
@@ -225,7 +252,7 @@ test('doctor：required check 缺失 → violation (exit 1)', async () => {
         .filter((c) => c.context !== REQUIRED[0]);
     const { result } = await doctorWith(master, validTagDetail());
     assert.equal(result.exitCode, 1);
-    assert.ok(result.problems.some((p) => /misses required check/.test(p)));
+    assert.ok(result.problems.some((p) => /miss required check/.test(p)));
 });
 
 test('doctor：tag deletion 未保护 → violation (exit 1)', async () => {
@@ -233,7 +260,7 @@ test('doctor：tag deletion 未保护 → violation (exit 1)', async () => {
     tag.rules = tag.rules.filter((r) => r.type !== 'deletion');
     const { result } = await doctorWith(validMasterDetail(), tag);
     assert.equal(result.exitCode, 1);
-    assert.ok(result.problems.some((p) => /does not block deletion/.test(p)));
+    assert.ok(result.problems.some((p) => /do not block deletion/.test(p)));
 });
 
 test('doctor：tag non-fast-forward 未保护 → violation (exit 1)', async () => {
@@ -241,7 +268,7 @@ test('doctor：tag non-fast-forward 未保护 → violation (exit 1)', async () 
     tag.rules = tag.rules.filter((r) => r.type !== 'non_fast_forward');
     const { result } = await doctorWith(validMasterDetail(), tag);
     assert.equal(result.exitCode, 1);
-    assert.ok(result.problems.some((p) => /does not block non-fast-forward/.test(p)));
+    assert.ok(result.problems.some((p) => /do not block non-fast-forward/.test(p)));
 });
 
 test('doctor：无 token → CANNOT VERIFY (exit 2)，不是 pass', () => {

--- a/scripts/ci/test/first-admission-bridge.test.mjs
+++ b/scripts/ci/test/first-admission-bridge.test.mjs
@@ -53,7 +53,7 @@ test('Gate 通用入口报告当前可信发布版本', () => {
         cwd: ROOT, encoding: 'utf8',
     });
     assert.equal(result.status, 0, result.stderr);
-    assert.match(result.stdout, /trusted-release-gate 4/);
+    assert.match(result.stdout, /trusted-release-gate 5/);
     const invalid = spawnSync(process.execPath,
         ['scripts/ci/trust-gate.mjs', '--version', '--unknown'], { cwd: ROOT, encoding: 'utf8' });
     assert.notEqual(invalid.status, 0);

--- a/scripts/ci/test/gate-contract.test.mjs
+++ b/scripts/ci/test/gate-contract.test.mjs
@@ -21,7 +21,7 @@ test('gate-contract：Epoch 4 兼容实现只委托共享检查器', () => {
 test('gate-contract：版本与缺参均 fail closed', () => {
     const version = spawnSync(process.execPath, [CONTRACT, '--version'], { cwd: ROOT, encoding: 'utf8' });
     assert.equal(version.status, 0, version.stderr);
-    assert.match(version.stdout, /gate-contract 5/);
+    assert.match(version.stdout, /gate-contract 6/);
     const invalidVersion = spawnSync(process.execPath, [CONTRACT, '--version', '--unknown'], {
         cwd: ROOT, encoding: 'utf8',
     });

--- a/scripts/ci/test/hooks.test.mjs
+++ b/scripts/ci/test/hooks.test.mjs
@@ -29,6 +29,9 @@ test('hooks：提前反馈面复用可信发布核心检查器', () => {
     const scripts = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')).scripts;
     assert.ok(surface.paths.includes('scripts/ci/gate-contract.mjs'));
     assert.ok(surface.paths.includes('scripts/ci/trust-gate.mjs'));
+    assert.ok(surface.paths.includes('scripts/ci/release-gate-verifier.mjs'));
+    assert.ok(surface.paths.includes('.github/workflows'));
+    assert.equal(surface.paths.some((rel) => /^\.github\/workflows\/[^/]+\.ya?ml$/u.test(rel)), false);
     assert.deepEqual(surface.paths.filter((rel) => rel.startsWith('scripts/i18n/')), [
         'scripts/i18n/check.mjs',
         'scripts/i18n/gate-contract.mjs',

--- a/scripts/ci/test/release-gate-trust.test.mjs
+++ b/scripts/ci/test/release-gate-trust.test.mjs
@@ -1,0 +1,85 @@
+'use strict';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const CLI = path.join(ROOT, 'scripts', 'ci', 'release-gate-trust.mjs');
+const CONTRACT = path.join(ROOT, 'scripts', 'ci', 'gate-contract.mjs');
+
+function git(root, args) {
+    return execFileSync('git', args, { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+function copy(root, rel) {
+    const target = path.join(root, ...rel.split('/'));
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(path.join(ROOT, ...rel.split('/')), target);
+}
+
+function commit(root, message) {
+    git(root, ['add', '-A']);
+    git(root, ['commit', '-q', '-m', message]);
+    return git(root, ['rev-parse', 'HEAD']);
+}
+
+test('Epoch 5 adoption accepts the required Merge commit and verifies both Epochs', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv trust v5 '));
+    const remote = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv trust v5 remote '));
+    try {
+        git(root, ['init', '-q']);
+        git(root, ['config', 'user.email', 'test@example.com']);
+        git(root, ['config', 'user.name', 'test']);
+        copy(root, '.gitignore');
+        copy(root, 'package.json');
+        const oldPolicy = JSON.parse(fs.readFileSync(path.join(ROOT, 'scripts/i18n/gate-policy.json'), 'utf8'));
+        const oldFiles = new Set([...oldPolicy.minimumTrustedVerifier.requiredFiles,
+            ...oldPolicy.requiredWorkflowFiles, 'scripts/ci/github-ruleset-invariants.json',
+            'scripts/ci/gate-contract.mjs']);
+        for (const rel of oldFiles) copy(root, rel);
+        fs.symlinkSync(path.join(ROOT, 'node_modules'), path.join(root, 'node_modules'),
+            process.platform === 'win32' ? 'junction' : 'dir');
+        const base = commit(root, 'Epoch 4 source');
+        git(root, ['branch', '-M', 'master']);
+        git(root, ['tag', 'i18n-gate-epoch-4-root', base]);
+
+        git(root, ['switch', '-q', '-c', 'epoch-5']);
+        copy(root, 'scripts/ci/release-gate-policy.json');
+        const policy = JSON.parse(fs.readFileSync(path.join(ROOT, 'scripts/ci/release-gate-policy.json'), 'utf8'));
+        for (const rel of policy.protectedCore) copy(root, rel);
+        commit(root, 'Epoch 5 candidate');
+        git(root, ['switch', '-q', 'master']);
+        git(root, ['merge', '--no-ff', '-q', '-m', 'Epoch 5 root', 'epoch-5']);
+        const candidate = git(root, ['rev-parse', 'HEAD']);
+        git(root, ['tag', 'release-gate-epoch-5-root', candidate]);
+
+        git(remote, ['init', '--bare', '-q']);
+        git(root, ['remote', 'add', 'origin', remote]);
+        git(root, ['push', '-q', 'origin', `${candidate}:refs/heads/master`,
+            'refs/tags/i18n-gate-epoch-4-root', 'refs/tags/release-gate-epoch-5-root']);
+        git(root, ['update-ref', 'refs/remotes/origin/master', candidate]);
+        git(root, ['config', '--local', 'pixiv.i18n.trustedGateEpoch', '4']);
+        git(root, ['config', '--local', 'pixiv.i18n.trustedGateRef', base]);
+
+        const env = { ...process.env };
+        delete env.CI;
+        const result = spawnSync(process.execPath, [CLI, '--adopt-root', '--ref', candidate], {
+            cwd: root, env, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024,
+        });
+        assert.equal(result.status, 0, result.stderr || result.stdout);
+        assert.equal(git(root, ['config', '--local', '--get', 'pixiv.release.trustedGateEpoch']), '5');
+        assert.equal(git(root, ['config', '--local', '--get', 'pixiv.release.trustedGateRef']), candidate);
+        const contract = spawnSync(process.execPath, [CONTRACT, '--repo-root', root,
+            '--candidate-ref', candidate], { cwd: root, env, encoding: 'utf8' });
+        assert.equal(contract.status, 0, contract.stderr || contract.stdout);
+        assert.match(contract.stdout, /TRUSTED RELEASE GATE 5 OK/u);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+        fs.rmSync(remote, { recursive: true, force: true });
+    }
+});

--- a/scripts/ci/test/release-gate-v5.test.mjs
+++ b/scripts/ci/test/release-gate-v5.test.mjs
@@ -1,0 +1,257 @@
+'use strict';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const VERIFIER = path.join(ROOT, 'scripts', 'ci', 'release-gate-verifier.mjs');
+const POLICY_REL = 'scripts/ci/release-gate-policy.json';
+
+function git(root, args) {
+    const result = spawnSync('git', args, { cwd: root, encoding: 'utf8' });
+    if (result.status !== 0) throw new Error(result.stderr || result.stdout);
+    return result.stdout.trim();
+}
+
+function copy(root, rel) {
+    const target = path.join(root, ...rel.split('/'));
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(path.join(ROOT, ...rel.split('/')), target);
+}
+
+function commit(root, message) {
+    git(root, ['add', '-A']);
+    git(root, ['commit', '-q', '-m', message]);
+    return git(root, ['rev-parse', 'HEAD']);
+}
+
+function fixture() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv release gate v5 '));
+    git(root, ['init', '-q']);
+    git(root, ['config', 'user.email', 'test@example.com']);
+    git(root, ['config', 'user.name', 'test']);
+    copy(root, POLICY_REL);
+    const policy = JSON.parse(fs.readFileSync(path.join(ROOT, POLICY_REL), 'utf8'));
+    for (const rel of policy.protectedCore) copy(root, rel);
+    for (const rel of fs.readdirSync(path.join(ROOT, '.github', 'workflows'))
+        .filter((name) => /\.ya?ml$/.test(name)).map((name) => `.github/workflows/${name}`)) {
+        copy(root, rel);
+    }
+    copy(root, 'package.json');
+    try {
+        fs.symlinkSync(path.join(ROOT, 'node_modules'), path.join(root, 'node_modules'),
+            process.platform === 'win32' ? 'junction' : 'dir');
+    } catch {
+        fs.cpSync(path.join(ROOT, 'node_modules'), path.join(root, 'node_modules'), { recursive: true });
+    }
+    const base = commit(root, 'trusted root');
+    git(root, ['tag', 'release-gate-epoch-5-root', base]);
+    git(root, ['update-ref', 'refs/remotes/origin/master', base]);
+    return { root, base };
+}
+
+function verify(root, candidate, trusted, extra = []) {
+    return spawnSync(process.execPath, [VERIFIER, '--repo-root', root,
+        '--candidate-ref', candidate, '--trusted-ref', trusted, ...extra], {
+        cwd: root, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024,
+    });
+}
+
+function mutatePolicy(root, mutate) {
+    const file = path.join(root, ...POLICY_REL.split('/'));
+    const policy = JSON.parse(fs.readFileSync(file, 'utf8'));
+    mutate(policy);
+    fs.writeFileSync(file, JSON.stringify(policy, null, 2) + '\n', 'utf8');
+}
+
+test('Epoch 5 root policy and immutable core pass the self-protection suite', () => {
+    const f = fixture();
+    try {
+        const result = verify(f.root, f.base, f.base, ['--invariants']);
+        assert.equal(result.status, 0, result.stderr);
+    } finally {
+        fs.rmSync(f.root, { recursive: true, force: true });
+    }
+});
+
+test('candidate cannot shrink the immutable core or historical root registry', () => {
+    for (const mutate of [
+        (policy) => policy.protectedCore.pop(),
+        (policy) => delete policy.ruleset.roots['refs/tags/i18n-gate-epoch-2-root'],
+    ]) {
+        const f = fixture();
+        try {
+            mutatePolicy(f.root, mutate);
+            const candidate = commit(f.root, 'weaken policy');
+            const result = verify(f.root, candidate, f.base);
+            assert.notEqual(result.status, 0);
+        } finally {
+            fs.rmSync(f.root, { recursive: true, force: true });
+        }
+    }
+});
+
+test('monotonic policy additions do not require another Epoch', () => {
+    const f = fixture();
+    try {
+        mutatePolicy(f.root, (policy) => {
+            policy.ruleset.requiredChecks.push('future-security-check');
+            policy.ruleset.minimumApprovals = 1;
+            policy.qualityGate.allowedPushExclusions = [];
+        });
+        const qualityGate = path.join(f.root, '.github', 'workflows', 'quality-gate.yml');
+        fs.writeFileSync(qualityGate, fs.readFileSync(qualityGate, 'utf8')
+            .replace('branches-ignore: [gh-pages]', 'branches-ignore: []'), 'utf8');
+        const candidate = commit(f.root, 'strengthen policy');
+        const result = verify(f.root, candidate, f.base);
+        assert.equal(result.status, 0, result.stderr);
+    } finally {
+        fs.rmSync(f.root, { recursive: true, force: true });
+    }
+});
+
+test('required predecessor-verifier jobs cannot retire without another Epoch', () => {
+    const f = fixture();
+    try {
+        const qualityGate = path.join(f.root, '.github', 'workflows', 'quality-gate.yml');
+        const body = fs.readFileSync(qualityGate, 'utf8')
+            .replace(/\n  signature-guard:[\s\S]*?(?=\n  i18n-check:)/u, '\n');
+        fs.writeFileSync(qualityGate, body, 'utf8');
+        const candidate = commit(f.root, 'retire Epoch 4 bootstrap');
+        const result = verify(f.root, candidate, f.base);
+        assert.notEqual(result.status, 0);
+        assert.match(result.stderr, /quality-gate\.yml jobs removed signature-guard/u);
+    } finally {
+        fs.rmSync(f.root, { recursive: true, force: true });
+    }
+});
+
+test('all workflow files are discovered and write-capable jobs require Gate plus Environment', () => {
+    const f = fixture();
+    try {
+        const workflow = path.join(f.root, '.github', 'workflows', 'manual-publish.yml');
+        fs.writeFileSync(workflow, [
+            'name: Manual publish',
+            'on: workflow_dispatch',
+            'permissions:',
+            '  contents: write',
+            'jobs:',
+            '  publish:',
+            '    runs-on: ubuntu-latest',
+            '    steps:',
+            '      - run: echo publish',
+            '',
+        ].join('\n'), 'utf8');
+        const candidate = commit(f.root, 'add unsafe workflow');
+        const result = verify(f.root, candidate, f.base);
+        assert.notEqual(result.status, 0);
+        assert.match(result.stderr, /manual-publish\.yml.*publish/u);
+    } finally {
+        fs.rmSync(f.root, { recursive: true, force: true });
+    }
+});
+
+test('a new read-only workflow is ordinary maintenance', () => {
+    const f = fixture();
+    try {
+        const workflow = path.join(f.root, '.github', 'workflows', 'manual-audit.yaml');
+        fs.writeFileSync(workflow, [
+            'name: Manual audit',
+            'on: workflow_dispatch',
+            'permissions:',
+            '  contents: read',
+            'jobs:',
+            '  audit:',
+            '    runs-on: ubuntu-latest',
+            '    steps:',
+            '      - run: echo audit',
+            '',
+        ].join('\n'), 'utf8');
+        const candidate = commit(f.root, 'add read-only workflow');
+        const result = verify(f.root, candidate, f.base);
+        assert.equal(result.status, 0, result.stderr);
+    } finally {
+        fs.rmSync(f.root, { recursive: true, force: true });
+    }
+});
+
+test('secret source names in ordinary workflows can change without another Epoch', () => {
+    const f = fixture();
+    try {
+        const release = path.join(f.root, '.github', 'workflows', 'release.yml');
+        const before = fs.readFileSync(release, 'utf8');
+        const after = before.replace(/\$\{\{\s*secrets\.[A-Z_][A-Z0-9_]*\s*\}\}/u,
+            '${{ secrets.RENAMED_RELEASE_TOKEN }}');
+        assert.notEqual(after, before);
+        fs.writeFileSync(release, after, 'utf8');
+        const candidate = commit(f.root, 'rename secret sources');
+        const result = verify(f.root, candidate, f.base);
+        assert.equal(result.status, 0, result.stderr);
+    } finally {
+        fs.rmSync(f.root, { recursive: true, force: true });
+    }
+});
+
+test('top-level writes, inherited secrets and modified trusted core fail closed', () => {
+    for (const mutate of [
+        (root) => {
+            const workflow = path.join(root, '.github', 'workflows', 'shared-snippets-check.yml');
+            fs.writeFileSync(workflow, fs.readFileSync(workflow, 'utf8')
+                .replace('contents: read', 'contents: write'), 'utf8');
+        },
+        (root) => {
+            const workflow = path.join(root, '.github', 'workflows', 'manual-secrets.yml');
+            fs.writeFileSync(workflow, [
+                'name: Secret pass-through',
+                'on: workflow_dispatch',
+                'permissions:',
+                '  contents: read',
+                'jobs:',
+                '  call:',
+                '    uses: ./.github/workflows/quality-gate.yml',
+                '    secrets: inherit',
+                '',
+            ].join('\n'), 'utf8');
+        },
+        (root) => {
+            const workflow = path.join(root, '.github', 'workflows', 'bracket-secret.yml');
+            fs.writeFileSync(workflow, [
+                'name: Bracket secret',
+                'on: workflow_dispatch',
+                'permissions:',
+                '  contents: read',
+                'jobs:',
+                '  publish:',
+                '    runs-on: ubuntu-latest',
+                "    env: { TOKEN: \"${{ secrets['TOKEN'] }}\" }",
+                '    steps:',
+                '      - run: echo publish',
+                '',
+            ].join('\n'), 'utf8');
+        },
+        (root) => fs.appendFileSync(path.join(root, 'scripts', 'ci', 'release-gate-verifier.mjs'),
+            '\n// candidate change\n', 'utf8'),
+        (root) => {
+            const workflow = path.join(root, '.github', 'workflows', 'quality-gate.yml');
+            fs.writeFileSync(workflow, fs.readFileSync(workflow, 'utf8')
+                .replace('node "$GATE_DIR/scripts/ci/release-gate-verifier.mjs"',
+                    'node candidate.mjs'), 'utf8');
+        },
+        (root) => fs.appendFileSync(path.join(root, 'scripts', 'ci', 'resolve-trusted-base.mjs'),
+            '\n// candidate change\n', 'utf8'),
+    ]) {
+        const f = fixture();
+        try {
+            mutate(f.root);
+            const candidate = commit(f.root, 'weaken authority');
+            assert.notEqual(verify(f.root, candidate, f.base).status, 0);
+        } finally {
+            fs.rmSync(f.root, { recursive: true, force: true });
+        }
+    }
+});

--- a/scripts/ci/trust-gate.mjs
+++ b/scripts/ci/trust-gate.mjs
@@ -1,8 +1,22 @@
 #!/usr/bin/env node
 'use strict';
 
+import { execFileSync } from 'node:child_process';
+
 if (process.argv.length === 3 && process.argv[2] === '--version') {
-    console.log('trusted-release-gate 4');
+    console.log('trusted-release-gate 5');
+} else if (process.argv.includes('--adopt-root') || configuredEpoch() === '5') {
+    await import('./release-gate-trust.mjs');
 } else {
     await import('../i18n/trust-gate.mjs');
+}
+
+function configuredEpoch() {
+    try {
+        return execFileSync('git', ['config', '--local', '--get', 'pixiv.release.trustedGateEpoch'], {
+            encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim();
+    } catch {
+        return '';
+    }
 }

--- a/scripts/i18n/test/lib/surface-fixture.mjs
+++ b/scripts/i18n/test/lib/surface-fixture.mjs
@@ -9,10 +9,6 @@ import path from 'node:path';
 /** 除 scripts/ci（已整目录复制）外的额外 gate surface 文件。 */
 export const GATE_SURFACE_FILES = [
     'scripts/sync-shared-snippets.ps1',
-    '.github/workflows/shared-snippets-check.yml',
-    '.github/workflows/release.yml',
-    '.github/workflows/nightly.yml',
-    '.github/workflows/publish-plugins.yml',
 ];
 
 /** 把真实仓库的额外 gate surface 文件复制进 fixture（幂等）。 */
@@ -21,5 +17,10 @@ export function copyGateSurfaceFiles(srcRoot, dstRoot) {
     fs.mkdirSync(path.join(dstRoot, '.github', 'workflows'), { recursive: true });
     for (const rel of GATE_SURFACE_FILES) {
         fs.copyFileSync(path.join(srcRoot, rel), path.join(dstRoot, rel));
+    }
+    for (const name of fs.readdirSync(path.join(srcRoot, '.github', 'workflows'))
+        .filter((item) => /\.ya?ml$/u.test(item))) {
+        fs.copyFileSync(path.join(srcRoot, '.github', 'workflows', name),
+            path.join(dstRoot, '.github', 'workflows', name));
     }
 }


### PR DESCRIPTION
## 变更内容

- 将可信发布门禁升级到 Epoch 5，由受保护前驱动态发现并审核全部工作流
- 将不可变可信核心收敛到 verifier、trust 管理与 trusted base 解析三个文件
- 允许普通只读工作流、发布约束增强和密钥名称在单调策略内维护
- 保留 Epoch 4 仅用于本次首次准入，后续候选统一由 Epoch 5 前驱验证

## 验证

- [x] `npm run test:js`
- [x] `npm run i18n:check`
- [x] `npm run test:i18n`
- [x] `npm run test:web-standards`
- [x] `npm run gate:parity`
- [x] `npm run gate:signature`
- [x] `PluginReleaseScriptsTest`
- [x] 工作分支精确 head SHA 的 push Quality Gate 全部成功
- [x] PR merge candidate 的 required checks 全部成功
- [x] CHANGELOG 已判断为不适用：本次只调整内部 CI 与发布门禁

## 关联

无。
