### PR TITLE
feat(release): 发布插件 SDK 1.0.0-rc2

### DIFF
--- a/pixivdownload-sdk-info/src/main/java/top/sywyar/pixivdownload/sdk/SdkVersion.java
+++ b/pixivdownload-sdk-info/src/main/java/top/sywyar/pixivdownload/sdk/SdkVersion.java
@@ -48,7 +48,7 @@ public final class SdkVersion {
     /**
      * 返回不可变的 SDK 发布标识。
      *
-     * @return 形如 {@code sdk-api-v1.0.0-rc1} 的发布标识
+     * @return 形如 {@code sdk-api-v1.0.0-rc2} 的发布标识
      */
     public static String releaseId() {
         return "sdk-api-v" + VERSION;

--- a/pixivdownload-sdk-info/src/main/resources/META-INF/pixivdownload-sdk.properties
+++ b/pixivdownload-sdk-info/src/main/resources/META-INF/pixivdownload-sdk.properties
@@ -1,1 +1,1 @@
-version=1.0.0-rc1
+version=1.0.0-rc2

--- a/pixivdownload-sdk-info/src/test/java/top/sywyar/pixivdownload/sdk/SdkVersionTest.java
+++ b/pixivdownload-sdk-info/src/test/java/top/sywyar/pixivdownload/sdk/SdkVersionTest.java
@@ -11,14 +11,14 @@ class SdkVersionTest {
     @Test
     @DisplayName("SDK 元数据派生统一的预发布身份和兼容版本")
     void metadataAndCompatibilityUseOneSdkVersion() {
-        assertThat(SdkVersion.VERSION).isEqualTo("1.0.0-rc1");
+        assertThat(SdkVersion.VERSION).isEqualTo("1.0.0-rc2");
         assertThat(SdkVersion.MAJOR).isEqualTo(1);
         assertThat(SdkVersion.MINOR).isZero();
         assertThat(SdkVersion.PATCH).isZero();
         assertThat(SdkVersion.PRERELEASE_CHANNEL).isEqualTo("rc");
-        assertThat(SdkVersion.PRERELEASE_SEQUENCE).isEqualTo(1);
+        assertThat(SdkVersion.PRERELEASE_SEQUENCE).isEqualTo(2);
         assertThat(SdkVersion.isPrerelease()).isTrue();
-        assertThat(SdkVersion.releaseId()).isEqualTo("sdk-api-v1.0.0-rc1");
+        assertThat(SdkVersion.releaseId()).isEqualTo("sdk-api-v1.0.0-rc2");
         assertThat(SdkVersion.isCompatibleWith(1, 0)).isTrue();
         assertThat(SdkVersion.isCompatible(1, 2, 1, 1)).isTrue();
         assertThat(SdkVersion.isCompatible(1, 0, 1, 1)).isFalse();

--- a/plugin-templates/README.md
+++ b/plugin-templates/README.md
@@ -23,7 +23,7 @@
 
     mvn -f plugin-templates/pom.xml verify
 
-这个验证 reactor 会先构建同仓的 SDK Info、Plugin API、Core API 与 SDK BOM。复制到仓库外时，两个子项目仍是无相对 parent 的独立 POM，但构建环境必须能从 Maven 仓库解析 <code>io.github.sywyar.pixivdownloader:pixivdownload-sdk-bom:1.0.0-rc1</code> 及 BOM 管理的公共构件；不要改成引用宿主源码目录或应用模块。
+这个验证 reactor 会先构建同仓的 SDK Info、Plugin API、Core API 与 SDK BOM。复制到仓库外时，两个子项目仍是无相对 parent 的独立 POM，但构建环境必须能从 Maven 仓库解析 <code>io.github.sywyar.pixivdownloader:pixivdownload-sdk-bom:1.0.0-rc2</code> 及 BOM 管理的公共构件；不要改成引用宿主源码目录或应用模块。
 
 产物位于 <code>plugin-templates/minimal-feature-plugin/target/example-minimal-plugin-0.1.0.jar</code>。将复制并改名后的插件 JAR 通过插件管理页安装，或放入宿主的运行期 <code>plugins/</code> 目录；两种方式都受宿主的包验证与本地未签名策略约束，模板不包含签名、信任根或 installer 内部实现。插件启用后可由管理员直接访问 <code>/example-minimal.html</code>。
 
@@ -43,7 +43,7 @@
 | <code>ExampleMinimal</code> | 你的 Java 类型名前缀 |
 | <code>0.1.0</code> | 插件项目版本与 <code>plugin.version</code> |
 | <code>plugin.requires=1.0</code> | 目标宿主的 major.minor 契约版本；只替换这一整行，不要误改 <code>1.0.0</code> |
-| <code>&lt;pixivdownload.sdk.version&gt;1.0.0-rc1&lt;/pixivdownload.sdk.version&gt;</code> | 构建环境提供的统一 SDK/BOM 版本 |
+| <code>&lt;pixivdownload.sdk.version&gt;1.0.0-rc2&lt;/pixivdownload.sdk.version&gt;</code> | 构建环境提供的统一 SDK/BOM 版本 |
 | <code>plugin.provider=Example Developer</code> | 你的 provider 名称 |
 
 最后修改两份 i18n 文件中的展示文案，并再次运行 <code>mvn verify</code>。不要只改 <code>plugin.properties</code>：feature id、route、static、namespace、插件自有表名前缀和测试中的对应值必须同步替换。

--- a/plugin-templates/download-type-plugin/pom.xml
+++ b/plugin-templates/download-type-plugin/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <pixivdownload.sdk.version>1.0.0-rc1</pixivdownload.sdk.version>
+        <pixivdownload.sdk.version>1.0.0-rc2</pixivdownload.sdk.version>
         <spring-boot.version>3.5.7</spring-boot.version>
         <pf4j.version>3.12.0</pf4j.version>
         <maven.compiler.version>3.13.0</maven.compiler.version>

--- a/plugin-templates/minimal-feature-plugin/pom.xml
+++ b/plugin-templates/minimal-feature-plugin/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <spring-boot.version>3.5.7</spring-boot.version>
-        <pixivdownload.sdk.version>1.0.0-rc1</pixivdownload.sdk.version>
+        <pixivdownload.sdk.version>1.0.0-rc2</pixivdownload.sdk.version>
         <pf4j.version>3.12.0</pf4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <java.version>17</java.version>
         <app.release.version>${project.version}</app.release.version>
         <!-- sdk-info 资源是 SDK 身份事实源；revision 只是 Maven CI-friendly 版本投影名。 -->
-        <revision>1.0.0-rc1</revision>
+        <revision>1.0.0-rc2</revision>
         <pixivdownload.sdk.version>${revision}</pixivdownload.sdk.version>
         <pixivdownload.source.sha>HEAD</pixivdownload.source.sha>
         <flatten.maven.version>1.7.3</flatten.maven.version>

--- a/scripts/ci/test/sdk-contract.test.mjs
+++ b/scripts/ci/test/sdk-contract.test.mjs
@@ -145,7 +145,7 @@ test('Wrapper 纯权限变化不属于 SDK 语义合同', () => {
             '--report', report
         ], { cwd: root, encoding: 'utf8' });
         assert.equal(result.status, 0, result.stderr || result.stdout);
-        assert.equal(result.stdout, 'NO_PUBLISH: sdk-api-v1.0.0-rc1\n');
+        assert.equal(result.stdout, 'NO_PUBLISH: sdk-api-v1.0.0-rc2\n');
         assert.deepEqual(JSON.parse(fs.readFileSync(report, 'utf8')).mavenContractChanges, []);
     } finally {
         fs.rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## 变更内容

将结构化 SDK 身份及 Maven、模板投影提升为 `1.0.0-rc2`，使合入 `master` 后由现有可信发布链创建整合式单包候选版本；兼容主次版本仍为 `1.0`。

## 验证

- [x] SDK 版本与合同 Node 回归测试
- [x] SDK Info、Plugin API、Core API 与 BOM `clean verify`
- [x] 两个第三方插件模板 `clean verify`
- [x] 聚合 Javadoc、单一 SDK ZIP 与 schema 2 发行元数据生成
- [x] SDK ZIP 的在线依赖准备、字节替换与离线隔离消费者验证
- [x] `npm run test:js`
- [x] `npm run gate:parity`
- [x] 当前 PR merge candidate 的 required checks 全部通过
- [x] CHANGELOG 已检查；单包变化已由前置主线提交记录，本次不重复增加条目
