### PR TITLE
fix(release): 修复稳定版 FFmpeg 跨平台构建

### DIFF
--- a/.github/workflows/build-stable-ffmpeg.yml
+++ b/.github/workflows/build-stable-ffmpeg.yml
@@ -148,6 +148,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ "$ASSET_ID" == "macos-x64" ]]; then
+            brew install nasm
+            exit 0
+          fi
           if [[ "$RUNNER_OS" != "Linux" ]]; then
             exit 0
           fi
@@ -220,13 +224,17 @@ jobs:
               --target-os=mingw32
               --arch=x86_64
               --cross-prefix=x86_64-w64-mingw32-
+              --pkg-config=pkg-config
             )
           fi
           cd "ffmpeg-$version"
-          ./configure "${configure_args[@]}"
+          if ! ./configure "${configure_args[@]}"; then
+            test ! -f ffbuild/config.log || tail -n 200 ffbuild/config.log
+            exit 1
+          fi
           make -j3
           make install
-          grep -Eq '^#define CONFIG_LIBWEBP_ENCODER 1$' config.h
+          grep -Eq '^#define CONFIG_LIBWEBP_ENCODER 1$' config_components.h
 
       - name: Verify and package binaries
         shell: bash

--- a/scripts/ci/test/quality-gate-workflow.test.mjs
+++ b/scripts/ci/test/quality-gate-workflow.test.mjs
@@ -168,7 +168,10 @@ test('FFmpeg：手动流程从官方稳定源码构建并在门禁后发布五�
         ['workflow_dispatch']);
     const text = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'build-stable-ffmpeg.yml'), 'utf8');
     assert.match(text, /gpg --batch --verify/);
-    assert.match(text, /CONFIG_LIBWEBP_ENCODER 1/);
+    assert.match(text, /if \[\[ "\$ASSET_ID" == "macos-x64" \]\]; then\s+brew install nasm/);
+    assert.match(text, /--pkg-config=pkg-config/);
+    assert.match(text, /tail -n 200 ffbuild\/config\.log/);
+    assert.match(text, /CONFIG_LIBWEBP_ENCODER 1\$' config_components\.h/);
     assert.match(text, /ffmpeg-LGPLv2\.1\.txt/);
     assert.match(text, /libwebp-COPYING\.txt/);
     assert.match(text, /libwebp-PATENTS\.txt/);


### PR DESCRIPTION
## 变更内容

修复稳定版 FFmpeg 工作流在 Intel macOS、Windows 交叉构建和 FFmpeg 组件配置校验上的失败，并在配置失败时输出诊断日志。

## 验证

- [x] 稳定版 FFmpeg workflow 聚焦契约测试
- [x] 完整 JavaScript 测试、严格 i18n 检查和 Gate parity
- [x] 工作分支 push Quality Gate
- [x] Epoch 5 trusted base 与 GitHub Ruleset 一致性检查
- [x] CHANGELOG 已判断为无需更新（修复同一未发布周期内新增的工作流）

## 未验证项

分支上的手动 FFmpeg workflow 因仅允许 `master` 运行而全部跳过，因此尚未完成五个平台的实际 FFmpeg 构建验证。
