### PR TITLE
fix(api): 补齐严格打包所需的 Javadoc

### DIFF
--- a/pixivdownload-core-api/src/main/java/top/sywyar/pixivdownload/core/artwork/download/ArtworkDownloadStatistics.java
+++ b/pixivdownload-core-api/src/main/java/top/sywyar/pixivdownload/core/artwork/download/ArtworkDownloadStatistics.java
@@ -31,6 +31,12 @@ public interface ArtworkDownloadStatistics {
      * @param failed 未完整成功且未取消的任务数
      */
     record DailyOutcomes(int completed, int failed) {
+        /**
+         * 创建并校验一个本地日期内的插画下载终态计数。
+         *
+         * @param completed 完整成功的任务数
+         * @param failed 未完整成功且未取消的任务数
+         */
         public DailyOutcomes {
             if (completed < 0 || failed < 0) {
                 throw new IllegalArgumentException("download outcome counts must not be negative");

--- a/pixivdownload-plugin-api/src/main/java/top/sywyar/pixivdownload/plugin/api/gui/DesktopUiContext.java
+++ b/pixivdownload-plugin-api/src/main/java/top/sywyar/pixivdownload/plugin/api/gui/DesktopUiContext.java
@@ -54,7 +54,16 @@ public final class DesktopUiContext {
     /**
      * 创建带当前实际提供者标识的桌面业务上下文。
      *
+     * @param startupLaunch 是否由应用启动流程打开桌面界面
+     * @param serverPort 本地服务端口
+     * @param rootFolder 下载根目录
+     * @param configPath 主配置文件路径
      * @param selectedProviderId 本次启动实际选中的桌面 UI 提供者 id
+     * @param host 工具包无关的宿主业务能力
+     * @param startupPlugins 启动时已经冻结的活动插件快照
+     * @param currentPlugins 当前活动插件快照读取器
+     * @param textResolver 本地化文本解析器
+     * @param themePreference 当前共享主题偏好读取器
      */
     public DesktopUiContext(
             boolean startupLaunch,


### PR DESCRIPTION
## 变更内容

- 补齐 `DesktopUiContext` 带提供者标识构造器的全部参数文档。
- 补齐 `ArtworkDownloadStatistics.DailyOutcomes` compact constructor 的严格 Javadoc。

## 验证

- [x] `mvn -Pofficial-surveys -pl pixivdownload-plugin-download-workbench -am package '-DskipTests' '-Dexec.skip=true'`
- [x] `mvn -pl pixivdownload-plugin-api,pixivdownload-core-api -am test '-Dexec.skip=true'`
- [x] 工作分支精确 SHA 的 push Quality Gate 全部通过
- [x] PR merge candidate 的 required checks 全部通过
- [x] CHANGELOG 已判断：仅修复内部构建元数据，不适用

## 关联

- [Nightly Build #109](https://github.com/Sywyar/PixivDownloader/actions/runs/32996434948)
