### PR TITLE
fix(release): 支持 SDK 预发布版本的插件分发

### DIFF
--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
@@ -149,6 +149,30 @@ class PluginReleaseScriptsTest {
     }
 
     @Test
+    @DisplayName("共享分发脚本接受 SDK 支持的稳定版和预发布版本")
+    void commonDistributionScriptParsesSdkPrereleaseVersions(@TempDir Path tempDir) throws Exception {
+        Path metadata = tempDir.resolve(
+                "pixivdownload-sdk-info/src/main/resources/META-INF/pixivdownload-sdk.properties");
+        Files.createDirectories(metadata.getParent());
+        for (String version : List.of("1.0.0", "1.0.0-alpha1", "1.0.0-beta2", "1.0.0-rc12")) {
+            Files.writeString(metadata, "version=" + version + "\n", StandardCharsets.UTF_8);
+            assertThat(runPowerShell(
+                    "$ErrorActionPreference='Stop'; "
+                            + ". './scripts/plugin-distribution-common.ps1'; "
+                            + "Get-PixivDownloadSdkVersion -ProjectRoot '" + psQuote(tempDir) + "'"))
+                    .isEqualTo(version);
+        }
+
+        Files.writeString(metadata, "version=1.0.0-rc0\n", StandardCharsets.UTF_8);
+        CommandResult invalid = runPowerShellResult(
+                "$ErrorActionPreference='Stop'; "
+                        + ". './scripts/plugin-distribution-common.ps1'; "
+                        + "Get-PixivDownloadSdkVersion -ProjectRoot '" + psQuote(tempDir) + "'");
+        assertThat(invalid.exitCode()).as(invalid.output()).isNotZero();
+        assertThat(invalid.output()).contains("SDK metadata contains an invalid semantic version");
+    }
+
+    @Test
     @DisplayName("共享分发脚本提供官方插件 jar 产物名解析和私有 lib 形态断言")
     void commonDistributionScriptResolvesOfficialArtifactNames() throws Exception {
         String common = script("plugin-distribution-common.ps1");

--- a/scripts/plugin-distribution-common.ps1
+++ b/scripts/plugin-distribution-common.ps1
@@ -27,7 +27,7 @@ function Get-PixivDownloadSdkVersion {
     }
     $metadata = ConvertFrom-StringData (Get-Content -LiteralPath $metadataPath -Raw -Encoding UTF8)
     $version = [string]$metadata.version
-    if ($version -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$') {
+    if ($version -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(alpha|beta|rc)([1-9]\d*))?$') {
         throw "SDK metadata contains an invalid semantic version: $version"
     }
     return $version


### PR DESCRIPTION
## 变更内容

修复插件分发脚本无法读取 SDK 结构化预发布版本的问题，使 Nightly 和其它共享分发入口接受稳定版及 `alphaN`、`betaN`、`rcN`，并继续拒绝非法序号。

## 验证

- [x] `PluginReleaseScriptsTest`
- [x] SDK 版本解析 Node 测试
- [x] `git diff --check`
- [x] 未修改 Gate/workflow 编排，无需额外 parity 验证
- [x] CHANGELOG 已判断：本次为未发布 SDK 基础设施中的内部回归修复，无需新增条目
- [ ] required checks 全部通过