### PR TITLE
build(release): 接入 ProGuard 最终产物流水线

### DIFF
--- a/.github/actions/package-release-java/action.yml
+++ b/.github/actions/package-release-java/action.yml
@@ -43,7 +43,7 @@ runs:
       env:
         RELEASE_VERSION: ${{ inputs.release_version }}
       run: >
-        mvn package -Pofficial-surveys -DskipTests "-Dapp.release.version=$RELEASE_VERSION"
+        mvn verify -Pofficial-surveys -DskipTests "-Dapp.release.version=$RELEASE_VERSION"
         "-Dplugin.credential.filter=$PLUGIN_CREDENTIAL_FILTER"
 
     - name: Verify packaged distribution boundaries
@@ -104,6 +104,7 @@ runs:
           OutputDir = "build/plugin-inputs"
           SignatureToolJar = $signatureTools[0].FullName
           IncludeOptional = $true
+          RequireProguard = $true
         }
         if (-not [string]::IsNullOrWhiteSpace($env:PLUGIN_MANIFEST_COMMIT)) {
           if ($env:PLUGIN_MANIFEST_COMMIT -notmatch '^[0-9a-f]{40}$') {

--- a/.github/actions/test-release-artifacts/action.yml
+++ b/.github/actions/test-release-artifacts/action.yml
@@ -1,0 +1,45 @@
+name: Test release artifacts
+description: Install and start every Windows release distribution before publication
+
+inputs:
+  release_version:
+    description: Version embedded in the release artifacts
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up JDK 17
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+      with:
+        java-version: '17'
+        distribution: temurin
+
+    - name: Download Windows installer artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: windows-installer
+        path: artifacts/windows-installer
+
+    - name: Download Java distribution artifacts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: java-distributions
+        path: artifacts/java-distributions
+
+    - name: Install and start final release artifacts
+      shell: pwsh
+      env:
+        RELEASE_VERSION: ${{ inputs.release_version }}
+      run: |
+        $installers = @(Get-ChildItem artifacts/windows-installer/*-setup.exe -File)
+        $javaZips = @(Get-ChildItem artifacts/java-distributions/PixivDownload-*-java.zip -File)
+        $offlineZips = @(Get-ChildItem artifacts/java-distributions/PixivDownload-*-full-offline.zip -File)
+        if ($installers.Count -ne 1 -or $javaZips.Count -ne 1 -or $offlineZips.Count -ne 1) {
+          throw "Expected one installer, one Java ZIP and one full-offline ZIP."
+        }
+        ./scripts/test-release-artifacts.ps1 `
+          -Version $env:RELEASE_VERSION `
+          -InstallerPath $installers[0].FullName `
+          -JavaZipPath $javaZips[0].FullName `
+          -FullOfflineZipPath $offlineZips[0].FullName

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -165,8 +165,24 @@ jobs:
         with:
           release_version: ${{ needs.resolve-version.outputs.version }}
 
+  release-artifact-e2e:
+    needs: [resolve-version, build-jar, build-windows-installer]
+    if: needs.resolve-version.outputs.has_changes == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Test final release artifacts
+        uses: ./.github/actions/test-release-artifacts
+        with:
+          release_version: ${{ needs.resolve-version.outputs.version }}
+
   release-nightly:
-    needs: [resolve-version, publish-plugins, publish-plugin-artifacts, build-jar, build-windows-installer]
+    needs: [resolve-version, publish-plugins, publish-plugin-artifacts, build-jar, build-windows-installer, release-artifact-e2e]
     if: needs.resolve-version.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     environment: release

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -79,6 +79,14 @@ jobs:
         run: mvn -B -ntp -pl pixivdownload-official-plugins -am compile -Dexec.skip=true
       - name: Run Java tests
         run: mvn -B -ntp test -Dexec.skip=true -Duser.language=en -Duser.country=US
+      - name: Build release artifacts with ProGuard
+        run: mvn -B -ntp verify -Pofficial-surveys -DskipTests
+      - name: Verify packaged release boundaries
+        run: |
+          mvn -B -ntp -pl pixivdownload-app -am test -Dtest=DistributionPackagingBoundaryTest -Dsurefire.failIfNoSpecifiedTests=false -Ddistribution.packaging.require-artifacts=true -Dexec.skip=true
+          REPORT=$(find pixivdownload-app/target/surefire-reports -name '*DistributionPackagingBoundaryTest.txt' -print -quit)
+          test -n "$REPORT"
+          grep -Eq 'Tests run: [1-9][0-9]*, Failures: 0, Errors: 0, Skipped: 0' "$REPORT"
       - name: Package SDK contract artifacts
         run: mvn -B -ntp -pl pixivdownload-sdk-info,pixivdownload-plugin-api,pixivdownload-core-api,pixivdownload-sdk-bom package -DskipTests -Dexec.skip=true
       - name: Compare SDK public contract

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,8 +151,24 @@ jobs:
         with:
           release_version: ${{ needs.build-jar.outputs.version }}
 
+  release-artifact-e2e:
+    needs: [build-jar, build-windows-installer]
+    if: github.event_name == 'push'
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Test final release artifacts
+        uses: ./.github/actions/test-release-artifacts
+        with:
+          release_version: ${{ needs.build-jar.outputs.version }}
+
   release:
-    needs: [publish-plugins, publish-plugin-artifacts, build-jar, build-windows-installer]
+    needs: [publish-plugins, publish-plugin-artifacts, build-jar, build-windows-installer, release-artifact-e2e]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment: release

--- a/build-support/proguard/base.pro
+++ b/build-support/proguard/base.pro
@@ -1,0 +1,25 @@
+-dontobfuscate
+-optimizationpasses 3
+-keepattributes Exceptions,InnerClasses,Signature,Deprecated,SourceFile,LineNumberTable,*Annotation*,EnclosingMethod,MethodParameters,Record,PermittedSubclasses
+-keepdirectories
+-dontnote module-info
+-dontnote jdk.internal.jimage.**
+-dontnote jdk.internal.jrtfs.**
+
+-keep,allowoptimization public class * {
+    public static void main(java.lang.String[]);
+}
+
+-keepclasseswithmembernames,includedescriptorclasses class * {
+    native <methods>;
+}
+
+-keepclassmembers,includedescriptorclasses,allowoptimization enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
+-keepclassmembers,includedescriptorclasses,allowoptimization class * extends java.lang.Record {
+    <fields>;
+    <methods>;
+}

--- a/build-support/proguard/compose.pro
+++ b/build-support/proguard/compose.pro
@@ -1,0 +1,98 @@
+-keep class kotlin.** { *; }
+-keep class org.jetbrains.skia.** { *; }
+-keep class org.jetbrains.skiko.** { *; }
+
+-keep,allowoptimization class top.sywyar.pixivdownload.guicompose.** { *; }
+-keepclasseswithmembernames,includedescriptorclasses class * {
+    native <methods>;
+}
+-keepclassmembers class kotlinx.coroutines.DefaultExecutor {
+    void shutdownForTests(long);
+}
+
+-assumenosideeffects public class androidx.compose.runtime.ComposerKt {
+    void sourceInformation(androidx.compose.runtime.Composer,java.lang.String);
+    void sourceInformationMarkerStart(androidx.compose.runtime.Composer,int,java.lang.String);
+    void sourceInformationMarkerEnd(androidx.compose.runtime.Composer);
+    boolean isTraceInProgress();
+    void traceEventStart(int,java.lang.String);
+    void traceEventEnd();
+}
+
+-keepnames class kotlinx.coroutines.internal.MainDispatcherFactory { *; }
+-keepnames class kotlinx.coroutines.CoroutineExceptionHandler { *; }
+-keepclassmembers class kotlinx.coroutines.** {
+    volatile <fields>;
+}
+-keepclassmembers class kotlin.coroutines.SafeContinuation {
+    volatile <fields>;
+}
+-dontwarn java.lang.instrument.ClassFileTransformer
+-dontwarn java.lang.instrument.Instrumentation
+-dontwarn sun.misc.SignalHandler
+-dontwarn sun.misc.Signal
+-dontwarn java.lang.ClassValue
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+-keep,allowshrinking,allowobfuscation class kotlinx.coroutines.flow.FlowKt** { *; }
+-keep,allowshrinking,allowobfuscation class kotlinx.coroutines.Job { *; }
+-dontnote kotlinx.coroutines.**
+-keep class kotlinx.coroutines.swing.SwingDispatcherFactory { *; }
+
+-dontwarn kotlinx.serialization.KSerializer
+-dontwarn kotlinx.serialization.Serializable
+-dontwarn kotlinx.datetime.serializers.**
+-dontwarn android.annotation.SuppressLint
+-dontnote kotlin.coroutines.jvm.internal.**
+-dontnote kotlin.internal.**
+-dontnote kotlin.jvm.internal.**
+-dontnote kotlin.reflect.**
+-dontnote kotlinx.coroutines.debug.internal.**
+-dontnote kotlinx.coroutines.internal.**
+-keep class kotlin.coroutines.Continuation { *; }
+-keep class kotlinx.coroutines.CancellableContinuation { *; }
+-keep class kotlinx.coroutines.channels.Channel { *; }
+-keep class kotlinx.coroutines.CoroutineDispatcher { *; }
+-keep class kotlinx.coroutines.CoroutineScope { *; }
+-dontwarn org.graalvm.compiler.core.aarch64.AArch64NodeMatchRules_MatchStatementSet*
+
+-keep,allowshrinking,allowobfuscation class androidx.compose.runtime.SnapshotStateKt__DerivedStateKt { *; }
+-keep class androidx.compose.material3.SliderDefaults { *; }
+-dontnote androidx.**
+
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$* Companion;
+}
+-keepnames @kotlinx.serialization.internal.NamedCompanion class *
+-if @kotlinx.serialization.internal.NamedCompanion class *
+-keepclassmembernames class * {
+    static <1> *;
+}
+-if @kotlinx.serialization.Serializable class ** {
+    static **$* *;
+}
+-keepclassmembers class <2>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-if @kotlinx.serialization.Serializable class ** {
+    public static ** INSTANCE;
+}
+-keepclassmembers class <1> {
+    public static <1> INSTANCE;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault
+-dontnote kotlinx.serialization.**
+-dontwarn kotlinx.serialization.internal.ClassValueReferences
+-keepclassmembers public class **$$serializer {
+    private ** descriptor;
+}
+-keep class **$$serializer { *; }
+-dontnote **$$serializer
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1>$** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+-dontwarn com.jetbrains.JBR**
+-dontnote com.jetbrains.JBR**

--- a/build-support/proguard/plugin.pro
+++ b/build-support/proguard/plugin.pro
@@ -1,0 +1,8 @@
+-keep,includedescriptorclasses,allowoptimization class * extends org.pf4j.Plugin {
+    public <init>(org.pf4j.PluginWrapper);
+}
+
+-keep,includedescriptorclasses,allowoptimization @top.sywyar.pixivdownload.plugin.api.plugin.PluginManagedBean class * { *; }
+-keep,includedescriptorclasses,allowoptimization class * implements top.sywyar.pixivdownload.plugin.api.plugin.PixivPluginProvider { *; }
+
+-adaptresourcefilecontents plugin.properties,META-INF/spring/**

--- a/build-support/proguard/spring.pro
+++ b/build-support/proguard/spring.pro
@@ -1,0 +1,35 @@
+-keep,includedescriptorclasses,allowoptimization @org.springframework.boot.autoconfigure.SpringBootApplication class * { *; }
+-keep,includedescriptorclasses,allowoptimization @org.springframework.context.annotation.Configuration class * { *; }
+-keep,includedescriptorclasses,allowoptimization @org.springframework.stereotype.Component class * { *; }
+-keep,includedescriptorclasses,allowoptimization @org.springframework.stereotype.Service class * { *; }
+-keep,includedescriptorclasses,allowoptimization @org.springframework.stereotype.Repository class * { *; }
+-keep,includedescriptorclasses,allowoptimization @org.springframework.stereotype.Controller class * { *; }
+-keep,includedescriptorclasses,allowoptimization @org.springframework.web.bind.annotation.RestController class * { *; }
+-keep,includedescriptorclasses,allowoptimization @org.springframework.web.bind.annotation.RestControllerAdvice class * { *; }
+-keep,includedescriptorclasses,allowoptimization @org.springframework.boot.context.properties.ConfigurationProperties class * { *; }
+-keep,includedescriptorclasses,allowoptimization @org.apache.ibatis.annotations.Mapper interface * { *; }
+
+-keepclassmembers,includedescriptorclasses,allowoptimization class * {
+    @org.springframework.context.annotation.Bean <methods>;
+    @org.springframework.context.event.EventListener <methods>;
+    @org.springframework.scheduling.annotation.Scheduled <methods>;
+    @org.springframework.web.bind.annotation.RequestMapping <methods>;
+    @org.springframework.web.bind.annotation.GetMapping <methods>;
+    @org.springframework.web.bind.annotation.PostMapping <methods>;
+    @org.springframework.web.bind.annotation.PutMapping <methods>;
+    @org.springframework.web.bind.annotation.PatchMapping <methods>;
+    @org.springframework.web.bind.annotation.DeleteMapping <methods>;
+    @com.fasterxml.jackson.annotation.JsonCreator <methods>;
+    @com.fasterxml.jackson.annotation.JsonProperty <fields>;
+    @com.fasterxml.jackson.annotation.JsonProperty <methods>;
+}
+
+-dontnote org.springframework.**
+-dontnote org.apache.ibatis.annotations.**
+-dontnote com.fasterxml.jackson.annotation.**
+
+-keepclassmembers,includedescriptorclasses,allowoptimization class * {
+    public <init>(...);
+    public <fields>;
+    public <methods>;
+}

--- a/pixivdownload-app/pom.xml
+++ b/pixivdownload-app/pom.xml
@@ -14,6 +14,11 @@
 
     <properties>
         <plugin.credential.filter>${project.basedir}/src/main/filters/plugin-credential-key-open-source.properties</plugin.credential.filter>
+        <pixivdownload.proguard.skip>false</pixivdownload.proguard.skip>
+        <pixivdownload.proguard.additionalProgramPath>${project.build.directory}/proguard/program-dependencies</pixivdownload.proguard.additionalProgramPath>
+        <pixivdownload.proguard.preservedContractsPath>${project.build.directory}/proguard/preserved-contracts</pixivdownload.proguard.preservedContractsPath>
+        <pixivdownload.proguard.libraryExcludeArtifactIds>mybatis-spring-boot-starter,pixivdownload-plugin-signature,pixivdownload-plugin-worker,pixivdownload-plugin-runtime</pixivdownload.proguard.libraryExcludeArtifactIds>
+        <pixivdownload.jar.classesDirectory>${pixivdownload.proguard.outputDirectory}</pixivdownload.jar.classesDirectory>
     </properties>
 
     <dependencies>
@@ -196,6 +201,36 @@
                 <version>3.8.1</version>
                 <executions>
                     <execution>
+                        <id>merge-host-program-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeArtifactIds>pixivdownload-plugin-signature,pixivdownload-plugin-worker,pixivdownload-plugin-runtime</includeArtifactIds>
+                            <outputDirectory>${pixivdownload.proguard.additionalProgramPath}</outputDirectory>
+                            <excludes>META-INF/MANIFEST.MF,META-INF/maven/**</excludes>
+                            <overWriteReleases>true</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stage-host-contract-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeArtifactIds>pixivdownload-sdk-info,pixivdownload-plugin-api,pixivdownload-core-api</includeArtifactIds>
+                            <outputDirectory>${pixivdownload.proguard.preservedContractsPath}</outputDirectory>
+                            <excludes>META-INF/MANIFEST.MF,META-INF/maven/**</excludes>
+                            <overWriteReleases>true</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>embed-isolated-plugin-worker</id>
                         <phase>prepare-package</phase>
                         <goals>
@@ -225,6 +260,33 @@
                 <version>3.1.0</version>
                 <executions>
                     <execution>
+                        <id>clean-proguard-program-dependencies</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <delete dir="${pixivdownload.proguard.additionalProgramPath}" quiet="true"/>
+                                <delete dir="${pixivdownload.proguard.preservedContractsPath}" quiet="true"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>preserve-host-contract-classes</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <copy todir="${pixivdownload.proguard.outputDirectory}" overwrite="true">
+                                    <fileset dir="${pixivdownload.proguard.preservedContractsPath}"/>
+                                </copy>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>generate-maintainer-catalog</id>
                         <phase>generate-resources</phase>
                         <goals>
@@ -253,6 +315,32 @@
                 <configuration>
                     <mainClass>top.sywyar.pixivdownload.gui.GuiLauncher</mainClass>
                     <classifier>boot</classifier>
+                    <excludes>
+                        <exclude>
+                            <groupId>io.github.sywyar.pixivdownloader</groupId>
+                            <artifactId>pixivdownload-sdk-info</artifactId>
+                        </exclude>
+                        <exclude>
+                            <groupId>io.github.sywyar.pixivdownloader</groupId>
+                            <artifactId>pixivdownload-plugin-api</artifactId>
+                        </exclude>
+                        <exclude>
+                            <groupId>io.github.sywyar.pixivdownloader</groupId>
+                            <artifactId>pixivdownload-core-api</artifactId>
+                        </exclude>
+                        <exclude>
+                            <groupId>top.sywyar.lovepopup</groupId>
+                            <artifactId>pixivdownload-plugin-signature</artifactId>
+                        </exclude>
+                        <exclude>
+                            <groupId>top.sywyar.lovepopup</groupId>
+                            <artifactId>pixivdownload-plugin-worker</artifactId>
+                        </exclude>
+                        <exclude>
+                            <groupId>top.sywyar.lovepopup</groupId>
+                            <artifactId>pixivdownload-plugin-runtime</artifactId>
+                        </exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <!-- 把外置插件的构建产物目录传给集成测试（据此组装临时插件 jar 做真实 PF4J 加载验证）。

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/gui/PluginBootstrapBackendRestartTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/gui/PluginBootstrapBackendRestartTest.java
@@ -298,8 +298,8 @@ class PluginBootstrapBackendRestartTest {
     /** 把 {@link BackendRestartProbePlugin} + {@link BackendRestartProbeFeaturePlugin} 编译产物组装成 PF4J 可加载的 thin 插件 jar。 */
     private static Path stageProbeJar(Path pluginsDir) throws IOException {
         Files.createDirectories(pluginsDir);
-        Path jar = pluginsDir.resolve("bootstrap-probe-1.0.0.jar");
-        String props = "plugin.id=bootstrap-probe\nplugin.version=1.0.0\nplugin.requires=1.0\n"
+        Path jar = pluginsDir.resolve("bootstrap-probe-7.8.9.jar");
+        String props = "plugin.id=bootstrap-probe\nplugin.version=7.8.9\nplugin.requires=1.0\n"
                 + "plugin.class=" + BackendRestartProbePlugin.class.getName() + "\n"
                 + "plugin.provider=test\nplugin.description=bootstrap probe\n"
                 + "pixiv.execution-mode=host-process-full-trust\n"
@@ -311,7 +311,7 @@ class PluginBootstrapBackendRestartTest {
             addClassEntry(zos, BackendRestartProbePlugin.class);
             addClassEntry(zos, BackendRestartProbeFeaturePlugin.class);
         }
-        PluginTestProvenance.writeVerifiedLocalUpload(pluginsDir, jar, "bootstrap-probe", "1.0.0");
+        PluginTestProvenance.writeVerifiedLocalUpload(pluginsDir, jar);
         return jar;
     }
 

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/DistributionPackagingBoundaryTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/DistributionPackagingBoundaryTest.java
@@ -76,8 +76,24 @@ class DistributionPackagingBoundaryTest {
             Boolean.getBoolean("distribution.packaging.require-production-credential-key");
     private static final String PLUGIN_CREDENTIAL_KEY_RESOURCE =
             "BOOT-INF/classes/plugin-credential-key.properties";
+    private static final String PROGUARD_METADATA_RESOURCE =
+            "META-INF/pixivdownload-proguard.properties";
     private static final String ISOLATED_WORKER_RESOURCE =
             "BOOT-INF/classes/top/sywyar/pixivdownload/plugin/runtime/isolated-plugin-worker.jar";
+    private static final Set<String> PROGUARD_RELEASE_ARTIFACT_IDS = Set.of(
+            "pixivdownload-plugin-download-workbench",
+            "pixivdownload-plugin-gui-compose",
+            "pixivdownload-plugin-gui-swing",
+            "pixivdownload-plugin-gallery-tools",
+            "pixivdownload-plugin-posthog",
+            "pixivdownload-plugin-gallery",
+            "pixivdownload-plugin-novel",
+            "pixivdownload-plugin-notification",
+            "pixivdownload-plugin-multi-mode-decision-survey",
+            "pixivdownload-plugin-push",
+            "pixivdownload-plugin-mail",
+            "pixivdownload-plugin-tts",
+            "pixivdownload-plugin-ai");
 
     private static final String DOWNLOAD_WORKBENCH_CLASSES_PROPERTY = "download-workbench.plugin.classes";
     private static final String POSTHOG_CLASSES_PROPERTY = "posthog.plugin.classes";
@@ -362,13 +378,43 @@ class DistributionPackagingBoundaryTest {
                 "boot jar 尚未生成（需 package 阶段），无法执行 jar 条目级边界验证");
 
         List<String> entries = jarEntryNames(bootJar);
+        assertProguardProcessedArtifact(bootJar);
+        assertThat(entries).as("宿主一方模块应合并进优化后的 BOOT-INF/classes")
+                .contains(
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/sdk/SdkVersion.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/plugin/api/plugin/PixivFeaturePlugin.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/core/download/InteractiveDownloadExecutionLane.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/plugin/signature/PluginSupplyChainVerifier.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/plugin/runtime/isolation/IsolatedPluginProtocol.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/plugin/runtime/PluginRuntimeManager.class");
+        assertContractClassesPresent(entries, "pixivdownload-sdk-info");
+        assertContractClassesPresent(entries, "pixivdownload-plugin-api");
+        assertContractClassesPresent(entries, "pixivdownload-core-api");
+        assertThat(entries).as("已合并处理的一方模块不得再以未处理依赖 JAR 进入 Boot classpath")
+                .noneMatch(name -> name.matches(
+                        "BOOT-INF/lib/pixivdownload-(?:sdk-info|plugin-api|core-api|plugin-signature|plugin-worker|plugin-runtime)-[^/]+\\.jar"));
         List<String> forbiddenPrefixes = List.of(
-                "BOOT-INF/classes/top/sywyar/pixivdownload/ai/",
-                "BOOT-INF/classes/top/sywyar/pixivdownload/notification/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/ai/controller/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/ai/http/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/ai/preset/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/ai/probe/",
                 "BOOT-INF/classes/top/sywyar/pixivdownload/notificationbase/",
                 "BOOT-INF/classes/top/sywyar/pixivdownload/multimodesurvey/",
-                "BOOT-INF/classes/top/sywyar/pixivdownload/push/",
-                "BOOT-INF/classes/top/sywyar/pixivdownload/tts/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/push/channel/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/push/controller/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/push/http/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/tts/controller/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/tts/dto/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/tts/http/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/tts/narration/engine/cosyvoice/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/tts/narration/engine/doubao/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/tts/narration/engine/elevenlabs/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/tts/narration/engine/fish/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/tts/narration/engine/http/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/tts/narration/engine/mimo/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/tts/narration/engine/minimax/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/tts/narration/engine/qwen/",
+                "BOOT-INF/classes/top/sywyar/pixivdownload/tts/narration/engine/voxcpm/",
                 "BOOT-INF/classes/top/sywyar/pixivdownload/mail/",
                 "BOOT-INF/classes/top/sywyar/pixivdownload/gallerytools/",
                 "BOOT-INF/classes/top/sywyar/pixivdownload/stats/",
@@ -434,6 +480,22 @@ class DistributionPackagingBoundaryTest {
                     .as("boot jar must not contain external plugin payload prefix " + prefix)
                     .noneMatch(name -> name.startsWith(prefix) && !name.endsWith("/"));
         }
+        assertThat(entries).as("共享 API 包内不得混入外置插件入口或实现")
+                .doesNotContain(
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/ai/AiPf4jPlugin.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/ai/AiPlugin.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/ai/AiPluginConfiguration.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/ai/OpenAiCompatibleAiClient.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/notification/NotificationPushTestController.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/notification/PushNotificationSink.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/push/PushPf4jPlugin.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/push/PushPlugin.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/push/PushPluginConfiguration.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/push/PushHttpSender.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/tts/TtsPf4jPlugin.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/tts/TtsPlugin.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/tts/TtsPluginConfiguration.class",
+                        "BOOT-INF/classes/top/sywyar/pixivdownload/tts/EdgeTtsClient.class");
         assertThat(entries).as("Compose / Kotlin / Skiko 私有运行库不得进入 boot jar")
                 .noneMatch(name -> name.startsWith("BOOT-INF/lib/desktop-jvm-")
                         || name.startsWith("BOOT-INF/lib/ui-desktop-")
@@ -475,6 +537,7 @@ class DistributionPackagingBoundaryTest {
 
         try (JarFile worker = new JarFile(workerJar.toFile())) {
             List<String> entries = worker.stream().map(JarEntry::getName).toList();
+            assertProguardProcessedArtifact(workerJar);
             assertThat(worker.getManifest().getMainAttributes().getValue("Start-Class"))
                     .isEqualTo("top.sywyar.pixivdownload.plugin.runtime.isolation.IsolatedPluginWorkerMain");
             assertThat(entries)
@@ -651,6 +714,7 @@ class DistributionPackagingBoundaryTest {
             return;
         }
         List<String> entries = jarEntryNames(jar);
+        assertProguardProcessedArtifact(jar);
         assertThat(entries).contains("plugin.properties");
         assertThat(entries).contains("top/sywyar/pixivdownload/guitheme/GuiSwingPf4jPlugin.class");
         assertThat(entries).contains("top/sywyar/pixivdownload/gui/MainFrame.class");
@@ -688,6 +752,7 @@ class DistributionPackagingBoundaryTest {
             return;
         }
         List<String> entries = jarEntryNames(jar);
+        assertProguardProcessedArtifact(jar);
         assertThat(entries).contains(
                 "plugin.properties",
                 "top/sywyar/pixivdownload/guicompose/GuiComposePf4jPlugin.class",
@@ -758,6 +823,9 @@ class DistributionPackagingBoundaryTest {
                 .noneMatch(name -> name.startsWith("top/sywyar/pixivdownload/plugin/api/"));
         assertThat(entries).as("thin 插件 jar 不得携带私有 lib/*.jar")
                 .noneMatch(name -> name.matches("lib/[^/]+\\.jar"));
+        if (PROGUARD_RELEASE_ARTIFACT_IDS.contains(artifactId)) {
+            assertProguardProcessedArtifact(jar);
+        }
     }
 
     private void assertJarWithPrivateLibraries(String classesProperty, String artifactId, String mainClassEntry,
@@ -790,6 +858,7 @@ class DistributionPackagingBoundaryTest {
             assertThat(entries).as("插件 JAR 应在 lib/ 中携带私有依赖 " + required)
                     .anyMatch(name -> name.matches("lib/" + required));
         }
+        assertProguardProcessedArtifact(jar);
     }
 
     // --- helpers ---
@@ -837,14 +906,42 @@ class DistributionPackagingBoundaryTest {
     private static Properties loadUtf8Properties(Path jar, String resource) {
         try (JarFile jarFile = new JarFile(jar.toFile())) {
             JarEntry entry = jarFile.getJarEntry(resource);
-            assertThat(entry).as("boot jar 应包含 %s", resource).isNotNull();
+            assertThat(entry).as("JAR 应包含 %s", resource).isNotNull();
             try (InputStream input = jarFile.getInputStream(entry)) {
                 Properties properties = new Properties();
                 properties.load(new InputStreamReader(input, StandardCharsets.UTF_8));
                 return properties;
             }
         } catch (IOException e) {
-            throw new IllegalStateException("读取 boot jar 资源失败: " + resource, e);
+            throw new IllegalStateException("读取 JAR 资源失败: " + resource, e);
+        }
+    }
+
+    private static void assertProguardProcessedArtifact(Path jar) {
+        Properties metadata = loadUtf8Properties(jar, PROGUARD_METADATA_RESOURCE);
+        assertThat(metadata.getProperty("formatVersion")).isEqualTo("1");
+        assertThat(metadata.getProperty("proguard.version")).isNotBlank();
+        assertThat(metadata.getProperty("shrink")).isEqualTo("true");
+        assertThat(metadata.getProperty("optimize")).isEqualTo("true");
+        assertThat(metadata.getProperty("obfuscate")).isEqualTo("false");
+    }
+
+    private static void assertContractClassesPresent(List<String> entries, String module) {
+        Path classes = locateRepoRoot().resolve(module).resolve("target").resolve("classes");
+        assertThat(classes).as("公共契约模块应已构建: %s", module).isDirectory();
+        try (Stream<Path> stream = Files.walk(classes)) {
+            List<String> expected = stream
+                    .filter(Files::isRegularFile)
+                    .map(classes::relativize)
+                    .map(Path::toString)
+                    .filter(name -> name.endsWith(".class"))
+                    .map(name -> "BOOT-INF/classes/" + name.replace('\\', '/'))
+                    .toList();
+            assertThat(expected).as("公共契约模块应至少包含一个 class: %s", module).isNotEmpty();
+            assertThat(entries).as("boot jar 应原样保留公共契约模块全部 class: %s", module)
+                    .containsAll(expected);
+        } catch (IOException e) {
+            throw new IllegalStateException("读取公共契约模块失败: " + module, e);
         }
     }
 
@@ -889,6 +986,15 @@ class DistributionPackagingBoundaryTest {
     private static boolean isFreshBootJar(Path candidate, Path repoRoot) {
         try {
             FileTime jarTime = Files.getLastModifiedTime(candidate);
+            String bootName = candidate.getFileName().toString();
+            Path mainJar = candidate.resolveSibling(
+                    bootName.substring(0, bootName.length() - "-boot.jar".length()) + ".jar");
+            if (Files.isRegularFile(mainJar)) {
+                FileTime mainJarTime = Files.getLastModifiedTime(mainJar);
+                if (mainJarTime.compareTo(jarTime) > 0) {
+                    jarTime = mainJarTime;
+                }
+            }
             return !hasNewerFile(repoRoot.resolve("pixivdownload-app").resolve("src").resolve("main").resolve("java"),
                     jarTime)
                     && !hasNewerFile(repoRoot.resolve("pixivdownload-app").resolve("src").resolve("main")

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/DouyinExternalPluginBootContextTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/DouyinExternalPluginBootContextTest.java
@@ -182,9 +182,7 @@ class DouyinExternalPluginBootContextTest {
         assertThat(pluginDiscoveryResult.hasFailures()).isFalse();
         assertThat(pluginDiscoveryResult.discovered())
                 .extracting(DiscoveredFeaturePlugin::featurePluginId).contains("douyin");
-        assertThat(pluginRuntimeManager.loadedDescriptor("douyin"))
-                .get()
-                .satisfies(descriptor -> assertThat(descriptor.version()).isEqualTo("1.0.0"));
+        assertThat(pluginRuntimeManager.loadedDescriptor("douyin")).isPresent();
     }
 
     @Test
@@ -507,7 +505,7 @@ class DouyinExternalPluginBootContextTest {
             Files.createDirectories(PLUGINS_DIR);
             Path jar = PLUGINS_DIR.resolve("douyin-plugin.jar");
             zipDirectoryAsJar(classes, jar);
-            PluginTestProvenance.writeVerifiedLocalUpload(PLUGINS_DIR, jar, "douyin", "1.0.0");
+            PluginTestProvenance.writeVerifiedLocalUpload(PLUGINS_DIR, jar);
             return new StageResult(true, PluginTestProvenance.verifier(), null, null, jar);
         } catch (IOException | RuntimeException ex) {
             return StageResult.skipped();

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/DownloadWorkbenchExternalPluginBootContextTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/DownloadWorkbenchExternalPluginBootContextTest.java
@@ -192,9 +192,7 @@ class DownloadWorkbenchExternalPluginBootContextTest {
         assertThat(pluginDiscoveryResult.discovered())
                 .extracting(DiscoveredFeaturePlugin::featurePluginId)
                 .contains(PLUGIN_ID);
-        assertThat(pluginRuntimeManager.loadedDescriptor(PLUGIN_ID))
-                .get()
-                .satisfies(descriptor -> assertThat(descriptor.version()).isEqualTo("1.0.0"));
+        assertThat(pluginRuntimeManager.loadedDescriptor(PLUGIN_ID)).isPresent();
 
         assertThat(pluginRegistry.plugins())
                 .extracting(PixivFeaturePlugin::id)
@@ -570,8 +568,7 @@ class DownloadWorkbenchExternalPluginBootContextTest {
             Files.createDirectories(PLUGINS_DIR);
             Path jar = PLUGINS_DIR.resolve("download-workbench-plugin.jar");
             zipDirectoryAsJar(workbenchClasses, jar);
-            PluginTestProvenance.writeVerifiedLocalUpload(
-                    PLUGINS_DIR, jar, PLUGIN_ID, "1.0.0");
+            PluginTestProvenance.writeVerifiedLocalUpload(PLUGINS_DIR, jar);
             return true;
         } catch (IOException failure) {
             throw new IllegalStateException(

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/ExternalPluginClassLoaderReleaseTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/ExternalPluginClassLoaderReleaseTest.java
@@ -66,7 +66,7 @@ class ExternalPluginClassLoaderReleaseTest {
         tempPluginsDir = Files.createTempDirectory(Path.of("target", "test-runtime"), "pixiv-plugins-leak");
         Path jar = tempPluginsDir.resolve("gallery-tools-plugin.jar");
         zipDirectoryAsJar(statsClasses, jar);
-        PluginTestProvenance.writeVerifiedLocalUpload(tempPluginsDir, jar, "gallery-tools", "1.0.0");
+        PluginTestProvenance.writeVerifiedLocalUpload(tempPluginsDir, jar);
 
         WeakReference<ClassLoader> weakCl = loadCaptureAndUnload(tempPluginsDir);
         assertThat(weakCl).as("加载时应已捕获到真实 stats classloader 的弱引用").isNotNull();

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/GalleryExternalPluginBootContextTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/GalleryExternalPluginBootContextTest.java
@@ -285,7 +285,7 @@ class GalleryExternalPluginBootContextTest {
             Files.createDirectories(PLUGINS_DIR);
             Path jar = PLUGINS_DIR.resolve("gallery-plugin.jar");
             zipDirectoryAsJar(galleryClasses, jar);
-            PluginTestProvenance.writeVerifiedLocalUpload(PLUGINS_DIR, jar, "gallery", "1.0.0");
+            PluginTestProvenance.writeVerifiedLocalUpload(PLUGINS_DIR, jar);
             return true;
         } catch (IOException | RuntimeException ex) {
             return false;

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/GalleryToolsDuplicateBootContextTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/GalleryToolsDuplicateBootContextTest.java
@@ -268,7 +268,7 @@ class GalleryToolsDuplicateBootContextTest {
             Files.createDirectories(PLUGINS_DIR);
             Path jar = PLUGINS_DIR.resolve("gallery-tools-plugin.jar");
             zipDirectoryAsJar(duplicateClasses, jar);
-            PluginTestProvenance.writeVerifiedLocalUpload(PLUGINS_DIR, jar, "gallery-tools", "1.0.0");
+            PluginTestProvenance.writeVerifiedLocalUpload(PLUGINS_DIR, jar);
             return true;
         } catch (IOException | RuntimeException ex) {
             return false;

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/GalleryToolsExternalPluginIntegrationTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/GalleryToolsExternalPluginIntegrationTest.java
@@ -86,7 +86,7 @@ class GalleryToolsExternalPluginIntegrationTest {
         tempPluginsDir = Files.createTempDirectory("pixiv-plugins-it");
         Path jar = tempPluginsDir.resolve("gallery-tools-plugin-0.0.1.jar");
         zipDirectoryAsJar(statsClasses, jar);
-        PluginTestProvenance.writeVerifiedLocalUpload(tempPluginsDir, jar, "gallery-tools", "1.0.0");
+        PluginTestProvenance.writeVerifiedLocalUpload(tempPluginsDir, jar);
 
         manager = new PluginRuntimeManager(tempPluginsDir, PluginTestProvenance.verifier());
         status = manager.start();
@@ -127,7 +127,6 @@ class GalleryToolsExternalPluginIntegrationTest {
         PluginDescriptor descriptor = stats.descriptor();
         assertThat(descriptor.id()).isEqualTo("gallery-tools");
         assertThat(descriptor.sourcePluginId()).isEqualTo("gallery-tools");
-        assertThat(descriptor.version()).isEqualTo("1.0.0");
         assertThat(descriptor.pluginClass())
                 .isEqualTo("top.sywyar.pixivdownload.gallerytools.GalleryToolsPf4jPlugin");
         assertThat(descriptor.requires().present()).isTrue();

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/GalleryToolsStatsBootContextTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/GalleryToolsStatsBootContextTest.java
@@ -451,7 +451,7 @@ class GalleryToolsStatsBootContextTest {
             Files.createDirectories(PLUGINS_DIR);
             Path jar = PLUGINS_DIR.resolve("gallery-tools-plugin.jar");
             zipDirectoryAsJar(statsClasses, jar);
-            PluginTestProvenance.writeVerifiedLocalUpload(PLUGINS_DIR, jar, "gallery-tools", "1.0.0");
+            PluginTestProvenance.writeVerifiedLocalUpload(PLUGINS_DIR, jar);
             return true;
         } catch (IOException | RuntimeException ex) {
             return false;

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/NovelExternalPluginBootContextTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/NovelExternalPluginBootContextTest.java
@@ -351,7 +351,7 @@ class NovelExternalPluginBootContextTest {
             Files.createDirectories(PLUGINS_DIR);
             Path jar = PLUGINS_DIR.resolve("novel-plugin.jar");
             zipDirectoryAsJar(classes, jar);
-            PluginTestProvenance.writeVerifiedLocalUpload(PLUGINS_DIR, jar, "novel", "1.0.0");
+            PluginTestProvenance.writeVerifiedLocalUpload(PLUGINS_DIR, jar);
             return true;
         } catch (IOException | RuntimeException ex) {
             return false;

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/NovelPluginDisabledContextTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/NovelPluginDisabledContextTest.java
@@ -179,7 +179,7 @@ class NovelPluginDisabledContextTest {
             Files.createDirectories(PLUGINS_DIR);
             Path jar = PLUGINS_DIR.resolve("novel-plugin.jar");
             zipDirectoryAsJar(classes, jar);
-            PluginTestProvenance.writeVerifiedLocalUpload(PLUGINS_DIR, jar, "novel", "1.0.0");
+            PluginTestProvenance.writeVerifiedLocalUpload(PLUGINS_DIR, jar);
             return true;
         } catch (IOException | RuntimeException ex) {
             return false;

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/PluginRequiredVerificationRecoveryTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/PluginRequiredVerificationRecoveryTest.java
@@ -202,7 +202,7 @@ class PluginRequiredVerificationRecoveryTest {
     @DisplayName("local unsigned optional：显式开发态准入时允许加载并投影为本地来源")
     void localUnsignedOptionalAllowedWithExplicitSidecar() throws Exception {
         Scenario scenario = scenario("local-unsigned");
-        PluginTestProvenance.writeLocalUpload(scenario.pluginsDir(), scenario.jar(), PLUGIN_ID, VERSION);
+        PluginTestProvenance.writeLocalUpload(scenario.pluginsDir(), scenario.jar());
 
         PluginRuntimeManager manager = startDevelopmentTrust(scenario, new PluginSupplyChainVerifier());
         try {
@@ -221,7 +221,7 @@ class PluginRequiredVerificationRecoveryTest {
     @DisplayName("生产模式在 PF4J 前拒绝开发专用本地未签名插件")
     void localUnsignedOptionalRejectedOutsideDevelopmentMode() throws Exception {
         Scenario scenario = scenario("local-unsigned-production");
-        PluginTestProvenance.writeLocalUpload(scenario.pluginsDir(), scenario.jar(), PLUGIN_ID, VERSION);
+        PluginTestProvenance.writeLocalUpload(scenario.pluginsDir(), scenario.jar());
 
         PluginRuntimeManager manager = start(scenario, new PluginSupplyChainVerifier());
         try {

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/PluginRuntimeChinesePathLoadTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/PluginRuntimeChinesePathLoadTest.java
@@ -73,7 +73,7 @@ class PluginRuntimeChinesePathLoadTest {
         Files.createDirectories(PLUGINS_DIR);
         Path jar = PLUGINS_DIR.resolve("pixivdownload-plugin-gallery-tools.jar");
         zipDirectoryAsJar(statsClasses, jar);
-        PluginTestProvenance.writeVerifiedLocalUpload(PLUGINS_DIR, jar, "gallery-tools", "1.0.0");
+        PluginTestProvenance.writeVerifiedLocalUpload(PLUGINS_DIR, jar);
 
         manager = new PluginRuntimeManager(PLUGINS_DIR, PluginTestProvenance.verifier());
         status = manager.start();

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/PluginTestProvenance.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/PluginTestProvenance.java
@@ -49,16 +49,18 @@ public final class PluginTestProvenance {
     private PluginTestProvenance() {
     }
 
-    public static void writeLocalUpload(Path pluginsDir, Path artifact, String pluginId, String version)
-            throws IOException {
+    public static void writeLocalUpload(Path pluginsDir, Path artifact) throws IOException {
+        var descriptor = PluginPackageReader.inspect(artifact).descriptor();
         VerificationResult result = new VerificationResult(VerificationStatus.UNSIGNED_ALLOWED,
-                pluginId, version, null, null, null, null, Instant.now(), Files.size(artifact),
+                descriptor.id(), descriptor.version(), null, null, null, null, Instant.now(), Files.size(artifact),
                 PluginPackageIntegrity.sha256Hex(artifact), "UNSIGNED_ALLOWED");
         new PluginProvenanceStore(pluginsDir).write(artifact, PluginPackageOrigin.localUpload(), result);
     }
 
-    public static void writeVerifiedLocalUpload(Path pluginsDir, Path artifact, String pluginId, String version)
-            throws IOException {
+    public static void writeVerifiedLocalUpload(Path pluginsDir, Path artifact) throws IOException {
+        var descriptor = PluginPackageReader.inspect(artifact).descriptor();
+        String pluginId = descriptor.id();
+        String version = descriptor.version();
         String sha256 = PluginPackageIntegrity.sha256Hex(artifact);
         SignatureMetadata metadata = new SignatureMetadata(
                 SignatureMetadata.FORMAT_VERSION,
@@ -77,8 +79,7 @@ public final class PluginTestProvenance {
                 VerificationPolicy.customRepository()));
         PluginProvenanceRecord provenance = PluginProvenanceRecord.from(origin, result);
         new PluginProvenanceStore(pluginsDir).write(artifact, provenance.withTrustDecision(
-                PluginTrustPolicy.approve(
-                        PluginPackageReader.inspect(artifact).descriptor(), provenance, Instant.now())));
+                PluginTrustPolicy.approve(descriptor, provenance, Instant.now())));
     }
 
     public static PluginSupplyChainVerifier verifier() {

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/RecoverySentinelExternalPluginIntegrationTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/RecoverySentinelExternalPluginIntegrationTest.java
@@ -77,7 +77,7 @@ class RecoverySentinelExternalPluginIntegrationTest {
         tempPluginsDir = Files.createTempDirectory("pixiv-recovery-sentinel-it");
         Path jar = tempPluginsDir.resolve("recovery-sentinel-plugin-0.0.1.jar");
         zipDirectoryAsJar(sentinelClasses, jar);
-        PluginTestProvenance.writeVerifiedLocalUpload(tempPluginsDir, jar, "recovery-sentinel", "1.0.0");
+        PluginTestProvenance.writeVerifiedLocalUpload(tempPluginsDir, jar);
 
         manager = new PluginRuntimeManager(tempPluginsDir, PluginTestProvenance.verifier());
         status = manager.start();

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
@@ -1135,6 +1135,55 @@ class PluginReleaseScriptsTest {
     }
 
     @Test
+    @DisplayName("release/nightly 发布前安装并启动最终 Windows 与 Java 分发产物")
+    void releaseWorkflowsRunFinalArtifactAcceptanceBeforePublication() throws Exception {
+        String script = script("test-release-artifacts.ps1");
+        String acceptanceAction = action("test-release-artifacts");
+
+        assertThat(script).contains(
+                "Refusing installer E2E because PixivDownload is already registered",
+                "Expand-Archive -LiteralPath $Archive",
+                "PixivDownload-$Version.jar",
+                "runtime\\bin\\server\\jvm.dll",
+                "--setup",
+                "--no-gui",
+                "/actuator/health",
+                "/actuator/info",
+                "/api/auth/login",
+                "/api/plugins/status",
+                "status -ne \"STARTED\"",
+                "runtimePhase -ne \"STARTED\"",
+                "recoveryMode",
+                "Wait-ArtifactProcessExit",
+                "-TimeoutSeconds 600",
+                "-TimeoutSeconds 300",
+                "unins000.exe");
+        assertAsciiWithoutBom(repoRoot().resolve("scripts").resolve("test-release-artifacts.ps1"));
+        assertThat(acceptanceAction).contains(
+                "name: windows-installer",
+                "name: java-distributions",
+                "Install and start final release artifacts",
+                "./scripts/test-release-artifacts.ps1",
+                "-InstallerPath $installers[0].FullName",
+                "-JavaZipPath $javaZips[0].FullName",
+                "-FullOfflineZipPath $offlineZips[0].FullName");
+
+        for (String name : List.of("release.yml", "nightly.yml")) {
+            String workflow = workflow(name);
+            String acceptanceJob = workflowJob(workflow, "release-artifact-e2e");
+            String publicationJob = workflowJob(workflow,
+                    name.equals("release.yml") ? "release" : "release-nightly");
+
+            assertThat(acceptanceJob).as(name).contains(
+                    "runs-on: windows-latest",
+                    "timeout-minutes: 45",
+                    "uses: ./.github/actions/test-release-artifacts",
+                    "release_version:");
+            assertThat(publicationJob).as(name).contains("release-artifact-e2e");
+        }
+    }
+
+    @Test
     @DisplayName("分发组装脚本支持精确 PrebuiltJar 输入：互斥、严格验证、精确路径、本地 fallback 保留")
     void distributionAssemblerSupportsExactPrebuiltJarInput() throws Exception {
         String distribution = script("assemble-plugin-distribution.ps1");
@@ -1556,7 +1605,8 @@ class PluginReleaseScriptsTest {
         assertThat(nightly).contains("workflow_dispatch:");
         assertThat(releaseJob)
                 .contains(
-                        "needs: [resolve-version, publish-plugins, publish-plugin-artifacts, build-jar, build-windows-installer]",
+                        "needs: [resolve-version, publish-plugins, publish-plugin-artifacts, build-jar, "
+                                + "build-windows-installer, release-artifact-e2e]",
                         "if: needs.resolve-version.outputs.has_changes == 'true'")
                 .doesNotContain("always()");
         assertThat(releaseStep).contains(

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
@@ -196,6 +196,7 @@ class PluginReleaseScriptsTest {
                 "function Find-ModulePluginArtifact",
                 "function Find-PluginArtifactSignatureSidecar",
                 "function Assert-PluginArtifactSignature",
+                "function Assert-ProguardProcessedArtifact",
                 "function Get-PluginArtifactSignatureForDistribution",
                 "Assert-JarWithPrivatePluginLibs",
                 "Assert-ThinPluginJar",
@@ -207,6 +208,27 @@ class PluginReleaseScriptsTest {
                 "Plugin jar is not thin - found private lib/*.jar entries");
         assertThat(common).doesNotContain("Format = \"zip\"");
         assertThat(common).doesNotContain("Assert-ExplodedPluginZip");
+    }
+
+    @Test
+    @DisplayName("发布产物 ProGuard 标记必须声明 shrink/optimize 且关闭混淆")
+    void proguardArtifactMetadataIsValidated(@TempDir Path tempDir) throws Exception {
+        Path processed = tempDir.resolve("processed.jar");
+        writeThinPluginJar(processed, "sample", "1.0.1", "1.0");
+        assertThat(runPowerShell(
+                "$ErrorActionPreference='Stop'; "
+                        + ". './scripts/plugin-distribution-common.ps1'; "
+                        + "Assert-ProguardProcessedArtifact '" + psQuote(processed) + "'; 'OK'"))
+                .isEqualTo("OK");
+
+        Path raw = tempDir.resolve("raw.jar");
+        writeThinPluginJar(raw, "sample", "1.0.1", "1.0", false);
+        CommandResult failure = runPowerShellResult(
+                "$ErrorActionPreference='Stop'; "
+                        + ". './scripts/plugin-distribution-common.ps1'; "
+                        + "Assert-ProguardProcessedArtifact '" + psQuote(raw) + "'");
+        assertThat(failure.exitCode()).as(failure.output()).isNotZero();
+        assertThat(failure.output()).contains("Release artifact is missing ProGuard metadata");
     }
 
     @Test
@@ -2024,6 +2046,12 @@ class PluginReleaseScriptsTest {
 
     private static void writeThinPluginJar(Path path, String id, String version, String requires)
             throws IOException {
+        writeThinPluginJar(path, id, version, requires, true);
+    }
+
+    private static void writeThinPluginJar(
+            Path path, String id, String version, String requires, boolean includeProguardMetadata)
+            throws IOException {
         try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(path), StandardCharsets.UTF_8)) {
             zip.putNextEntry(new ZipEntry("plugin.properties"));
             zip.write(("plugin.id=" + id + "\n"
@@ -2031,6 +2059,15 @@ class PluginReleaseScriptsTest {
                     + "plugin.requires=" + requires + "\n"
                     + "pixiv.execution-mode=host-process-full-trust\n").getBytes(StandardCharsets.UTF_8));
             zip.closeEntry();
+            if (includeProguardMetadata) {
+                zip.putNextEntry(new ZipEntry("META-INF/pixivdownload-proguard.properties"));
+                zip.write(("formatVersion=1\n"
+                        + "proguard.version=7.10.0\n"
+                        + "shrink=true\n"
+                        + "optimize=true\n"
+                        + "obfuscate=false\n").getBytes(StandardCharsets.UTF_8));
+                zip.closeEntry();
+            }
         }
     }
 

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
@@ -337,7 +337,6 @@ class PluginReleaseScriptsTest {
         assertThat(curation.has("douyin")).isFalse();
         assertThat(pluginDescriptor("pixivdownload-plugin-douyin")).contains(
                 "plugin.id=douyin",
-                "plugin.version=1.0.0",
                 "plugin.requires=1.0");
     }
 
@@ -865,17 +864,6 @@ class PluginReleaseScriptsTest {
                 "package-ecosystem: \"github-actions\"",
                 "directory: \"/\"",
                 "interval: \"weekly\"");
-    }
-
-    @Test
-    @DisplayName("所有未发布官方插件统一使用初始版本 1.0.0 和首个SDK 1.0")
-    void officialPluginVersionsStartAtInitialVersion() throws Exception {
-        for (OfficialPlugin plugin : officialDistributionPlugins()) {
-            assertThat(pluginDescriptor(plugin.module())).as(plugin.id())
-                    .contains("plugin.version=1.0.0", "plugin.requires=1.0");
-        }
-        assertThat(pluginDescriptor("pixivdownload-plugin-recovery-sentinel"))
-                .contains("plugin.version=1.0.0", "plugin.requires=1.0");
     }
 
     @Test

--- a/pixivdownload-plugin-ai/pom.xml
+++ b/pixivdownload-plugin-ai/pom.xml
@@ -12,6 +12,11 @@
     <name>PixivDownloader AI Plugin</name>
     <description>Official external OpenAI-compatible AI plugin.</description>
 
+    <properties>
+        <pixivdownload.proguard.skip>false</pixivdownload.proguard.skip>
+        <pixivdownload.jar.classesDirectory>${pixivdownload.proguard.outputDirectory}</pixivdownload.jar.classesDirectory>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.github.sywyar.pixivdownloader</groupId>

--- a/pixivdownload-plugin-download-workbench/pom.xml
+++ b/pixivdownload-plugin-download-workbench/pom.xml
@@ -12,6 +12,11 @@
     <name>PixivDownloader Download Workbench Plugin</name>
     <description>Official required external PF4J plugin for the download workbench, Pixiv fetch proxy, queue, userscripts, and scheduled download host.</description>
 
+    <properties>
+        <pixivdownload.proguard.skip>false</pixivdownload.proguard.skip>
+        <pixivdownload.jar.classesDirectory>${pixivdownload.proguard.outputDirectory}</pixivdownload.jar.classesDirectory>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.github.sywyar.pixivdownloader</groupId>

--- a/pixivdownload-plugin-gallery-tools/pom.xml
+++ b/pixivdownload-plugin-gallery-tools/pom.xml
@@ -15,6 +15,8 @@
 
     <properties>
         <java.version>17</java.version>
+        <pixivdownload.proguard.skip>false</pixivdownload.proguard.skip>
+        <pixivdownload.jar.classesDirectory>${pixivdownload.proguard.outputDirectory}</pixivdownload.jar.classesDirectory>
     </properties>
 
     <dependencies>

--- a/pixivdownload-plugin-gallery/pom.xml
+++ b/pixivdownload-plugin-gallery/pom.xml
@@ -12,6 +12,11 @@
     <name>PixivDownloader Gallery Plugin</name>
     <description>本地画廊官方可选功能插件：画廊 / 作品详情 / 精选集 / 系列页面、展示 API、批量管理、导航、i18n 与静态资源。核心下载事实、元数据、资产与删除能力留在主程序。</description>
 
+    <properties>
+        <pixivdownload.proguard.skip>false</pixivdownload.proguard.skip>
+        <pixivdownload.jar.classesDirectory>${pixivdownload.proguard.outputDirectory}</pixivdownload.jar.classesDirectory>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.github.sywyar.pixivdownloader</groupId>

--- a/pixivdownload-plugin-gui-compose/build.gradle.kts
+++ b/pixivdownload-plugin-gui-compose/build.gradle.kts
@@ -1,15 +1,34 @@
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.testing.Test
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import proguard.gradle.ProGuardTask
+import java.io.BufferedOutputStream
 import java.util.Properties
+import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.guardsquare:proguard-gradle:${project.property("proguardVersion")}")
+    }
+}
 
 abstract class VerifyPluginArtifact : DefaultTask() {
     @get:InputFile
@@ -35,6 +54,9 @@ abstract class VerifyPluginArtifact : DefaultTask() {
             }
             check("META-INF/licenses/ComposeWindowsDecoration-LICENSE.txt" in entries) {
                 "Windows decoration license is missing"
+            }
+            check("META-INF/pixivdownload-proguard.properties" in entries) {
+                "ProGuard build marker is missing"
             }
             val classOwners = mutableMapOf<String, MutableList<String>>()
             zip.entries().asSequence().filter { it.name.startsWith("lib/") && it.name.endsWith(".jar") }
@@ -66,6 +88,46 @@ abstract class VerifyPluginArtifact : DefaultTask() {
             check(descriptor.getProperty("plugin.id") == "gui-compose") { "unexpected plugin id" }
             check(descriptor.getProperty("pixiv.lifecycle-policy") == "process-restart") {
                 "desktop UI providers must use process-restart lifecycle"
+            }
+        }
+    }
+}
+
+abstract class NormalizeProguardArchives : DefaultTask() {
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.NAME_ONLY)
+    abstract val archives: ConfigurableFileCollection
+
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @TaskAction
+    fun normalize() {
+        val destination = outputDirectory.get().asFile
+        check(destination.deleteRecursively()) { "Cannot clear normalized ProGuard archive directory: $destination" }
+        check(destination.mkdirs() || destination.isDirectory) {
+            "Cannot create normalized ProGuard archive directory: $destination"
+        }
+        archives.files.sortedBy(File::getName).forEach { input ->
+            val output = destination.resolve(input.name)
+            ZipFile(input).use { zip ->
+                ZipOutputStream(BufferedOutputStream(output.outputStream())).use { normalized ->
+                    zip.entries().asSequence()
+                        .filterNot { entry ->
+                            val name = entry.name.uppercase()
+                            name.startsWith("META-INF/") &&
+                                    (name.endsWith(".SF") || name.endsWith(".RSA") || name.endsWith(".DSA"))
+                        }
+                        .sortedBy(ZipEntry::getName)
+                        .forEach { source ->
+                            val target = ZipEntry(source.name).also { it.time = 0L }
+                            normalized.putNextEntry(target)
+                            if (!source.isDirectory) {
+                                zip.getInputStream(source).use { it.copyTo(normalized) }
+                            }
+                            normalized.closeEntry()
+                        }
+                }
             }
         }
     }
@@ -111,6 +173,7 @@ val missingMavenClasspathFiles = mavenClasspathFiles.filterNot(File::exists)
 val mavenClasspathReady = mavenClasspathFiles.isNotEmpty() && missingMavenClasspathFiles.isEmpty()
 val idePluginApiClasses = layout.projectDirectory.dir("../pixivdownload-plugin-api/target/classes")
 val sdkClasspath = if (mavenClasspathReady) mavenClasspath else files(idePluginApiClasses)
+val proguardVersion = providers.gradleProperty("proguardVersion").get()
 val idePf4jVersion = if (mavenClasspathReady) null else {
     val parentPom = providers.fileContents(layout.projectDirectory.file("../pom.xml")).asText.get()
     Regex("""<pf4j\.version>\s*([^<\s]+)\s*</pf4j\.version>""")
@@ -202,18 +265,90 @@ tasks.withType<Test>().configureEach {
 
 tasks.named<Jar>("jar") { enabled = false }
 
+val proguardInputJar = tasks.register<Jar>("proguardInputJar") {
+    dependsOn(tasks.named("classes"))
+    archiveFileName.set("plugin-code.jar")
+    destinationDirectory.set(mavenBuildDirectory.resolve("proguard/input"))
+    duplicatesStrategy = DuplicatesStrategy.FAIL
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+    from(sourceSets.main.get().output)
+}
+
+val proguardRawDirectory = mavenBuildDirectory.resolve("proguard/raw")
+val proguardRawLibraries = proguardRawDirectory.resolve("lib")
+val proguardReportsDirectory = mavenBuildDirectory.resolve("proguard/reports")
+val composeProguardRules = layout.projectDirectory.file("../build-support/proguard/compose.pro")
+val proguardRuntimeJars = configurations.runtimeClasspath.map { runtimeClasspath ->
+    runtimeClasspath.files.sortedBy(File::getName).also { files ->
+        check(files.map(File::getName).distinct().size == files.size) {
+            "Compose runtime classpath contains duplicate JAR file names"
+        }
+    }
+}
+val proguardRuntimeOutputs = proguardRuntimeJars.map { files ->
+    files.map { proguardRawLibraries.resolve(it.name) }
+}
+val proguardPlugin = tasks.register<ProGuardTask>("proguardPlugin") {
+    group = "build"
+    description = "Shrinks and optimizes the Compose plugin artifact without obfuscation."
+    dependsOn(proguardInputJar, verifyMavenClasspath)
+    inputs.file(proguardInputJar.flatMap(Jar::getArchiveFile))
+    inputs.files(configurations.runtimeClasspath, mavenClasspath)
+    inputs.file(composeProguardRules)
+    outputs.dir(proguardRawDirectory)
+    configuration(composeProguardRules.asFile)
+    dontobfuscate()
+    optimizationpasses(3)
+    printconfiguration(proguardReportsDirectory.resolve("configuration.pro"))
+    printseeds(proguardReportsDirectory.resolve("seeds.txt"))
+    printusage(proguardReportsDirectory.resolve("usage.txt"))
+    val input = proguardInputJar.get().archiveFile.get().asFile
+    injars(input)
+    outjars(proguardRawDirectory.resolve(input.name))
+    proguardRuntimeJars.get().forEach { runtimeJar ->
+        injars(runtimeJar)
+        outjars(proguardRawLibraries.resolve(runtimeJar.name))
+    }
+    mavenClasspath.files.sortedBy(File::getAbsolutePath).forEach(::libraryjars)
+    File(System.getProperty("java.home"), "jmods").listFiles()
+        .orEmpty()
+        .filter { it.isFile && it.extension.equals("jmod", ignoreCase = true) }
+        .sortedBy(File::getName)
+        .forEach { jmod ->
+            libraryjars(mapOf("jarfilter" to "!**.jar", "filter" to "!module-info.class"), jmod)
+        }
+}
+
+val normalizedProguardLibraries = mavenBuildDirectory.resolve("proguard/normalized-lib")
+val normalizeProguardLibraries = tasks.register<NormalizeProguardArchives>("normalizeProguardLibraries") {
+    dependsOn(proguardPlugin)
+    archives.from(proguardRuntimeOutputs)
+    outputDirectory.set(normalizedProguardLibraries)
+}
+
 val pluginJar = tasks.register<Jar>("pluginJar") {
     group = "build"
     description = "Builds the reproducible PF4J JAR-with-lib artifact."
-    dependsOn(tasks.named("classes"))
+    dependsOn(proguardPlugin, normalizeProguardLibraries)
     archiveFileName.set("$mavenFinalName.jar")
     destinationDirectory.set(mavenBuildDirectory)
     duplicatesStrategy = DuplicatesStrategy.FAIL
     isPreserveFileTimestamps = false
     isReproducibleFileOrder = true
-    from(sourceSets.main.get().output)
+    from(zipTree(proguardRawDirectory.resolve("plugin-code.jar")))
+    into("META-INF") {
+        from(resources.text.fromString("""formatVersion=1
+proguard.version=$proguardVersion
+shrink=true
+optimize=true
+obfuscate=false
+""")) {
+            rename { "pixivdownload-proguard.properties" }
+        }
+    }
     into("lib") {
-        from(configurations.runtimeClasspath)
+        from(normalizedProguardLibraries)
     }
 }
 

--- a/pixivdownload-plugin-gui-compose/gradle.properties
+++ b/pixivdownload-plugin-gui-compose/gradle.properties
@@ -8,3 +8,4 @@ kotlinLanguageVersion=2.4
 composeVersion=1.11.1
 composeMaterial3Version=1.9.0
 skikoVersion=0.144.6
+proguardVersion=7.10.0

--- a/pixivdownload-plugin-gui-compose/pom.xml
+++ b/pixivdownload-plugin-gui-compose/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>pixivdownload-plugin-gui-compose</artifactId>
-    <packaging>jar</packaging>
+    <packaging>pom</packaging>
     <name>PixivDownloader Compose Multiplatform GUI Plugin</name>
     <description>Gradle-built optional Compose Multiplatform desktop UI provider packaged as a PF4J JAR-with-lib.</description>
 
@@ -159,6 +159,26 @@
                         <phase>verify</phase>
                         <goals><goal>exec</goal></goals>
                         <configuration><arguments combine.children="append"><argument>checkPlugin</argument></arguments></configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>register-gradle-artifact</id>
+                        <phase>package</phase>
+                        <goals><goal>attach-artifact</goal></goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${project.build.directory}/${project.build.finalName}.jar</file>
+                                    <type>jar</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pixivdownload-plugin-gui-swing/pom.xml
+++ b/pixivdownload-plugin-gui-swing/pom.xml
@@ -12,6 +12,11 @@
     <name>PixivDownloader Swing GUI Plugin</name>
     <description>Official process-lifetime Swing desktop UI and theme plugin, packaged as a PF4J JAR-with-lib.</description>
 
+    <properties>
+        <pixivdownload.proguard.skip>false</pixivdownload.proguard.skip>
+        <pixivdownload.jar.classesDirectory>${pixivdownload.proguard.outputDirectory}</pixivdownload.jar.classesDirectory>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.github.sywyar.pixivdownloader</groupId>

--- a/pixivdownload-plugin-mail/pom.xml
+++ b/pixivdownload-plugin-mail/pom.xml
@@ -12,6 +12,11 @@
     <name>PixivDownloader Mail Plugin</name>
     <description>Official external SMTP mail notification plugin.</description>
 
+    <properties>
+        <pixivdownload.proguard.skip>false</pixivdownload.proguard.skip>
+        <pixivdownload.jar.classesDirectory>${pixivdownload.proguard.outputDirectory}</pixivdownload.jar.classesDirectory>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.github.sywyar.pixivdownloader</groupId>

--- a/pixivdownload-plugin-multi-mode-decision-survey/pom.xml
+++ b/pixivdownload-plugin-multi-mode-decision-survey/pom.xml
@@ -12,6 +12,11 @@
     <name>PixivDownloader Multi-mode Decision Survey Plugin</name>
     <description>Official inbox-only survey publisher for the proposed removal of multi-user mode.</description>
 
+    <properties>
+        <pixivdownload.proguard.skip>false</pixivdownload.proguard.skip>
+        <pixivdownload.jar.classesDirectory>${pixivdownload.proguard.outputDirectory}</pixivdownload.jar.classesDirectory>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.github.sywyar.pixivdownloader</groupId>

--- a/pixivdownload-plugin-notification/pom.xml
+++ b/pixivdownload-plugin-notification/pom.xml
@@ -12,6 +12,11 @@
     <name>PixivDownloader Notification Plugin</name>
     <description>Official notification scenario configuration and administrator inbox plugin.</description>
 
+    <properties>
+        <pixivdownload.proguard.skip>false</pixivdownload.proguard.skip>
+        <pixivdownload.jar.classesDirectory>${pixivdownload.proguard.outputDirectory}</pixivdownload.jar.classesDirectory>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.github.sywyar.pixivdownloader</groupId>

--- a/pixivdownload-plugin-novel/pom.xml
+++ b/pixivdownload-plugin-novel/pom.xml
@@ -12,6 +12,11 @@
     <name>PixivDownloader Novel Plugin</name>
     <description>小说官方可选功能插件：下载支持、Pixiv 小说 API、计划任务小说执行、正文保存、翻译、合订、AI 听书协作、小说画廊与阅读页展示。</description>
 
+    <properties>
+        <pixivdownload.proguard.skip>false</pixivdownload.proguard.skip>
+        <pixivdownload.jar.classesDirectory>${pixivdownload.proguard.outputDirectory}</pixivdownload.jar.classesDirectory>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.github.sywyar.pixivdownloader</groupId>

--- a/pixivdownload-plugin-posthog/pom.xml
+++ b/pixivdownload-plugin-posthog/pom.xml
@@ -12,6 +12,11 @@
     <name>PixivDownloader PostHog Plugin</name>
     <description>Official thin PF4J plugin providing the vendored PostHog browser SDK and isolated named clients configured by survey-publishing plugins.</description>
 
+    <properties>
+        <pixivdownload.proguard.skip>false</pixivdownload.proguard.skip>
+        <pixivdownload.jar.classesDirectory>${pixivdownload.proguard.outputDirectory}</pixivdownload.jar.classesDirectory>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.github.sywyar.pixivdownloader</groupId>

--- a/pixivdownload-plugin-push/pom.xml
+++ b/pixivdownload-plugin-push/pom.xml
@@ -12,6 +12,11 @@
     <name>PixivDownloader Push Plugin</name>
     <description>Official external push notification plugin.</description>
 
+    <properties>
+        <pixivdownload.proguard.skip>false</pixivdownload.proguard.skip>
+        <pixivdownload.jar.classesDirectory>${pixivdownload.proguard.outputDirectory}</pixivdownload.jar.classesDirectory>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.github.sywyar.pixivdownloader</groupId>

--- a/pixivdownload-plugin-runtime/src/main/java/top/sywyar/pixivdownload/plugin/runtime/PluginRuntimeManager.java
+++ b/pixivdownload-plugin-runtime/src/main/java/top/sywyar/pixivdownload/plugin/runtime/PluginRuntimeManager.java
@@ -1401,8 +1401,9 @@ public class PluginRuntimeManager {
             recoveryToken = isolatedRecoveryTokens.merge(packageId, 1L, Math::addExact);
             attempts = isolatedSessions.get(packageId).restartAttempts();
         }
-        log.error("Isolated plugin worker crashed: pluginId={}, generation={}, crashCount={}, exitCode={}",
-                packageId, generation, event.crashCount(), exit.exitCode());
+        log.error("Isolated plugin worker crashed: "
+                        + "pluginId={}, generation={}, crashCount={}, exitCode={}, workerLog={}",
+                packageId, generation, event.crashCount(), exit.exitCode(), event.logPath());
         notifyWorkerListeners(event);
         if (attempts > 0) {
             scheduleIsolatedRecovery(packageId, generation, recoveryToken, 1);
@@ -1473,6 +1474,8 @@ public class PluginRuntimeManager {
             }
         }
         if (recovered != null) {
+            log.info("Isolated plugin worker recovered: pluginId={}, generation={}, attempt={}",
+                    recovered.pluginId(), recovered.generation(), recovered.restartAttempt());
             notifyWorkerListeners(recovered);
         } else if (retry) {
             scheduleIsolatedRecovery(packageId, generation, recoveryToken, attempt + 1);

--- a/pixivdownload-plugin-runtime/src/test/java/top/sywyar/pixivdownload/plugin/runtime/PluginRuntimeManagerTest.java
+++ b/pixivdownload-plugin-runtime/src/test/java/top/sywyar/pixivdownload/plugin/runtime/PluginRuntimeManagerTest.java
@@ -234,6 +234,85 @@ class PluginRuntimeManagerTest {
     }
 
     @Test
+    @DisplayName("声明式 worker 连续启停一百次均清退旧进程并保持同一 generation")
+    void survivesOneHundredIsolatedWorkerStartStopCycles() throws IOException {
+        Path plugins = tempDir.resolve("plugins-isolated-start-stop-stress");
+        Path jar = plugins.resolve("bootstrap-probe-1.0.0.jar");
+        writeDeclarativeProbeJar(jar);
+        writeLocalProvenance(plugins, jar);
+        top.sywyar.pixivdownload.plugin.runtime.PluginRuntimeManager manager =
+                new top.sywyar.pixivdownload.plugin.runtime.PluginRuntimeManager(plugins, () -> true);
+        try {
+            manager.loadPlugin(jar);
+            long generation = manager.generation(PROBE_ID).orElseThrow();
+            for (int cycle = 1; cycle <= 100; cycle++) {
+                manager.startPlugin(PROBE_ID);
+                assertThat(manager.isolatedWorkerAliveForTest(PROBE_ID)).as("start cycle %s", cycle).isTrue();
+                assertThat(manager.packagePhases().get(PROBE_ID)).isEqualTo(PluginRuntimePackagePhase.STARTED);
+
+                manager.stopPlugin(PROBE_ID);
+                assertThat(manager.isolatedWorkerAliveForTest(PROBE_ID)).as("stop cycle %s", cycle).isFalse();
+                assertThat(manager.packagePhases().get(PROBE_ID)).isEqualTo(PluginRuntimePackagePhase.STOPPED);
+                assertThat(manager.generation(PROBE_ID)).contains(generation);
+            }
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    @DisplayName("单个声明式 worker 崩溃与恢复不改变兄弟 worker 的进程和状态")
+    void isolatesWorkerCrashAndRecoveryFromSibling() throws Exception {
+        Path plugins = tempDir.resolve("plugins-isolated-crash-boundary");
+        Path crashingJar = plugins.resolve("bootstrap-probe-1.0.0.jar");
+        Path siblingJar = plugins.resolve("isolated-static-probe-1.0.0.jar");
+        writeDeclarativeProbeJar(crashingJar);
+        writeIsolatedStaticProbeJar(siblingJar);
+        writeLocalProvenance(plugins, crashingJar);
+        writeLocalProvenance(plugins, siblingJar, "isolated-static-probe", PROBE_VERSION);
+        System.setProperty(IsolatedPluginSession.RESTART_ATTEMPTS_PROPERTY, "2");
+        System.setProperty(IsolatedPluginSession.RESTART_INITIAL_DELAY_PROPERTY, "250");
+        System.setProperty(IsolatedPluginSession.RESTART_MAX_DELAY_PROPERTY, "500");
+        top.sywyar.pixivdownload.plugin.runtime.PluginRuntimeManager manager =
+                new top.sywyar.pixivdownload.plugin.runtime.PluginRuntimeManager(plugins, () -> true);
+        LinkedBlockingQueue<top.sywyar.pixivdownload.plugin.runtime.PluginRuntimeManager.WorkerEvent> events =
+                new LinkedBlockingQueue<>();
+        manager.addWorkerListener(events::add);
+        try {
+            manager.loadPlugin(crashingJar);
+            manager.loadPlugin(siblingJar);
+            manager.startPlugin(PROBE_ID);
+            manager.startPlugin("isolated-static-probe");
+            long crashedPid = manager.isolatedWorkerPidForTest(PROBE_ID);
+            long siblingPid = manager.isolatedWorkerPidForTest("isolated-static-probe");
+
+            ProcessHandle.of(crashedPid).orElseThrow().destroyForcibly();
+
+            top.sywyar.pixivdownload.plugin.runtime.PluginRuntimeManager.WorkerEvent crashed =
+                    events.poll(10, TimeUnit.SECONDS);
+            assertThat(crashed).isNotNull();
+            assertThat(crashed.type()).isEqualTo(
+                    top.sywyar.pixivdownload.plugin.runtime.PluginRuntimeManager.WorkerEventType.CRASHED);
+            assertThat(crashed.pluginId()).isEqualTo(PROBE_ID);
+            assertThat(manager.isolatedWorkerAliveForTest("isolated-static-probe")).isTrue();
+            assertThat(manager.isolatedWorkerPidForTest("isolated-static-probe")).isEqualTo(siblingPid);
+            assertThat(manager.packagePhases().get("isolated-static-probe"))
+                    .isEqualTo(PluginRuntimePackagePhase.STARTED);
+
+            top.sywyar.pixivdownload.plugin.runtime.PluginRuntimeManager.WorkerEvent recovered =
+                    events.poll(10, TimeUnit.SECONDS);
+            assertThat(recovered).isNotNull();
+            assertThat(recovered.type()).isEqualTo(
+                    top.sywyar.pixivdownload.plugin.runtime.PluginRuntimeManager.WorkerEventType.RECOVERED);
+            assertThat(recovered.pluginId()).isEqualTo(PROBE_ID);
+            assertThat(manager.isolatedWorkerAliveForTest("isolated-static-probe")).isTrue();
+            assertThat(manager.isolatedWorkerPidForTest("isolated-static-probe")).isEqualTo(siblingPid);
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
     @DisplayName("隔离 worker 只把有界静态纯值和插件自有资源代理回宿主")
     void projectsOnlyBoundedStaticContributionsFromIsolatedWorker() throws Exception {
         Path plugins = tempDir.resolve("plugins-isolated-static");

--- a/pixivdownload-plugin-runtime/src/test/java/top/sywyar/pixivdownload/plugin/runtime/artifact/PluginRuntimeFileSecurityTest.java
+++ b/pixivdownload-plugin-runtime/src/test/java/top/sywyar/pixivdownload/plugin/runtime/artifact/PluginRuntimeFileSecurityTest.java
@@ -8,8 +8,15 @@ import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.AclFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -19,6 +26,38 @@ class PluginRuntimeFileSecurityTest {
 
     @TempDir
     Path tempDir;
+
+    @Test
+    @DisplayName("原生文件系统按 POSIX 或 ACL 能力收紧 runtime 托管目录")
+    void hardensManagedDirectoriesOnNativeFilesystem() throws Exception {
+        Path plugins = Files.createDirectory(tempDir.resolve("plugins-native"));
+        PluginRuntimeLayout layout = new PluginRuntimeLayout(plugins);
+
+        var owner = PluginRuntimeFileSecurity.secureLoadingRoots(layout);
+        Path runtime = layout.runtimeDirectory();
+        PosixFileAttributeView posix = Files.getFileAttributeView(
+                runtime, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+        if (posix != null) {
+            assertThat(posix.readAttributes().permissions()).isEqualTo(Set.of(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE));
+            return;
+        }
+
+        AclFileAttributeView acl = Files.getFileAttributeView(
+                runtime, AclFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+        if (acl != null && owner != null) {
+            assertThat(acl.getAcl()).singleElement().satisfies(entry -> {
+                assertThat(entry.type()).isEqualTo(AclEntryType.ALLOW);
+                assertThat(entry.principal().getName()).isEqualToIgnoringCase(owner.getName());
+                assertThat(entry.permissions()).contains(
+                        AclEntryPermission.READ_DATA,
+                        AclEntryPermission.WRITE_DATA,
+                        AclEntryPermission.EXECUTE);
+            });
+        }
+    }
 
     @Test
     @DisplayName("无 POSIX 权限和 ACL 的文件系统仍可创建安全托管目录")

--- a/pixivdownload-plugin-tts/pom.xml
+++ b/pixivdownload-plugin-tts/pom.xml
@@ -12,6 +12,11 @@
     <name>PixivDownloader TTS Plugin</name>
     <description>Official external TTS engine plugin.</description>
 
+    <properties>
+        <pixivdownload.proguard.skip>false</pixivdownload.proguard.skip>
+        <pixivdownload.jar.classesDirectory>${pixivdownload.proguard.outputDirectory}</pixivdownload.jar.classesDirectory>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.github.sywyar.pixivdownloader</groupId>

--- a/pixivdownload-plugin-worker/pom.xml
+++ b/pixivdownload-plugin-worker/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <java.version>17</java.version>
+        <pixivdownload.proguard.skip>false</pixivdownload.proguard.skip>
     </properties>
 
     <dependencies>
@@ -34,6 +35,26 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>proguard-worker-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classesDirectory>${pixivdownload.proguard.outputDirectory}</classesDirectory>
+                            <classifier>worker</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,13 @@
         <jacoco.version>0.8.12</jacoco.version>
         <jna.version>5.17.0</jna.version>
         <pf4j.version>3.12.0</pf4j.version>
+        <proguard.version>7.10.0</proguard.version>
+        <project.build.outputTimestamp>2000-01-01T00:00:00Z</project.build.outputTimestamp>
+        <pixivdownload.proguard.skip>true</pixivdownload.proguard.skip>
+        <pixivdownload.proguard.additionalProgramPath>${project.build.directory}/proguard/additional-program</pixivdownload.proguard.additionalProgramPath>
+        <pixivdownload.proguard.libraryExcludeArtifactIds>mybatis-spring-boot-starter</pixivdownload.proguard.libraryExcludeArtifactIds>
+        <pixivdownload.proguard.outputDirectory>${project.build.directory}/proguard/classes</pixivdownload.proguard.outputDirectory>
+        <pixivdownload.jar.classesDirectory>${project.build.outputDirectory}</pixivdownload.jar.classesDirectory>
         <!-- jacoco prepare-agent 会覆写该属性注入 agent；无 jacoco 的模块则解析为空串 -->
         <argLine></argLine>
     </properties>
@@ -156,6 +163,27 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <id>proguard-library-classpath</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>build-classpath</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${pixivdownload.proguard.skip}</skip>
+                            <includeScope>compile</includeScope>
+                            <excludeArtifactIds>${pixivdownload.proguard.libraryExcludeArtifactIds}</excludeArtifactIds>
+                            <outputProperty>pixivdownload.proguard.libraryClasspath</outputProperty>
+                            <silent>true</silent>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- JDK 23+ 默认禁用隐式注解处理（Lombok 等处理器不再经 classpath 自动发现），
                 显式声明 Lombok 处理器路径，使任意 JDK（17/21/23/26…）下 @RequiredArgsConstructor
                 等注解都能正常生成代码；未依赖 Lombok 的模块不受影响。 -->
@@ -170,6 +198,93 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <classesDirectory>${pixivdownload.jar.classesDirectory}</classesDirectory>
+                    <forceCreation>true</forceCreation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.guardsquare</groupId>
+                        <artifactId>proguard-ant</artifactId>
+                        <version>${proguard.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>proguard-release-classes</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${pixivdownload.proguard.skip}</skip>
+                            <target>
+                                <delete dir="${pixivdownload.proguard.outputDirectory}" quiet="true"/>
+                                <mkdir dir="${project.build.directory}/proguard/additional-program"/>
+                                <mkdir dir="${pixivdownload.proguard.outputDirectory}"/>
+                                <mkdir dir="${project.build.directory}/proguard/reports"/>
+                                <path id="pixivdownload.proguard.program">
+                                    <pathelement path="${pixivdownload.proguard.additionalProgramPath}"/>
+                                </path>
+                                <path id="pixivdownload.proguard.jmods">
+                                    <fileset dir="${java.home}/jmods">
+                                        <include name="*.jmod"/>
+                                    </fileset>
+                                </path>
+                                <path id="pixivdownload.proguard.libraries">
+                                    <path path="${pixivdownload.proguard.libraryClasspath}"/>
+                                </path>
+                                <java classname="proguard.ProGuard" fork="true" failonerror="true" maxmemory="2048m">
+                                    <classpath refid="maven.plugin.classpath"/>
+                                    <arg value="-include"/>
+                                    <arg file="${maven.multiModuleProjectDirectory}/build-support/proguard/base.pro"/>
+                                    <arg value="-include"/>
+                                    <arg file="${maven.multiModuleProjectDirectory}/build-support/proguard/spring.pro"/>
+                                    <arg value="-include"/>
+                                    <arg file="${maven.multiModuleProjectDirectory}/build-support/proguard/plugin.pro"/>
+                                    <arg value="-injars"/>
+                                    <arg value="${project.build.outputDirectory}(!**.jar;)"/>
+                                    <arg value="-injars"/>
+                                    <arg pathref="pixivdownload.proguard.program"/>
+                                    <arg value="-outjars"/>
+                                    <arg file="${pixivdownload.proguard.outputDirectory}"/>
+                                    <arg value="-libraryjars"/>
+                                    <arg pathref="pixivdownload.proguard.libraries"/>
+                                    <arg value="-libraryjars"/>
+                                    <arg pathref="pixivdownload.proguard.jmods"/>
+                                    <arg value="-printconfiguration"/>
+                                    <arg file="${project.build.directory}/proguard/reports/configuration.pro"/>
+                                    <arg value="-printseeds"/>
+                                    <arg file="${project.build.directory}/proguard/reports/seeds.txt"/>
+                                    <arg value="-printusage"/>
+                                    <arg file="${project.build.directory}/proguard/reports/usage.txt"/>
+                                </java>
+                                <copy todir="${pixivdownload.proguard.outputDirectory}" overwrite="true">
+                                    <fileset dir="${project.build.outputDirectory}" erroronmissingdir="false">
+                                        <include name="**/*.jar"/>
+                                    </fileset>
+                                </copy>
+                                <mkdir dir="${pixivdownload.proguard.outputDirectory}/META-INF"/>
+                                <echo file="${pixivdownload.proguard.outputDirectory}/META-INF/pixivdownload-proguard.properties"
+                                      encoding="UTF-8">formatVersion=1
+proguard.version=${proguard.version}
+shrink=true
+optimize=true
+obfuscate=false
+</echo>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <!-- Windows 中文环境下，JDK 17 的 surefire 测试 fork 默认用平台编码（GBK/cp936）写 stdout/stderr，
                 而 surefire 按 UTF-8 解码，导致测试输出的中文在控制台与 surefire-reports 中乱码。

--- a/scripts/assemble-plugin-distribution.ps1
+++ b/scripts/assemble-plugin-distribution.ps1
@@ -136,6 +136,7 @@ function Get-MavenCommand {
 
 function Assert-BootJarBoundary {
     param([string]$JarPath)
+    Assert-ProguardProcessedArtifact $JarPath
     $entries = Get-ZipEntryNames $JarPath
     $forbidden = @(
         "BOOT-INF/classes/top/sywyar/pixivdownload/ai/",
@@ -318,9 +319,9 @@ $PluginsOutDir = Join-Path $OutputDir "plugins"
 Push-Location $ProjectRoot
 try {
     if ($Build) {
-        Write-Step "Building reactor (mvn package -DskipTests)"
+        Write-Step "Building reactor release artifacts (mvn verify -DskipTests)"
         $mvn = Get-MavenCommand
-        & $mvn "package" "-DskipTests" "-Dexec.skip=true" "-Dapp.release.version=$Version"
+        & $mvn "verify" "-DskipTests" "-Dapp.release.version=$Version"
         if ($LASTEXITCODE -ne 0) { throw "Maven build failed." }
     }
 
@@ -328,7 +329,7 @@ try {
     if (-not $SelectedAppJar) {
         $appJarCandidate = Get-AppBootJar
         if (-not $appJarCandidate) {
-            throw "Could not find boot jar under pixivdownload-app/target/ (run with -Build, pass -PrebuiltJar, or 'mvn package' first)."
+            throw "Could not find boot jar under pixivdownload-app/target/ (run with -Build, pass -PrebuiltJar, or 'mvn verify' first)."
         }
         $SelectedAppJar = $appJarCandidate.FullName
         Write-Host "    Local target fallback: $SelectedAppJar" -ForegroundColor DarkGray
@@ -371,6 +372,7 @@ try {
         }
         $sourceSignaturePath = Find-PluginArtifactSignatureSidecar $sourceArtifact
         $descriptor = Assert-OfficialPluginArtifact $sourceArtifact $plugin
+        Assert-ProguardProcessedArtifact $sourceArtifact
         $pluginVersion = $descriptor["plugin.version"]
         $requires = $descriptor["plugin.requires"]
         $extension = Get-OfficialPluginArtifactExtension $plugin

--- a/scripts/ci/sdk-consumer.mjs
+++ b/scripts/ci/sdk-consumer.mjs
@@ -30,6 +30,30 @@ function thinJarEntries(pluginJar) {
     return entries;
 }
 
+export function parsePluginIdentity(propertiesText) {
+    const values = new Map();
+    for (const rawLine of propertiesText.split(/\r?\n/u)) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith('#') || line.startsWith('!')) continue;
+        const separator = line.search(/[=:]/u);
+        if (separator < 1) continue;
+        const key = line.slice(0, separator).trim();
+        if (key !== 'plugin.id' && key !== 'plugin.version') continue;
+        if (values.has(key)) fail(`plugin descriptor declares ${key} more than once`);
+        values.set(key, line.slice(separator + 1).trim());
+    }
+    const id = values.get('plugin.id');
+    const version = values.get('plugin.version');
+    if (!id || !version) fail('plugin descriptor must declare plugin.id and plugin.version');
+    return Object.freeze({ id, version });
+}
+
+function douyinPluginIdentity(repoRoot) {
+    const descriptor = path.join(
+            repoRoot, 'pixivdownload-plugin-douyin', 'src', 'main', 'resources', 'plugin.properties');
+    return parsePluginIdentity(fs.readFileSync(descriptor, 'utf8'));
+}
+
 function signatureToolJar(repoRoot) {
     const target = path.join(repoRoot, 'pixivdownload-plugin-signature', 'target');
     const candidates = fs.statSync(target, { throwIfNoEntry: false })?.isDirectory()
@@ -44,8 +68,7 @@ function signatureToolJar(repoRoot) {
 }
 
 function deriveDouyinPackages(repoRoot, work, pluginJar) {
-    const pluginId = 'douyin';
-    const pluginVersion = '1.0.0';
+    const { id: pluginId, version: pluginVersion } = douyinPluginIdentity(repoRoot);
     const packages = path.join(work, 'douyin-packages');
     const fileName = path.basename(pluginJar);
     const unsignedPluginJar = path.join(packages, 'unsigned', fileName);
@@ -281,7 +304,13 @@ export function verifyConsumer(options) {
     assertSdkResolution(localRepository, sdkRepository, identity.version);
     const pluginJar = path.join(project, 'plugin', 'target', 'example-download-plugin-0.1.0.jar');
     thinJarEntries(pluginJar);
-    const douyinPluginJar = path.join(douyinBuildDirectory, 'pixivdownload-plugin-douyin-1.0.0.jar');
+    const douyinCandidates = fs.readdirSync(douyinBuildDirectory)
+            .filter(name => /^pixivdownload-plugin-douyin-.+\.jar$/u.test(name))
+            .filter(name => !name.endsWith('-sources.jar') && !name.endsWith('-javadoc.jar'));
+    if (douyinCandidates.length !== 1) {
+        fail(`expected exactly one Douyin plugin JAR under ${douyinBuildDirectory}`);
+    }
+    const douyinPluginJar = path.join(douyinBuildDirectory, douyinCandidates[0]);
     const douyinEntries = thinJarEntries(douyinPluginJar);
     for (const required of [
         'top/sywyar/pixivdownload/douyin/DouyinPf4jPlugin.class',

--- a/scripts/ci/test/quality-gate-workflow.test.mjs
+++ b/scripts/ci/test/quality-gate-workflow.test.mjs
@@ -38,10 +38,16 @@ test('Quality Gate：五个 required context 与完整触发面保持稳定', ()
     assert.deepEqual(doc.on.push['branches-ignore'], ['gh-pages']);
     const javaSteps = doc.jobs['java-tests'].steps;
     const sdkResolve = javaSteps.find((step) => step.name === 'Resolve SDK contract predecessor');
+    const releaseBuild = javaSteps.find((step) => step.name === 'Build release artifacts with ProGuard');
+    const releaseBoundary = javaSteps.find((step) => step.name === 'Verify packaged release boundaries');
     const sdkPackage = javaSteps.find((step) => step.name === 'Package SDK contract artifacts');
     const sdkContract = javaSteps.find((step) => step.name === 'Compare SDK public contract');
     assert.equal(sdkResolve.env.INPUT_TRUSTED_BASE_SHA, '${{ inputs.trusted_base_sha }}');
     assert.match(sdkResolve.run, /resolve-trusted-base\.mjs/u);
+    assert.equal(releaseBuild.run, 'mvn -B -ntp verify -Pofficial-surveys -DskipTests');
+    assert.match(releaseBoundary.run, /DistributionPackagingBoundaryTest/u);
+    assert.match(releaseBoundary.run, /distribution\.packaging\.require-artifacts=true/u);
+    assert.match(releaseBoundary.run, /Failures: 0, Errors: 0, Skipped: 0/u);
     assert.match(sdkPackage.run, /pixivdownload-sdk-bom package -DskipTests/u);
     assert.match(sdkContract.run, /git archive "\$SDK_BASE_SHA"/u);
     assert.match(sdkContract.run, /sdk-api-surface\.mjs/u);

--- a/scripts/ci/test/sdk-consumer.test.mjs
+++ b/scripts/ci/test/sdk-consumer.test.mjs
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
-import { assertSdkResolution, stageSdkArtifacts } from '../sdk-consumer.mjs';
+import { assertSdkResolution, parsePluginIdentity, stageSdkArtifacts } from '../sdk-consumer.mjs';
 
 const VERSION = '1.0.0-rc1';
 const GROUP_PATH = path.join('io', 'github', 'sywyar', 'pixivdownloader');
@@ -25,6 +25,18 @@ function writeRepository(root) {
         }
     }
 }
+
+test('第三方验收签名身份从插件描述符读取', () => {
+    assert.deepEqual(parsePluginIdentity(`
+        # fixture
+        plugin.id=douyin
+        plugin.version=2.3.4
+        plugin.requires=1.0
+    `), { id: 'douyin', version: '2.3.4' });
+    assert.throws(() => parsePluginIdentity('plugin.id=douyin\n'), /must declare/u);
+    assert.throws(() => parsePluginIdentity(
+            'plugin.id=douyin\nplugin.id=other\nplugin.version=2.3.4\n'), /more than once/u);
+});
 
 test('隔离消费者按指定仓库字节离线验证 SDK，不依赖 Maven 来源 marker', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pixivdownload-sdk-consumer-'));

--- a/scripts/package-installer-with-plugins.ps1
+++ b/scripts/package-installer-with-plugins.ps1
@@ -129,8 +129,7 @@ try {
     $mavenArgs = @(
         "-pl", ($mavenProjects -join ","),
         "-am",
-        "package",
-        "-Dexec.skip=true",
+        "verify",
         "-Dapp.release.version=$Version"
     )
     if (-not $RunTests) {

--- a/scripts/package-local-plugin-staging.ps1
+++ b/scripts/package-local-plugin-staging.ps1
@@ -48,6 +48,9 @@ function Stage-OfficialPlugins {
             $sourceArtifact = Find-ModulePluginArtifact $plugin $ProjectRoot
         }
         $descriptor = Assert-OfficialPluginArtifact $sourceArtifact $plugin
+        if (-not $PrebuiltPluginsDir) {
+            Assert-ProguardProcessedArtifact $sourceArtifact
+        }
         $stableName = "$($plugin.Module).$extension"
         $targetArtifact = Join-Path $pluginsDir $stableName
         Copy-Item $sourceArtifact $targetArtifact -Force

--- a/scripts/package-local.ps1
+++ b/scripts/package-local.ps1
@@ -350,14 +350,16 @@ try {
             $mavenCmd = Get-MavenCommand
         }
         if ($RunTests) {
-            Invoke-External $mavenCmd @("package", "-Dapp.release.version=$Version")
+            Invoke-External $mavenCmd @("verify", "-Dapp.release.version=$Version")
         } else {
-            Invoke-External $mavenCmd @("package", "-DskipTests", "-Dapp.release.version=$Version")
+            Invoke-External $mavenCmd @("verify", "-DskipTests", "-Dapp.release.version=$Version")
         }
 
         $jar = Get-BuiltJar
         Copy-Item $jar.FullName $stagedJar -Force
     }
+
+    Assert-ProguardProcessedArtifact $stagedJar
 
     Write-Step "Building trimmed runtime image"
     Invoke-External "jlink" @(

--- a/scripts/plugin-distribution-common.ps1
+++ b/scripts/plugin-distribution-common.ps1
@@ -430,12 +430,15 @@ function Get-ZipEntryNames {
     }
 }
 
-function Read-PluginDescriptor {
-    param([Parameter(Mandatory = $true)][string]$JarPath)
+function Read-ZipProperties {
+    param(
+        [Parameter(Mandatory = $true)][string]$JarPath,
+        [Parameter(Mandatory = $true)][string]$EntryName
+    )
     Import-ZipFileAssembly
     $archive = [System.IO.Compression.ZipFile]::OpenRead($JarPath)
     try {
-        $entry = $archive.GetEntry("plugin.properties")
+        $entry = $archive.GetEntry($EntryName)
         if (-not $entry) { return $null }
         $reader = New-Object System.IO.StreamReader($entry.Open(), [System.Text.Encoding]::UTF8)
         try { $text = $reader.ReadToEnd() } finally { $reader.Dispose() }
@@ -451,6 +454,33 @@ function Read-PluginDescriptor {
         $props[$trimmed.Substring(0, $idx).Trim()] = $trimmed.Substring($idx + 1).Trim()
     }
     return $props
+}
+
+function Read-PluginDescriptor {
+    param([Parameter(Mandatory = $true)][string]$JarPath)
+    return Read-ZipProperties -JarPath $JarPath -EntryName "plugin.properties"
+}
+
+function Assert-ProguardProcessedArtifact {
+    param([Parameter(Mandatory = $true)][string]$JarPath)
+    $metadata = Read-ZipProperties -JarPath $JarPath -EntryName "META-INF/pixivdownload-proguard.properties"
+    if (-not $metadata) {
+        throw "Release artifact is missing ProGuard metadata: $JarPath"
+    }
+    $expectedMetadata = [ordered]@{
+        formatVersion = "1"
+        shrink = "true"
+        optimize = "true"
+        obfuscate = "false"
+    }
+    foreach ($expected in $expectedMetadata.GetEnumerator()) {
+        if ($metadata[$expected.Key] -ne $expected.Value) {
+            throw "Release artifact has invalid ProGuard metadata '$($expected.Key)': $JarPath"
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace([string]$metadata["proguard.version"])) {
+        throw "Release artifact ProGuard version is missing: $JarPath"
+    }
 }
 
 function Find-ModuleJar {

--- a/scripts/publish-plugin-releases.ps1
+++ b/scripts/publish-plugin-releases.ps1
@@ -12,7 +12,7 @@
       - if release exists and the artifact is present but companions are missing -> regenerate only those companions
         from the published artifact bytes;
       - if release exists without the artifact -> FAIL and require a new plugin.version;
-      - else build ONLY that module (`mvn -Pofficial-surveys -pl <module> -am package` - its dep subtree, not the whole reactor
+      - else build ONLY that module (`mvn -Pofficial-surveys -pl <module> -am verify` - its dep subtree, not the whole reactor
         nor other plugins), verify its official artifact format, then create the release and upload the artifact
         + .sha256 + .sig.
 
@@ -139,7 +139,7 @@ function Build-StagedPluginArtifact {
     Write-Host "==> Building only module $($Plugin.Module) for release $($Plugin.Id)-v$Version"
     Push-Location $ProjectRoot
     try {
-        & $mvn "-Pofficial-surveys" "-pl" $Plugin.Module "-am" "package" "-DskipTests" "-Dexec.skip=true" |
+        & $mvn "-Pofficial-surveys" "-pl" $Plugin.Module "-am" "verify" "-DskipTests" |
             ForEach-Object { Write-Host $_ }
         if ($LASTEXITCODE -ne 0) { throw "Maven build failed for module $($Plugin.Module)." }
     } finally {
@@ -148,6 +148,7 @@ function Build-StagedPluginArtifact {
 
     $builtArtifact = Find-ModulePluginArtifact $Plugin $ProjectRoot
     $descriptor = Assert-OfficialPluginArtifact $builtArtifact $Plugin
+    Assert-ProguardProcessedArtifact $builtArtifact
     $pluginVersion = $descriptor["plugin.version"]
     if ($pluginVersion -ne $Version) {
         throw "Built plugin.version '$pluginVersion' != source '$Version' for $($Plugin.Id)."

--- a/scripts/stage-official-plugin-inputs-from-catalog.ps1
+++ b/scripts/stage-official-plugin-inputs-from-catalog.ps1
@@ -14,7 +14,8 @@ param(
     [string]$ManifestUrl = "https://raw.githubusercontent.com/Sywyar/PixivDownloader-plugins/master/manifest.json",
     [string]$OutputDir,
     [Parameter(Mandatory = $true)][string]$SignatureToolJar,
-    [switch]$IncludeOptional
+    [switch]$IncludeOptional,
+    [switch]$RequireProguard
 )
 
 $ErrorActionPreference = "Stop"
@@ -251,6 +252,9 @@ try {
             $plugin.Id $version $expectedSize $sha256)
 
         $descriptor = Assert-OfficialPluginArtifact $artifactPath $plugin
+        if ($RequireProguard) {
+            Assert-ProguardProcessedArtifact $artifactPath
+        }
         if ($descriptor["plugin.version"] -ne $version) {
             throw "Catalog version '$version' does not match plugin.properties version '$($descriptor["plugin.version"])' for $($plugin.Id)."
         }

--- a/scripts/test-release-artifacts.ps1
+++ b/scripts/test-release-artifacts.ps1
@@ -1,0 +1,369 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$Version,
+    [Parameter(Mandatory = $true)][string]$JavaZipPath,
+    [Parameter(Mandatory = $true)][string]$FullOfflineZipPath,
+    [string]$InstallerPath,
+    [string]$AppImagePath,
+    [string]$WorkRoot
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$Username = "release-e2e"
+$Password = "ReleaseE2ePassword2026"
+$UninstallKeys = @(
+    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{4D4F3566-C6C0-4D24-9242-86059B2A84A5}_is1",
+    "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{4D4F3566-C6C0-4D24-9242-86059B2A84A5}_is1",
+    "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{4D4F3566-C6C0-4D24-9242-86059B2A84A5}_is1",
+    "HKCU:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{4D4F3566-C6C0-4D24-9242-86059B2A84A5}_is1"
+)
+
+function Resolve-RequiredFile {
+    param([string]$Path, [string]$Label)
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "$Label not found or not a file: $Path"
+    }
+    return (Resolve-Path -LiteralPath $Path).Path
+}
+
+function Resolve-OptionalDirectory {
+    param([string]$Path, [string]$Label)
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return ""
+    }
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        throw "$Label not found or not a directory: $Path"
+    }
+    return (Resolve-Path -LiteralPath $Path).Path
+}
+
+function New-TestSessionRoot {
+    $base = $WorkRoot
+    if ([string]::IsNullOrWhiteSpace($base)) {
+        $base = if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+            [System.IO.Path]::GetTempPath()
+        } else {
+            $env:RUNNER_TEMP
+        }
+    }
+    [System.IO.Directory]::CreateDirectory($base) | Out-Null
+    $resolvedBase = (Resolve-Path -LiteralPath $base).Path
+    $session = Join-Path $resolvedBase ("pixiv-release-e2e-" + [Guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $session | Out-Null
+    return [pscustomobject]@{ Base = $resolvedBase; Session = $session }
+}
+
+function Remove-TestSessionRoot {
+    param($Context)
+    if ($null -eq $Context -or -not (Test-Path -LiteralPath $Context.Session)) {
+        return
+    }
+    $candidate = [System.IO.Path]::GetFullPath($Context.Session)
+    if ((Split-Path -Parent $candidate) -ne [System.IO.Path]::GetFullPath($Context.Base) -or
+        (Split-Path -Leaf $candidate) -notlike "pixiv-release-e2e-*") {
+        throw "Refusing to remove unsafe test session root: $candidate"
+    }
+    Remove-Item -LiteralPath $candidate -Recurse -Force
+}
+
+function Assert-NoInstalledCopy {
+    $existing = @($UninstallKeys | Where-Object { Test-Path -LiteralPath $_ })
+    if ($existing.Count -ne 0) {
+        throw "Refusing installer E2E because PixivDownload is already registered: $($existing -join ', ')"
+    }
+}
+
+function Get-ManifestPath {
+    param([string]$Root)
+    $candidates = @(
+        (Join-Path $Root "plugins-manifest.json"),
+        (Join-Path $Root "plugins\plugins-manifest.json")
+    )
+    $found = @($candidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf })
+    if ($found.Count -ne 1) {
+        throw "Expected exactly one plugins-manifest.json under $Root, found $($found.Count)"
+    }
+    return $found[0]
+}
+
+function Read-ExpectedPluginIds {
+    param([string]$ManifestPath)
+    $manifest = @(Get-Content -LiteralPath $ManifestPath -Raw -Encoding UTF8 | ConvertFrom-Json)
+    $ids = @($manifest | ForEach-Object { $_.id })
+    if ($ids.Count -eq 0 -or $ids -contains $null -or (@($ids | Sort-Object -Unique)).Count -ne $ids.Count) {
+        throw "Invalid plugin id set in $ManifestPath"
+    }
+    return $ids
+}
+
+function Set-IsolatedRuntimeEnvironment {
+    param([string]$RuntimeRoot)
+    New-Item -ItemType Directory -Force -Path $RuntimeRoot | Out-Null
+    $normalized = $RuntimeRoot.Replace("\", "/")
+    $env:JAVA_TOOL_OPTIONS = @(
+        "-Dfile.encoding=UTF-8",
+        "-Dpixivdownload.config-dir=`"$normalized/config`"",
+        "-Dpixivdownload.state-dir=`"$normalized/state`"",
+        "-Dpixivdownload.data-dir=`"$normalized/data`"",
+        "-Dpixivdownload.instance-dir=`"$normalized/instance`""
+    ) -join " "
+    $env:NO_PROXY = "localhost,127.0.0.1"
+}
+
+function Assert-SafeArguments {
+    param([string[]]$Arguments)
+    foreach ($argument in $Arguments) {
+        if ($argument -notmatch '^[A-Za-z0-9._:=!/-]+$') {
+            throw "Unsafe release E2E launcher argument: $argument"
+        }
+    }
+}
+
+function Start-ArtifactProcess {
+    param(
+        [string]$Launcher,
+        [string]$WorkingDirectory,
+        [string[]]$Arguments,
+        [string]$LogPrefix,
+        [switch]$Wait
+    )
+    Assert-SafeArguments $Arguments
+    $stdout = "$LogPrefix.stdout.log"
+    $stderr = "$LogPrefix.stderr.log"
+    if ([System.IO.Path]::GetExtension($Launcher) -ieq ".bat") {
+        $commandLine = "/d /s /c `"`"$Launcher`" $($Arguments -join ' ')`""
+        $process = Start-Process -FilePath $env:ComSpec -ArgumentList $commandLine `
+            -WorkingDirectory $WorkingDirectory -WindowStyle Hidden -PassThru `
+            -RedirectStandardOutput $stdout -RedirectStandardError $stderr
+    } else {
+        $process = Start-Process -FilePath $Launcher -ArgumentList $Arguments `
+            -WorkingDirectory $WorkingDirectory -WindowStyle Hidden -PassThru `
+            -RedirectStandardOutput $stdout -RedirectStandardError $stderr
+    }
+    if ($Wait) {
+        Wait-ArtifactProcessExit -Process $process -Label $Launcher -TimeoutSeconds 180
+    }
+    return $process
+}
+
+function Stop-ArtifactProcess {
+    param($Process)
+    if ($null -eq $Process) {
+        return
+    }
+    $Process.Refresh()
+    if (-not $Process.HasExited) {
+        & taskkill.exe /PID $Process.Id /T /F | Out-Null
+        $Process.WaitForExit(30000) | Out-Null
+    }
+}
+
+function Wait-ArtifactProcessExit {
+    param($Process, [string]$Label, [int]$TimeoutSeconds)
+    if (-not $Process.WaitForExit($TimeoutSeconds * 1000)) {
+        Stop-ArtifactProcess $Process
+        throw "$Label did not exit within $TimeoutSeconds seconds"
+    }
+    $Process.WaitForExit()
+}
+
+function Get-FreePort {
+    $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    try {
+        $listener.Start()
+        return ([System.Net.IPEndPoint]$listener.LocalEndpoint).Port
+    } finally {
+        $listener.Stop()
+    }
+}
+
+function Wait-ForHealthyApplication {
+    param([int]$Port, $Process, [string]$Label)
+    $deadline = [DateTime]::UtcNow.AddMinutes(3)
+    do {
+        $Process.Refresh()
+        if ($Process.HasExited) {
+            throw "$Label exited before becoming healthy with code $($Process.ExitCode)"
+        }
+        try {
+            $health = Invoke-RestMethod -UseBasicParsing -Uri "http://127.0.0.1:$Port/actuator/health" `
+                -TimeoutSec 5
+            if ($health.status -eq "UP") {
+                $info = Invoke-WebRequest -UseBasicParsing -Uri "http://127.0.0.1:$Port/actuator/info" `
+                    -TimeoutSec 5
+                if ($info.StatusCode -ne 200) {
+                    throw "$Label actuator info returned HTTP $($info.StatusCode)"
+                }
+                return
+            }
+        } catch {
+            if ([DateTime]::UtcNow -ge $deadline) {
+                throw
+            }
+        }
+        Start-Sleep -Milliseconds 500
+    } while ([DateTime]::UtcNow -lt $deadline)
+    throw "$Label did not become healthy within three minutes"
+}
+
+function Assert-PluginRuntimeStatus {
+    param([int]$Port, [string[]]$ExpectedPluginIds, [string]$Label)
+    $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+    $body = @{ username = $Username; password = $Password; rememberMe = $false } | ConvertTo-Json -Compress
+    $login = Invoke-RestMethod -UseBasicParsing -Method Post -Uri "http://127.0.0.1:$Port/api/auth/login" `
+        -ContentType "application/json" -Body $body -WebSession $session -TimeoutSec 10
+    if (-not $login.ok) {
+        throw "$Label login did not return ok=true"
+    }
+    $status = Invoke-RestMethod -UseBasicParsing -Uri "http://127.0.0.1:$Port/api/plugins/status" `
+        -WebSession $session -TimeoutSec 15
+    if ($status.recoveryMode) {
+        throw "$Label entered plugin recovery mode"
+    }
+    foreach ($pluginId in $ExpectedPluginIds) {
+        $matches = @($status.plugins | Where-Object { $_.id -eq $pluginId })
+        if ($matches.Count -ne 1) {
+            throw "$Label expected one status row for $pluginId, found $($matches.Count)"
+        }
+        if ($matches[0].status -ne "STARTED" -or $matches[0].runtimePhase -ne "STARTED") {
+            throw "$Label plugin $pluginId is not fully started: status=$($matches[0].status), phase=$($matches[0].runtimePhase)"
+        }
+    }
+}
+
+function Test-ApplicationLayout {
+    param([string]$Label, [string]$Root, [string]$Launcher, [string]$RuntimeRoot, [string]$LogRoot)
+    $manifestPath = Get-ManifestPath $Root
+    $expectedPluginIds = @(Read-ExpectedPluginIds $manifestPath)
+    Set-IsolatedRuntimeEnvironment $RuntimeRoot
+    $setup = Start-ArtifactProcess -Launcher $Launcher -WorkingDirectory $Root -Arguments @(
+        "--setup",
+        "--username=$Username",
+        "--password=$Password",
+        "--mode=solo",
+        "--proxy-enabled=false"
+    ) -LogPrefix "$LogRoot-setup" -Wait
+    if ($setup.ExitCode -ne 0) {
+        throw "$Label setup failed with exit code $($setup.ExitCode)"
+    }
+
+    $port = Get-FreePort
+    $application = $null
+    try {
+        $application = Start-ArtifactProcess -Launcher $Launcher -WorkingDirectory $Root -Arguments @(
+            "--no-gui",
+            "--server.address=127.0.0.1",
+            "--server.port=$port"
+        ) -LogPrefix "$LogRoot-application"
+        Wait-ForHealthyApplication -Port $port -Process $application -Label $Label
+        Assert-PluginRuntimeStatus -Port $port -ExpectedPluginIds $expectedPluginIds -Label $Label
+        Write-Host "PASS: $Label ($($expectedPluginIds.Count) external plugin(s))" -ForegroundColor Green
+    } finally {
+        Stop-ArtifactProcess $application
+    }
+}
+
+function Test-JavaArchive {
+    param([string]$Label, [string]$Archive, [string]$Destination)
+    Expand-Archive -LiteralPath $Archive -DestinationPath $Destination
+    $launcher = Join-Path $Destination "run.bat"
+    $jar = Join-Path $Destination "PixivDownload-$Version.jar"
+    if (-not (Test-Path -LiteralPath $launcher -PathType Leaf) -or
+        -not (Test-Path -LiteralPath $jar -PathType Leaf)) {
+        throw "$Label does not contain run.bat and the exact versioned application JAR"
+    }
+    Test-ApplicationLayout -Label $Label -Root $Destination -Launcher $launcher `
+        -RuntimeRoot (Join-Path $Destination ".e2e-runtime") -LogRoot (Join-Path $Destination "e2e")
+}
+
+function Assert-PackagedRuntime {
+    param([string]$Root, [string]$Label)
+    $launcher = Join-Path $Root "PixivDownload.exe"
+    $jvm = Join-Path $Root "runtime\bin\server\jvm.dll"
+    if (-not (Test-Path -LiteralPath $launcher -PathType Leaf) -or
+        -not (Test-Path -LiteralPath $jvm -PathType Leaf)) {
+        throw "$Label does not contain PixivDownload.exe and its packaged JVM"
+    }
+    return $launcher
+}
+
+$resolvedJavaZip = Resolve-RequiredFile $JavaZipPath "Java distribution"
+$resolvedFullOfflineZip = Resolve-RequiredFile $FullOfflineZipPath "Full-offline distribution"
+$resolvedInstaller = if ([string]::IsNullOrWhiteSpace($InstallerPath)) {
+    ""
+} else {
+    Resolve-RequiredFile $InstallerPath "Windows installer"
+}
+$resolvedAppImage = Resolve-OptionalDirectory $AppImagePath "Windows app image"
+if ([string]::IsNullOrWhiteSpace($resolvedInstaller) -and [string]::IsNullOrWhiteSpace($resolvedAppImage)) {
+    throw "Specify InstallerPath or AppImagePath so the packaged JVM is exercised."
+}
+
+$oldJavaToolOptions = $env:JAVA_TOOL_OPTIONS
+$oldNoProxy = $env:NO_PROXY
+$context = $null
+$uninstaller = ""
+try {
+    $context = New-TestSessionRoot
+    Test-JavaArchive -Label "java-standard" -Archive $resolvedJavaZip `
+        -Destination (Join-Path $context.Session "java-standard")
+    Test-JavaArchive -Label "full-offline" -Archive $resolvedFullOfflineZip `
+        -Destination (Join-Path $context.Session "full-offline")
+
+    if (-not [string]::IsNullOrWhiteSpace($resolvedAppImage)) {
+        $launcher = Assert-PackagedRuntime $resolvedAppImage "Windows app image"
+        Test-ApplicationLayout -Label "windows-app-image" -Root $resolvedAppImage -Launcher $launcher `
+            -RuntimeRoot (Join-Path $context.Session "app-image-runtime") `
+            -LogRoot (Join-Path $context.Session "app-image")
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($resolvedInstaller)) {
+        Assert-NoInstalledCopy
+        $installDir = Join-Path $context.Session "installed"
+        $uninstaller = Join-Path $installDir "unins000.exe"
+        $installer = Start-Process -FilePath $resolvedInstaller -ArgumentList @(
+            "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/SP-", "/NOICONS", "/LANG=en",
+            "/DIR=`"$installDir`""
+        ) -WindowStyle Hidden -PassThru
+        Wait-ArtifactProcessExit -Process $installer -Label "Windows installer" -TimeoutSeconds 600
+        if ($installer.ExitCode -ne 0) {
+            throw "Windows installer failed with exit code $($installer.ExitCode)"
+        }
+        $launcher = Assert-PackagedRuntime $installDir "Installed application"
+        if (-not (Test-Path -LiteralPath $uninstaller -PathType Leaf)) {
+            throw "Installed application does not contain unins000.exe"
+        }
+        Test-ApplicationLayout -Label "windows-installer" -Root $installDir -Launcher $launcher `
+            -RuntimeRoot (Join-Path $context.Session "installer-runtime") `
+            -LogRoot (Join-Path $context.Session "installer")
+    }
+} finally {
+    $uninstallFailure = ""
+    if (-not [string]::IsNullOrWhiteSpace($uninstaller) -and
+        (Test-Path -LiteralPath $uninstaller -PathType Leaf)) {
+        try {
+            $uninstall = Start-Process -FilePath $uninstaller -ArgumentList @(
+                "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART"
+            ) -WindowStyle Hidden -PassThru
+            Wait-ArtifactProcessExit -Process $uninstall -Label "Windows uninstaller" -TimeoutSeconds 300
+            if ($uninstall.ExitCode -ne 0) {
+                $uninstallFailure = "Windows uninstaller exited with code $($uninstall.ExitCode)"
+            }
+        } catch {
+            $uninstallFailure = "Windows uninstaller failed: $($_.Exception.Message)"
+        }
+    }
+    $env:JAVA_TOOL_OPTIONS = $oldJavaToolOptions
+    $env:NO_PROXY = $oldNoProxy
+    Remove-TestSessionRoot $context
+    if (-not [string]::IsNullOrWhiteSpace($uninstallFailure)) {
+        throw $uninstallFailure
+    }
+}
+
+if (-not [string]::IsNullOrWhiteSpace($resolvedInstaller)) {
+    Assert-NoInstalledCopy
+}
+Write-Host "All requested release artifacts passed runtime acceptance." -ForegroundColor Green


### PR DESCRIPTION
## 变更内容

- 对应用、内部 worker 和面向用户发行的官方插件统一接入 ProGuard shrinking 与 optimizing，并保持 obfuscation 关闭；Compose GUI 由现有 Gradle artifact producer 处理插件代码及其私有运行库。
- 让 Maven、Gradle、本地打包、插件发布、Release 和 Nightly 共同消费带处理标记的最终产物，避免不同入口回退到未处理 classes 或旧 artifact。
- 在 Release 与 Nightly 发布附件前增加 Windows 最终发行物验收，覆盖 Java 标准包、full-offline 包和安装器的启动、登录、插件状态与恢复模式。
- 测试产物身份改为从实际插件描述符派生，并补强声明式 worker 的恢复观测及运行目录边界；未提升任何插件版本。

## 验证

- [x] 完整 Maven 测试与官方插件 `verify` 构建通过
- [x] 最终产物边界测试 19 项通过且无跳过
- [x] JavaScript 测试 276 项通过
- [x] Compose 在 Maven 与两次强制 Gradle 构建中得到一致 SHA-256
- [x] 当前 Windows app-image 使用 packaged JRE 启动，并通过健康、登录、插件状态与非恢复模式检查
- [x] pre-push i18n、签名守卫、Gate 5 与 gate contract 通过；远端 Ruleset 实时审计通过
- [x] 当前 PR merge candidate 的 required checks 全部通过
- [ ] 正式签名 ZIP 与 installer 的 Windows E2E（由后续 Release/Nightly 在上传发行附件前执行）
- [x] 已判断无需更新 CHANGELOG

## 关联

无关联 Issue。
