### PR TITLE
fix(release): 复用 Nightly 插件发布通道

### DIFF
--- a/.github/actions/publish-official-plugins/action.yml
+++ b/.github/actions/publish-official-plugins/action.yml
@@ -166,6 +166,25 @@ runs:
         if ($manifestCommit -notmatch '^[0-9a-f]{40}$') {
           throw "Invalid plugin manifest commit: $manifestCommit"
         }
+        if ($manifestName -eq "nightly-manifest.json") {
+          $nightlyTagRefspecs = @()
+          $manifest = Get-Content -Raw -LiteralPath $manifestName | ConvertFrom-Json
+          foreach ($entry in @($manifest.entries)) {
+            $pluginId = [string]$entry.pluginId
+            if ($pluginId -notmatch '^[a-z0-9]+(?:-[a-z0-9]+)*$') {
+              throw "Invalid Nightly plugin id: $pluginId"
+            }
+            $nightlyTag = "$pluginId-nightly"
+            git tag -f $nightlyTag HEAD
+            if ($LASTEXITCODE -ne 0) { throw "Failed to prepare Nightly tag $nightlyTag." }
+            $nightlyTagRefspecs += "+refs/tags/${nightlyTag}:refs/tags/${nightlyTag}"
+          }
+          if ($nightlyTagRefspecs.Count -eq 0) {
+            throw "Nightly manifest contains no plugin entries."
+          }
+          & git push --atomic origin @nightlyTagRefspecs
+          if ($LASTEXITCODE -ne 0) { throw "Failed to advance Nightly plugin tags." }
+        }
         [System.IO.File]::AppendAllText(
           $env:GITHUB_OUTPUT,
           "manifest_commit=$manifestCommit`n",

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
@@ -117,7 +117,7 @@ class PluginReleaseScriptsTest {
     }
 
     @Test
-    @DisplayName("Nightly 插件按各自版本发布 prerelease、改写包版本并生成独立清单")
+    @DisplayName("Nightly 插件按各自版本刷新固定 prerelease、改写包版本并生成独立清单")
     void nightlyPublicationUsesMatchingPluginVersionsAndManifest() throws Exception {
         String common = script("plugin-distribution-common.ps1");
         String publisher = script("publish-plugin-releases.ps1");
@@ -129,16 +129,21 @@ class PluginReleaseScriptsTest {
         assertThat(publisher).contains(
                 "[string]$NightlyBuildVersion",
                 "$version = Get-NightlyPluginVersion $sourceVersion $nightlySuffix",
-                "$tag = \"$($plugin.Id)-v$version\"",
+                "$tag = \"$($plugin.Id)-nightly\"",
+                "$title = \"Nightly Build $($plugin.Id)-v$version\"",
                 "Set-StagedPluginVersion -StagedArtifact $stagedArtifact -Plugin $Plugin -Version $Version",
                 "\"--update\" \"--file\" $StagedArtifact \"plugin.properties\"",
-                "--title \"Nightly Build $version ($($plugin.Id))\"",
+                "Remove-ExistingReleaseAssets -Tag $tag -AssetNames $assetNames",
+                "gh release edit $tag --repo $Repo --title $title",
+                "gh release create $tag $uploadPaths --repo $Repo --title $title",
                 "--prerelease");
+        assertThat(publisher).doesNotContain("Nightly release $tag already exists");
         assertThat(generator).contains(
                 "$manifestName = if ($isNightly) { \"nightly-manifest.json\" } else { \"manifest.json\" }",
                 "$version = if ($isNightly) {",
                 "Get-NightlyPluginVersion $sourceVersion $nightlySuffix",
-                "$tag = \"$id-v$version\"",
+                "$tag = if ($isNightly) { \"$id-nightly\" } else { \"$id-v$version\" }",
+                "$releasedTime = if ($isNightly) { $nowUtc } else { $rel.publishedAt }",
                 "$channel = if ($isNightly) { \"nightly\" } else { \"stable\" }",
                 "channel           = $channel");
     }

--- a/scripts/ci/test/quality-gate-workflow.test.mjs
+++ b/scripts/ci/test/quality-gate-workflow.test.mjs
@@ -67,6 +67,13 @@ test('发布链：所有凭据与写权限只在 release Environment 的门禁�
     assert.equal(publishAction.inputs.nightly_build_version.default, '');
     assert.equal(publishAction.outputs.manifest_commit.value,
         '${{ steps.commit-manifest.outputs.manifest_commit }}');
+    const manifestCommit = publishAction.runs.steps.find((step) => step.id === 'commit-manifest');
+    assert.ok(manifestCommit);
+    assert.match(manifestCommit.run, /\$nightlyTag = "\$pluginId-nightly"/);
+    assert.match(manifestCommit.run, /git tag -f \$nightlyTag HEAD/);
+    assert.match(manifestCommit.run,
+        /\+refs\/tags\/\$\{nightlyTag\}:refs\/tags\/\$\{nightlyTag\}/);
+    assert.match(manifestCommit.run, /git push --atomic origin @nightlyTagRefspecs/);
     assert.equal(publishAction.inputs.plugins_repo_token, undefined);
     assert.deepEqual(secretNames(publishAction), []);
     for (const action of [javaAction, windowsAction, updateSigningAction]) {

--- a/scripts/generate-market-manifest.ps1
+++ b/scripts/generate-market-manifest.ps1
@@ -4,10 +4,9 @@
     ALREADY-PUBLISHED GitHub Releases of the distribution repo + a curation source.
 
 .DESCRIPTION
-    The manifest is derived from the published release assets, NOT from a local build - so it is correct
-    whether or not anything was rebuilt this run (version-gated publishing keeps unchanged plugins' assets
-    untouched, and a rebuilt artifact of the same version can differ byte-wise). For each official required
-    or optional plugin:
+    The manifest is derived from the published release assets, NOT from a local build. Stable publication may
+    reuse complete versioned releases; Nightly publication refreshes every plugin's fixed rolling release from
+    current source. For each official required or optional plugin:
 
       - id / requires                : read from the module's source plugin.properties (literal, no build).
       - version                      : source plugin.version for stable, or that version plus the Nightly build suffix.
@@ -215,10 +214,11 @@ try {
         $colorToken = Require-DescriptorValue $d "pixiv.color-token" $plugin.Module
         $displayName = Resolve-LocalizedTextMap $plugin.Module $displayNamespace $displayNameKey
         $summary = Resolve-LocalizedTextMap $plugin.Module $displayNamespace $descriptionKey
-        $tag = "$id-v$version"
+        $tag = if ($isNightly) { "$id-nightly" } else { "$id-v$version" }
         $assetName = Get-OfficialPluginArtifactName $plugin $version
 
-        # Release metadata (must already exist): asset download_count + release publishedAt.
+        # Release metadata (must already exist): asset download_count + stable release publishedAt.
+        # A rolling Nightly Release keeps its original publishedAt, so use this manifest generation time instead.
         $relRaw = & gh release view $tag --repo $Repo --json assets,publishedAt
         if ($LASTEXITCODE -ne 0 -or -not $relRaw) {
             throw "Release $tag not found in $Repo. Publish it before generating the manifest."
@@ -227,7 +227,7 @@ try {
         $asset = $rel.assets | Where-Object { $_.name -eq $assetName } | Select-Object -First 1
         if (-not $asset) { throw "Asset $assetName not found on release $tag." }
         $downloadCount = [int]$asset.downloadCount
-        $releasedTime = $rel.publishedAt
+        $releasedTime = if ($isNightly) { $nowUtc } else { $rel.publishedAt }
         if (-not $releasedTime) { $releasedTime = $nowUtc }
 
         # Cumulative download count: when the plugin version changes, fold the previous version's

--- a/scripts/publish-plugin-releases.ps1
+++ b/scripts/publish-plugin-releases.ps1
@@ -2,8 +2,8 @@
 .SYNOPSIS
     Per-plugin, version-gated build + publish / repair: for each official required or optional plugin, create the
     GitHub Release when missing, supplement missing checksum/signature companions from immutable artifact bytes, or
-    force rebuild and replace release assets. With -NightlyBuildVersion, publish an immutable prerelease for each
-    official plugin using that plugin's own source version plus the current Nightly build suffix.
+    force rebuild and replace release assets. With -NightlyBuildVersion, rebuild every official plugin and refresh
+    its rolling `<plugin-id>-nightly` prerelease using the source version plus the current Nightly build suffix.
 
 .DESCRIPTION
     Version is the immutability key. For each plugin:
@@ -20,6 +20,10 @@
     artifact does not rebuild it; missing checksum / signature files are regenerated from the published bytes.
     The market manifest is generated separately (generate-market-manifest.ps1) from the published releases.
     ASCII source; runs under Windows PowerShell / pwsh. Needs gh + GH_TOKEN and Maven (mvnw / mvn).
+
+    With -NightlyBuildVersion, every official plugin is rebuilt from current source, its staged plugin.properties is
+    rewritten to the derived Nightly version, and the fixed `<plugin-id>-nightly` Release has all old assets replaced.
+    The matching tag is advanced by the publishing action only after the signed Nightly manifest is committed.
 
     With -Force/-f, every official plugin is rebuilt for the source plugin.version. Existing expected release
     assets (artifact + .sha256 + .sig) are deleted before the freshly built files are uploaded, so a manual
@@ -66,7 +70,7 @@ if (-not [string]::IsNullOrWhiteSpace($NightlyBuildVersion) -and
     throw "NightlyBuildVersion must match major.minor.patch-nightly.yyyymmdd.run.attempt."
 }
 if (-not [string]::IsNullOrWhiteSpace($NightlyBuildVersion) -and $Force) {
-    throw "Force is not supported for immutable Nightly plugin releases."
+    throw "Force is not supported for rolling Nightly plugin releases."
 }
 $nightlySuffix = if ([string]::IsNullOrWhiteSpace($NightlyBuildVersion)) {
     $null
@@ -294,11 +298,9 @@ if (-not [string]::IsNullOrWhiteSpace($NightlyBuildVersion)) {
     foreach ($plugin in $plugins) {
         $sourceVersion = Read-SourceVersion $plugin.Module
         $version = Get-NightlyPluginVersion $sourceVersion $nightlySuffix
-        $tag = "$($plugin.Id)-v$version"
+        $tag = "$($plugin.Id)-nightly"
+        $title = "Nightly Build $($plugin.Id)-v$version"
         $release = Get-ReleaseAssetState $tag
-        if ($release.Exists) {
-            throw "Nightly release $tag already exists. Rerun the workflow so GITHUB_RUN_ATTEMPT produces a new version."
-        }
         $assetName = Get-OfficialPluginArtifactName $plugin $version
         $stagedArtifact = Build-StagedNightlyPluginArtifact -Plugin $plugin -SourceVersion $sourceVersion `
             -Version $version -AssetName $assetName
@@ -306,14 +308,24 @@ if (-not [string]::IsNullOrWhiteSpace($NightlyBuildVersion)) {
             -Plugin $plugin -Version $version
 
         $uploadPaths = @($stagedArtifact, $companions.ShaFile, $companions.SigFile)
-        gh release create $tag $uploadPaths --repo $Repo `
-            --title "Nightly Build $version ($($plugin.Id))" `
-            --notes "Plugin $($plugin.Id) Nightly $version." --prerelease
-        if ($LASTEXITCODE -ne 0) { throw "gh release create failed for $tag." }
+        if ($release.Exists) {
+            $assetNames = @($release.AssetNames)
+            if ($assetNames.Count -gt 0) {
+                Remove-ExistingReleaseAssets -Tag $tag -AssetNames $assetNames -ExistingAssetNames $assetNames
+            }
+            gh release edit $tag --repo $Repo --title $title `
+                --notes "Plugin $($plugin.Id) Nightly $version." --prerelease
+            if ($LASTEXITCODE -ne 0) { throw "gh release edit failed for $tag." }
+            Upload-ReleaseAssetFiles -Tag $tag -Paths $uploadPaths
+        } else {
+            gh release create $tag $uploadPaths --repo $Repo --title $title `
+                --notes "Plugin $($plugin.Id) Nightly $version." --prerelease
+            if ($LASTEXITCODE -ne 0) { throw "gh release create failed for $tag." }
+        }
         $published += $tag
     }
 
-    Write-Host "Published Nightly plugin releases: $($published -join ', ')"
+    Write-Host "Refreshed Nightly plugin releases: $($published -join ', ')"
     return
 }
 


### PR DESCRIPTION
## 变更内容

- Nightly 每次继续从当前源码重建全部官方插件，并复用 `<plugin-id>-nightly` tag 与 prerelease
- 每次发布替换固定 Release 的旧附件，Release 名称包含插件 id、源码版本与 Nightly 构建后缀
- 签名 Nightly 清单提交后原子推进全部插件固定 tag；稳定发布链保持不变

## 验证

- [x] `PluginReleaseScriptsTest`（44/44）
- [x] `npm run test:js`（257/257）
- [x] `npm run i18n:check`
- [x] `npm run gate:parity`
- [x] 当前远端 head SHA 的 push Quality Gate 全部成功
- [x] CHANGELOG 已判断：该机制在最新正式 tag 后引入，本次为同一未发布周期内的 Nightly-only 修正，无需新增条目

## 不变范围

- 不修改稳定版 `release.yml`
- 不清理既有 Nightly tag、Release 或历史附件
