### PR TITLE
fix(sdk): 修正发布合同与隔离消费者验证

### DIFF
--- a/scripts/ci/sdk-consumer.mjs
+++ b/scripts/ci/sdk-consumer.mjs
@@ -70,25 +70,47 @@ function parseArguments(argv) {
     return options;
 }
 
-function assertSdkResolution(localRepository, version) {
+const SDK_ARTIFACTS = [
+    ['pixivdownload-sdk-bom', ['pom']],
+    ['pixivdownload-sdk-info', ['pom', 'jar']],
+    ['pixivdownload-plugin-api', ['pom', 'jar']],
+    ['pixivdownload-core-api', ['pom', 'jar']],
+];
+
+function sdkArtifactFiles(repository, version) {
     const group = SDK_GROUP_ID.split('.');
-    for (const artifact of [
-        ['pixivdownload-sdk-bom', 'pom'],
-        ['pixivdownload-sdk-info', 'jar'],
-        ['pixivdownload-plugin-api', 'jar'],
-        ['pixivdownload-core-api', 'jar'],
-    ]) {
-        const directory = path.join(localRepository, ...group, artifact[0], version);
-        const expected = path.join(directory, `${artifact[0]}-${version}.${artifact[1]}`);
-        if (!fs.statSync(expected, { throwIfNoEntry: false })?.isFile()) {
-            fail(`isolated consumer did not resolve ${artifact[0]}:${version}`);
+    return SDK_ARTIFACTS.flatMap(([artifact, extensions]) => extensions.map((extension) => ({
+        artifact,
+        file: path.join(repository, ...group, artifact, version, `${artifact}-${version}.${extension}`),
+    })));
+}
+
+export function assertSdkResolution(localRepository, sdkRepository, version) {
+    const sources = sdkArtifactFiles(sdkRepository, version);
+    const resolved = sdkArtifactFiles(localRepository, version);
+    for (let index = 0; index < sources.length; index += 1) {
+        if (!fs.statSync(resolved[index].file, { throwIfNoEntry: false })?.isFile()) {
+            fail(`isolated consumer did not resolve ${resolved[index].artifact}:${version}`);
         }
-        const marker = path.join(directory, '_remote.repositories');
-        const markerText = fs.readFileSync(marker, 'utf8');
-        if (!markerText.includes('>sdk-staging=')) {
-            fail(`${artifact[0]} was not resolved from sdk-staging`);
+        if (!fs.readFileSync(resolved[index].file).equals(fs.readFileSync(sources[index].file))) {
+            fail(`${resolved[index].artifact}:${version} does not match the supplied SDK repository`);
         }
     }
+}
+
+export function stageSdkArtifacts(localRepository, sdkRepository, version) {
+    const group = SDK_GROUP_ID.split('.');
+    fs.rmSync(path.join(localRepository, ...group), { recursive: true, force: true });
+    for (const artifact of sdkArtifactFiles(sdkRepository, version)) {
+        if (!fs.statSync(artifact.file, { throwIfNoEntry: false })?.isFile()) {
+            fail(`SDK repository is missing ${artifact.artifact}:${version}`);
+        }
+        const relative = path.relative(sdkRepository, artifact.file);
+        const target = path.join(localRepository, relative);
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.copyFileSync(artifact.file, target);
+    }
+    assertSdkResolution(localRepository, sdkRepository, version);
 }
 
 export function verifyConsumer(options) {
@@ -128,7 +150,22 @@ export function verifyConsumer(options) {
         cwd: project,
         env: { ...process.env, MAVEN_USER_HOME: mavenHome },
     });
-    assertSdkResolution(localRepository, identity.version);
+    stageSdkArtifacts(localRepository, sdkRepository, identity.version);
+    run(command, [...prefix,
+        '-B', '-ntp', '-o', '-s', settings, `-Dmaven.repo.local=${localRepository}`, 'clean', 'verify',
+    ], {
+        cwd: project,
+        env: { ...process.env, MAVEN_USER_HOME: mavenHome },
+    });
+    run(command, [...prefix,
+        '-B', '-ntp', '-o', '-s', settings, `-Dmaven.repo.local=${localRepository}`,
+        'org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get',
+        `-Dartifact=${SDK_GROUP_ID}:pixivdownload-core-api:${identity.version}`,
+    ], {
+        cwd: project,
+        env: { ...process.env, MAVEN_USER_HOME: mavenHome },
+    });
+    assertSdkResolution(localRepository, sdkRepository, identity.version);
     const pluginJar = path.join(project, 'plugin', 'target', 'example-download-plugin-0.1.0.jar');
     if (!fs.statSync(pluginJar, { throwIfNoEntry: false })?.isFile()) fail('isolated consumer plugin JAR is missing');
     const listing = spawnSync('jar', ['--list', '--file', pluginJar], { encoding: 'utf8' });

--- a/scripts/ci/sdk-contract.mjs
+++ b/scripts/ci/sdk-contract.mjs
@@ -6,26 +6,8 @@ import process from 'node:process';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
-import { inspectSdkVersion, parseSdkVersion, readSdkIdentity } from './sdk-version.mjs';
+import { inspectSdkVersion, parseSdkVersion, readSdkIdentity, SDK_GROUP_ID } from './sdk-version.mjs';
 
-const RELEASE_INPUT_PATHS = [
-    '.mvn/wrapper/maven-wrapper.properties',
-    'LICENSE',
-    'mvnw',
-    'mvnw.cmd',
-    'pixivdownload-sdk-info/pom.xml',
-    'pixivdownload-sdk-info/src/main',
-    'pixivdownload-plugin-api/pom.xml',
-    'pixivdownload-plugin-api/src/main',
-    'pixivdownload-core-api/pom.xml',
-    'pixivdownload-core-api/src/main',
-    'pixivdownload-sdk-bom/pom.xml',
-    'plugin-templates/minimal-feature-plugin',
-    'plugin-templates/download-type-plugin',
-    'plugin-templates/sdk-package',
-    'scripts/ci/sdk-javadocs.mjs',
-    'scripts/ci/sdk-release.mjs'
-];
 const CONSUMER_POM_MODULES = [
     'pixivdownload-sdk-info',
     'pixivdownload-plugin-api',
@@ -44,6 +26,66 @@ export function compareSurfaces(baseSurface, candidateSurface) {
         additions: [...candidate].filter((entry) => !base.has(entry)).sort(),
         removals: [...base].filter((entry) => !candidate.has(entry)).sort()
     });
+}
+
+function element(xml, name, fallback = '') {
+    const match = new RegExp(`<${name}(?:\\s[^>]*)?>\\s*([^<]*?)\\s*</${name}>`, 'u').exec(xml);
+    return match ? match[1].trim() : fallback;
+}
+
+function requiredElement(xml, name, owner) {
+    const value = element(xml, name);
+    if (!value) throw new Error(`${owner} must declare ${name}`);
+    return value;
+}
+
+function section(xml, name) {
+    const match = new RegExp(`<${name}(?:\\s[^>]*)?>([\\s\\S]*?)</${name}>`, 'u').exec(xml);
+    return match ? { source: match[0], body: match[1] } : null;
+}
+
+function dependencySurface(xml, kind, sdkVersion) {
+    const dependencies = section(xml, 'dependencies')?.body ?? '';
+    return [...dependencies.matchAll(/<dependency(?:\s[^>]*)?>([\s\S]*?)<\/dependency>/gu)]
+            .map((match) => {
+                const body = match[1];
+                const groupId = requiredElement(body, 'groupId', `${kind} dependency`);
+                const artifactId = requiredElement(body, 'artifactId', `${kind} dependency`);
+                let version = element(body, 'version');
+                if (groupId === SDK_GROUP_ID && version === sdkVersion) version = '@SDK_VERSION@';
+                const exclusions = [...body.matchAll(/<exclusion(?:\s[^>]*)?>([\s\S]*?)<\/exclusion>/gu)]
+                        .map((exclusion) => `${requiredElement(exclusion[1], 'groupId', 'dependency exclusion')}`
+                                + `:${requiredElement(exclusion[1], 'artifactId', 'dependency exclusion')}`)
+                        .sort();
+                return [
+                    kind,
+                    groupId,
+                    artifactId,
+                    version,
+                    element(body, 'type', 'jar'),
+                    element(body, 'classifier'),
+                    element(body, 'scope', 'compile'),
+                    element(body, 'optional', 'false'),
+                    element(body, 'systemPath'),
+                    exclusions.join(',')
+                ].join('\t');
+            })
+            .sort();
+}
+
+export function consumerPomSurface(pom, sdkVersion) {
+    const management = section(pom, 'dependencyManagement');
+    const directPom = management ? pom.replace(management.source, '') : pom;
+    return [
+        [
+            'PROJECT',
+            requiredElement(pom, 'groupId', 'consumer POM'),
+            requiredElement(pom, 'artifactId', 'consumer POM'),
+            element(pom, 'packaging', 'jar')
+        ].join('\t'),
+        ...dependencySurface(directPom, 'DEPENDENCY', sdkVersion),
+        ...dependencySurface(management?.body ?? '', 'MANAGED_DEPENDENCY', sdkVersion)
+    ].sort().join('\n');
 }
 
 function compareVersions(left, right) {
@@ -67,7 +109,7 @@ export function evaluateContract({
     candidateIdentity,
     baseSurface,
     candidateSurface,
-    releaseInputChanges = [],
+    mavenContractChanges = [],
     stableBaseline = null
 }) {
     const predecessorDiff = compareSurfaces(baseSurface, candidateSurface);
@@ -76,8 +118,8 @@ export function evaluateContract({
     if (surfaceChanged && !identityChanged) {
         throw new Error('Public SDK surface changed without a new SDK release identity');
     }
-    if (releaseInputChanges.length > 0 && !identityChanged) {
-        throw new Error(`SDK release inputs changed without a new SDK release identity: ${releaseInputChanges.join(', ')}`);
+    if (mavenContractChanges.length > 0 && !identityChanged) {
+        throw new Error(`Maven SDK consumer contract changed without a new SDK release identity: ${mavenContractChanges.join(', ')}`);
     }
     if (identityChanged && !baseIdentity.legacyRevision && compareVersions(candidateIdentity, baseIdentity) <= 0) {
         throw new Error(`SDK version must increase from ${baseIdentity.version} to a newer identity`);
@@ -101,13 +143,14 @@ export function evaluateContract({
         outcome: identityChanged ? 'PUBLISH' : 'NO_PUBLISH',
         identityChanged,
         surfaceChanged,
-        releaseInputChanges,
+        mavenContractChanges,
         predecessorDiff,
         stableDiff
     });
 }
 
-export function changedConsumerPoms(baseSdkRoot, candidateSdkRoot, allowMissingBase = false) {
+export function changedMavenContracts(baseSdkRoot, candidateSdkRoot, baseSdkVersion, candidateSdkVersion,
+        allowMissingBase = false) {
     const changes = [];
     for (const module of CONSUMER_POM_MODULES) {
         const relative = path.join(module, 'target', 'flattened-pom.xml');
@@ -118,24 +161,15 @@ export function changedConsumerPoms(baseSdkRoot, candidateSdkRoot, allowMissingB
         }
         if (!fs.existsSync(basePath)) {
             if (!allowMissingBase) throw new Error(`Missing base consumer POM: ${relative}`);
-            changes.push(`${module}/consumer-pom.xml`);
+            changes.push(`${module}/maven-consumer-contract`);
             continue;
         }
-        if (fs.readFileSync(basePath, 'utf8') !== fs.readFileSync(candidatePath, 'utf8')) {
-            changes.push(`${module}/consumer-pom.xml`);
+        const baseSurface = consumerPomSurface(fs.readFileSync(basePath, 'utf8'), baseSdkVersion);
+        const candidateSurface = consumerPomSurface(fs.readFileSync(candidatePath, 'utf8'), candidateSdkVersion);
+        if (baseSurface !== candidateSurface) {
+            changes.push(`${module}/maven-consumer-contract`);
         }
     }
-    return changes;
-}
-
-function changedReleaseInputs(repoRoot, baseRef, candidateRef, baseSdkRoot, candidateSdkRoot,
-        allowMissingBaseConsumerPoms) {
-    const changes = execFileSync('git', ['-C', repoRoot, 'diff', '--name-only', baseRef, candidateRef || 'HEAD', '--',
-        ...RELEASE_INPUT_PATHS], {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'pipe']
-    }).split(/\r?\n/u).filter(Boolean);
-    changes.push(...changedConsumerPoms(baseSdkRoot, candidateSdkRoot, allowMissingBaseConsumerPoms));
     return changes;
 }
 
@@ -232,12 +266,15 @@ function main() {
             candidateSurface
     );
     const result = evaluateContract({ baseIdentity, candidateIdentity, baseSurface, candidateSurface,
-        releaseInputChanges: changedReleaseInputs(repoRoot, options.baseRef, options.candidateRef,
-                path.resolve(options.baseSdkRoot), path.resolve(options.candidateSdkRoot),
+        mavenContractChanges: changedMavenContracts(
+                path.resolve(options.baseSdkRoot),
+                path.resolve(options.candidateSdkRoot),
+                baseIdentity.version,
+                candidateIdentity.version,
                 Boolean(baseIdentity.legacyRevision)),
         stableBaseline: baseline });
     const report = {
-        schemaVersion: 1,
+        schemaVersion: 2,
         baseReleaseId: baseIdentity.releaseId,
         candidateReleaseId: candidateIdentity.releaseId,
         ...result

--- a/scripts/ci/test/sdk-consumer.test.mjs
+++ b/scripts/ci/test/sdk-consumer.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { assertSdkResolution, stageSdkArtifacts } from '../sdk-consumer.mjs';
+
+const VERSION = '1.0.0-rc1';
+const GROUP_PATH = path.join('io', 'github', 'sywyar', 'pixivdownloader');
+const ARTIFACTS = [
+    ['pixivdownload-sdk-bom', ['pom']],
+    ['pixivdownload-sdk-info', ['pom', 'jar']],
+    ['pixivdownload-plugin-api', ['pom', 'jar']],
+    ['pixivdownload-core-api', ['pom', 'jar']],
+];
+
+function writeRepository(root) {
+    for (const [artifact, extensions] of ARTIFACTS) {
+        const directory = path.join(root, GROUP_PATH, artifact, VERSION);
+        fs.mkdirSync(directory, { recursive: true });
+        for (const extension of extensions) {
+            fs.writeFileSync(path.join(directory, `${artifact}-${VERSION}.${extension}`),
+                    `${artifact}:${extension}:public\n`, 'utf8');
+        }
+    }
+}
+
+test('隔离消费者按指定仓库字节离线验证 SDK，不依赖 Maven 来源 marker', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pixivdownload-sdk-consumer-'));
+    const supplied = path.join(root, 'supplied');
+    const local = path.join(root, 'local');
+    try {
+        writeRepository(supplied);
+        const stale = path.join(local, GROUP_PATH, 'pixivdownload-sdk-bom', VERSION);
+        fs.mkdirSync(stale, { recursive: true });
+        fs.writeFileSync(path.join(stale, '_remote.repositories'),
+                `pixivdownload-sdk-bom-${VERSION}.pom>central=\n`, 'utf8');
+        fs.writeFileSync(path.join(stale, `pixivdownload-sdk-bom-${VERSION}.pom`), 'stale', 'utf8');
+
+        stageSdkArtifacts(local, supplied, VERSION);
+        assert.equal(fs.existsSync(path.join(stale, '_remote.repositories')), false);
+        assert.doesNotThrow(() => assertSdkResolution(local, supplied, VERSION));
+
+        fs.writeFileSync(path.join(local, GROUP_PATH, 'pixivdownload-core-api', VERSION,
+                `pixivdownload-core-api-${VERSION}.jar`), 'tampered', 'utf8');
+        assert.throws(() => assertSdkResolution(local, supplied, VERSION), /does not match/u);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});

--- a/scripts/ci/test/sdk-contract.test.mjs
+++ b/scripts/ci/test/sdk-contract.test.mjs
@@ -1,11 +1,16 @@
 import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
-import { changedConsumerPoms, evaluateBaselineState, evaluateContract } from '../sdk-contract.mjs';
+import { changedMavenContracts, evaluateBaselineState, evaluateContract } from '../sdk-contract.mjs';
 import { parseSdkVersion } from '../sdk-version.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const CLI = path.join(ROOT, 'scripts', 'ci', 'sdk-contract.mjs');
 
 const CONSUMER_POM_MODULES = [
     'pixivdownload-sdk-info',
@@ -19,6 +24,62 @@ function identity(version, legacyRevision = 0) {
     return legacyRevision
         ? { ...parsed, legacyRevision, releaseId: `sdk-api-v${version}-r${legacyRevision}` }
         : parsed;
+}
+
+function dependency(groupId, artifactId, version, scope = '') {
+    return `<dependency>
+      <groupId>${groupId}</groupId>
+      <artifactId>${artifactId}</artifactId>
+      <version>${version}</version>
+      ${scope ? `<scope>${scope}</scope>` : ''}
+    </dependency>`;
+}
+
+function consumerPom(module, sdkVersion, label, servletVersion = '6.0.0') {
+    const directDependencies = module === 'pixivdownload-plugin-api'
+        ? `<dependencies>${dependency('jakarta.servlet', 'jakarta.servlet-api', servletVersion, 'provided')}</dependencies>`
+        : '';
+    const managedDependencies = module === 'pixivdownload-sdk-bom'
+        ? `<dependencyManagement><dependencies>${[
+            'pixivdownload-sdk-info',
+            'pixivdownload-plugin-api',
+            'pixivdownload-core-api'
+        ].map((artifact) => dependency('io.github.sywyar.pixivdownloader', artifact, sdkVersion)).join('')}</dependencies></dependencyManagement>`
+        : '';
+    return `<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.github.sywyar.pixivdownloader</groupId>
+  <artifactId>${module}</artifactId>
+  <version>${sdkVersion}</version>
+  ${module === 'pixivdownload-sdk-bom' ? '<packaging>pom</packaging>' : ''}
+  <name>${label}</name>
+  <description>${label} metadata</description>
+  ${directDependencies}
+  ${managedDependencies}
+</project>\n`;
+}
+
+function writeConsumerPoms(root, sdkVersion, label, servletVersion = '6.0.0') {
+    for (const module of CONSUMER_POM_MODULES) {
+        const target = path.join(root, module, 'target');
+        fs.mkdirSync(target, { recursive: true });
+        fs.writeFileSync(path.join(target, 'flattened-pom.xml'),
+                consumerPom(module, sdkVersion, label, servletVersion), 'utf8');
+    }
+}
+
+function git(root, args) {
+    return execFileSync('git', args, {
+        cwd: root,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe']
+    }).trim();
+}
+
+function copy(root, relativePath) {
+    const target = path.join(root, ...relativePath.split('/'));
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(path.join(ROOT, ...relativePath.split('/')), target);
 }
 
 test('公开表面变化必须同时更新 SDK 身份', () => {
@@ -36,23 +97,78 @@ test('公开表面变化必须同时更新 SDK 身份', () => {
     }).outcome, 'PUBLISH');
 });
 
-test('模板、POM 或发行包装变化必须同时更新 SDK 身份', () => {
+test('Wrapper 纯权限变化不属于 SDK 语义合同', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pixivdownload-sdk-wrapper-mode-'));
+    const baseSdk = path.join(root, 'base-sdk');
+    const candidateSdk = path.join(root, 'candidate-sdk');
+    try {
+        git(root, ['init', '-q']);
+        git(root, ['config', 'user.email', 'test@example.com']);
+        git(root, ['config', 'user.name', 'test']);
+        git(root, ['config', 'core.filemode', 'true']);
+        for (const relativePath of [
+            'pom.xml',
+            'pixivdownload-sdk-info/pom.xml',
+            'pixivdownload-sdk-info/src/main/resources/META-INF/pixivdownload-sdk.properties',
+            'pixivdownload-plugin-api/pom.xml',
+            'pixivdownload-core-api/pom.xml',
+            'pixivdownload-sdk-bom/pom.xml',
+            'plugin-templates/minimal-feature-plugin/pom.xml',
+            'plugin-templates/download-type-plugin/pom.xml'
+        ]) copy(root, relativePath);
+        fs.writeFileSync(path.join(root, 'mvnw'), '#!/bin/sh\n', 'utf8');
+        git(root, ['add', '-A']);
+        git(root, ['commit', '-q', '-m', 'base']);
+        const base = git(root, ['rev-parse', 'HEAD']);
+        git(root, ['update-index', '--chmod=+x', 'mvnw']);
+        git(root, ['commit', '-q', '-m', 'make wrapper executable']);
+        const candidate = git(root, ['rev-parse', 'HEAD']);
+        assert.equal(git(root, ['rev-parse', `${base}:mvnw`]), git(root, ['rev-parse', `${candidate}:mvnw`]));
+        assert.match(git(root, ['ls-tree', base, 'mvnw']), /^100644\s/u);
+        assert.match(git(root, ['ls-tree', candidate, 'mvnw']), /^100755\s/u);
+
+        writeConsumerPoms(baseSdk, '1.0.0-rc1', 'Base metadata');
+        writeConsumerPoms(candidateSdk, '1.0.0-rc1', 'Candidate metadata');
+        const baseSurface = path.join(root, 'base-surface.txt');
+        const candidateSurface = path.join(root, 'candidate-surface.txt');
+        const report = path.join(root, 'report.json');
+        fs.writeFileSync(baseSurface, 'type A\n', 'utf8');
+        fs.writeFileSync(candidateSurface, 'type A\n', 'utf8');
+        const result = spawnSync(process.execPath, [CLI,
+            '--repo-root', root,
+            '--base-ref', base,
+            '--candidate-ref', candidate,
+            '--base-surface', baseSurface,
+            '--candidate-surface', candidateSurface,
+            '--base-sdk-root', baseSdk,
+            '--candidate-sdk-root', candidateSdk,
+            '--report', report
+        ], { cwd: root, encoding: 'utf8' });
+        assert.equal(result.status, 0, result.stderr || result.stdout);
+        assert.equal(result.stdout, 'NO_PUBLISH: sdk-api-v1.0.0-rc1\n');
+        assert.deepEqual(JSON.parse(fs.readFileSync(report, 'utf8')).mavenContractChanges, []);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('Maven 消费语义变化必须同时更新 SDK 身份', () => {
     const identity = parseSdkVersion('1.2.3');
     assert.throws(() => evaluateContract({
         baseIdentity: identity,
         candidateIdentity: identity,
         baseSurface: 'type A',
         candidateSurface: 'type A',
-        releaseInputChanges: ['plugin-templates/download-type-plugin/pom.xml'],
-    }), /release inputs changed without a new SDK release identity/u);
+        mavenContractChanges: ['pixivdownload-plugin-api/maven-consumer-contract'],
+    }), /Maven SDK consumer contract changed without a new SDK release identity/u);
     const result = evaluateContract({
         baseIdentity: identity,
         candidateIdentity: parseSdkVersion('1.2.4'),
         baseSurface: 'type A',
         candidateSurface: 'type A',
-        releaseInputChanges: ['plugin-templates/download-type-plugin/pom.xml'],
+        mavenContractChanges: ['pixivdownload-plugin-api/maven-consumer-contract'],
     });
-    assert.deepEqual(result.releaseInputChanges, ['plugin-templates/download-type-plugin/pom.xml']);
+    assert.deepEqual(result.mavenContractChanges, ['pixivdownload-plugin-api/maven-consumer-contract']);
 });
 
 test('预发布版本必须单调递增且首次结构化身份可从旧元数据迁移', () => {
@@ -70,21 +186,36 @@ test('预发布版本必须单调递增且首次结构化身份可从旧元数�
     }).outcome, 'PUBLISH');
 });
 
-test('首次结构化身份把旧基线缺少的 consumer POM 视为发行输入变化', () => {
+test('Maven 合同比较忽略发布元数据和 SDK 自身版本投影', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pixivdownload-sdk-maven-contract-'));
+    const base = path.join(root, 'base');
+    const candidate = path.join(root, 'candidate');
+    try {
+        writeConsumerPoms(base, '1.2.3', 'Old metadata');
+        writeConsumerPoms(candidate, '1.2.4', 'New metadata');
+        assert.deepEqual(changedMavenContracts(base, candidate, '1.2.3', '1.2.4'), []);
+
+        writeConsumerPoms(candidate, '1.2.4', 'New metadata', '6.1.0');
+        assert.deepEqual(changedMavenContracts(base, candidate, '1.2.3', '1.2.4'),
+                ['pixivdownload-plugin-api/maven-consumer-contract']);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('首次结构化身份把旧基线缺少的 consumer POM 视为 Maven 合同变化', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pixivdownload-sdk-consumer-poms-'));
     const base = path.join(root, 'base');
     const candidate = path.join(root, 'candidate');
     try {
-        for (const module of CONSUMER_POM_MODULES) {
-            const target = path.join(candidate, module, 'target');
-            fs.mkdirSync(target, { recursive: true });
-            fs.writeFileSync(path.join(target, 'flattened-pom.xml'), `<project>${module}</project>\n`, 'utf8');
-        }
-        assert.deepEqual(changedConsumerPoms(base, candidate, true),
-                CONSUMER_POM_MODULES.map((module) => `${module}/consumer-pom.xml`));
-        assert.throws(() => changedConsumerPoms(base, candidate), /Missing base consumer POM/u);
+        writeConsumerPoms(candidate, '1.0.0-rc1', 'Candidate metadata');
+        assert.deepEqual(changedMavenContracts(base, candidate, '1.0.0', '1.0.0-rc1', true),
+                CONSUMER_POM_MODULES.map((module) => `${module}/maven-consumer-contract`));
+        assert.throws(() => changedMavenContracts(base, candidate, '1.0.0', '1.0.0-rc1'),
+                /Missing base consumer POM/u);
         fs.rmSync(path.join(candidate, CONSUMER_POM_MODULES[0], 'target', 'flattened-pom.xml'));
-        assert.throws(() => changedConsumerPoms(base, candidate, true), /Missing candidate consumer POM/u);
+        assert.throws(() => changedMavenContracts(base, candidate, '1.0.0', '1.0.0-rc1', true),
+                /Missing candidate consumer POM/u);
     } finally {
         fs.rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## 变更内容

修正 SDK 发布合同与隔离消费者验证的误判边界：只冻结第三方实际消费的 Java / Maven 语义，并以指定仓库制品的精确字节完成离线消费者复验。

## 验证

- [x] 已运行聚焦 SDK 合同与隔离消费者回归测试
- [x] 已使用公开 `1.0.0-rc1` SDK ZIP 与 Maven Central 制品完成联网预热及离线消费者验证
- [x] 已运行完整 JavaScript 测试、i18n 检查、Gate parity 与远端 Ruleset 审计
- [x] required checks 全部通过
- [x] Gate / workflow 变更已完成适用的 trusted contract / parity 验证
- [x] CHANGELOG 已判断为不适用
