### PR TITLE
fix(release): 精确匹配预构建插件产物

### DIFF
--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.LinkedHashMap;
@@ -435,7 +436,7 @@ class PluginReleaseScriptsTest {
         assertThat(windows).contains("Assert-NoPrivateKeyMaterial");
         assertThat(distribution).contains(
                 "[string]$PrebuiltPluginsDir",
-                "Find-PrebuiltPluginArtifact",
+                "Find-PrebuiltOfficialPluginArtifact",
                 "[switch]$DefaultDownloader",
                 "Get-OfficialDistributionPlugins -IncludeOptional:(!$DefaultDownloader)",
                 "CoreShellOnly and DefaultDownloader cannot be combined.");
@@ -949,7 +950,12 @@ class PluginReleaseScriptsTest {
                 "PowerShell 不可用，跳过行为测试");
         Path prebuilt = Files.createDirectories(tempDir.resolve("prebuilt"));
         Path appDir = Files.createDirectories(tempDir.resolve("app"));
-        writeThinPluginJar(prebuilt.resolve("sample-module-1.0.0.jar"), "sample", "1.0.0", "1.0");
+        Path expectedArtifact = prebuilt.resolve("sample-module-1.0.0.jar");
+        Path collidingArtifact = prebuilt.resolve("sample-module-tools-9.0.0.jar");
+        writeThinPluginJar(expectedArtifact, "sample", "1.0.0", "1.0");
+        writeThinPluginJar(collidingArtifact, "sample-tools", "9.0.0", "1.0");
+        Files.setLastModifiedTime(expectedArtifact, FileTime.fromMillis(1_000));
+        Files.setLastModifiedTime(collidingArtifact, FileTime.fromMillis(2_000));
 
         String command = "$ErrorActionPreference='Stop'; "
                 + ". './scripts/package-local-plugin-staging.ps1'; "

--- a/scripts/assemble-plugin-distribution.ps1
+++ b/scripts/assemble-plugin-distribution.ps1
@@ -259,22 +259,6 @@ function Get-AppBootJar {
         Select-Object -First 1
 }
 
-function Find-PrebuiltPluginArtifact {
-    param(
-        [Parameter(Mandatory = $true)]$Plugin,
-        [Parameter(Mandatory = $true)][string]$Directory
-    )
-    $extension = Get-OfficialPluginArtifactExtension $Plugin
-    $candidate = Get-ChildItem (Join-Path $Directory "$($Plugin.Module)-*.$extension") -File -ErrorAction SilentlyContinue |
-        Where-Object { $_.Name -notlike "*-sources.jar" -and $_.Name -notlike "*-javadoc.jar" } |
-        Sort-Object LastWriteTime -Descending |
-        Select-Object -First 1
-    if (-not $candidate) {
-        throw "Prebuilt plugin artifact for module $($Plugin.Module) not found under $Directory."
-    }
-    return $candidate.FullName
-}
-
 # Resolve and strictly validate the exact prebuilt core jar BEFORE Push-Location changes the current
 # directory, so a caller-provided relative path resolves in the caller's directory, not under
 # $ProjectRoot. With -PrebuiltJar set the script never calls Get-AppBootJar; the final selected jar
@@ -383,7 +367,7 @@ try {
     foreach ($plugin in $DistributionPlugins) {
         Write-Step "Staging plugin '$($plugin.Id)'"
         if ($ResolvedPrebuiltPluginsDir) {
-            $sourceArtifact = Find-PrebuiltPluginArtifact $plugin $ResolvedPrebuiltPluginsDir
+            $sourceArtifact = Find-PrebuiltOfficialPluginArtifact $plugin $ResolvedPrebuiltPluginsDir
         } else {
             $sourceArtifact = Find-ModulePluginArtifact $plugin $ProjectRoot
         }

--- a/scripts/package-local-plugin-staging.ps1
+++ b/scripts/package-local-plugin-staging.ps1
@@ -43,15 +43,7 @@ function Stage-OfficialPlugins {
     foreach ($plugin in $Plugins) {
         $extension = Get-OfficialPluginArtifactExtension $plugin
         if ($PrebuiltPluginsDir) {
-            $candidate = Get-ChildItem (Join-Path $PrebuiltPluginsDir "$($plugin.Module)-*.$extension") `
-                    -File -ErrorAction SilentlyContinue |
-                Where-Object { $_.Name -notlike "*-sources.jar" -and $_.Name -notlike "*-javadoc.jar" } |
-                Sort-Object LastWriteTime -Descending |
-                Select-Object -First 1
-            if (-not $candidate) {
-                throw "Prebuilt plugin artifact for module $($plugin.Module) not found under $PrebuiltPluginsDir."
-            }
-            $sourceArtifact = $candidate.FullName
+            $sourceArtifact = Find-PrebuiltOfficialPluginArtifact $plugin $PrebuiltPluginsDir
         } else {
             $sourceArtifact = Find-ModulePluginArtifact $plugin $ProjectRoot
         }

--- a/scripts/plugin-distribution-common.ps1
+++ b/scripts/plugin-distribution-common.ps1
@@ -148,6 +148,28 @@ function Get-OfficialPluginArtifactName {
     return "$($Plugin.Module)-$Version.$extension"
 }
 
+function Find-PrebuiltOfficialPluginArtifact {
+    param(
+        [Parameter(Mandatory = $true)]$Plugin,
+        [Parameter(Mandatory = $true)][string]$Directory
+    )
+    $extension = Get-OfficialPluginArtifactExtension $Plugin
+    $artifactNamePattern = '^' + [regex]::Escape($Plugin.Module) +
+        '-(?:0|[1-9][0-9]*)\..*\.' + [regex]::Escape($extension) + '$'
+    $candidate = Get-ChildItem -LiteralPath $Directory -File -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.Name -match $artifactNamePattern -and
+                $_.Name -notlike "*-sources.jar" -and
+                $_.Name -notlike "*-javadoc.jar"
+        } |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -First 1
+    if (-not $candidate) {
+        throw "Prebuilt plugin artifact for module $($Plugin.Module) not found under $Directory."
+    }
+    return $candidate.FullName
+}
+
 function Get-NightlyPluginVersion {
     param(
         [Parameter(Mandatory = $true)][string]$SourceVersion,


### PR DESCRIPTION
## 变更内容

共享预构建官方插件产物选择逻辑，并按精确模块版本边界排除 `gallery` 与 `gallery-tools` 等同名前缀碰撞。

## 验证

- [x] `mvn -f <worktree>/pom.xml -pl pixivdownload-app -am test -Dtest=PluginReleaseScriptsTest -Dsurefire.failIfNoSpecifiedTests=false -Dexec.skip=true`
- [ ] required checks 全部通过
- [x] CHANGELOG 已按规范判断；本次为未发布周期内的发布链修复，无需更新
