### PR TITLE
refactor(release): 收束 PR 准入与执行证据核对

### DIFF
--- a/.github/workflows/gate-checks.yml
+++ b/.github/workflows/gate-checks.yml
@@ -12,8 +12,9 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: gate-checks-${{ github.event.workflow_run.id || github.sha }}
+  group: gate-checks-${{ github.event.workflow_run.head_sha || github.sha }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   protected-base:

--- a/scripts/ci/gate-admission/release-gate-trust.mjs
+++ b/scripts/ci/gate-admission/release-gate-trust.mjs
@@ -110,8 +110,8 @@ function adopt(root, ref) {
         fail('adoption requires the Epoch 5 anchor, protected master tip, HEAD and Epoch 8 root');
     }
     const parents = git(root, ['rev-list', '--parents', '-n', '1', candidate]).split(/\s+/u).slice(1);
-    if (parents.length !== 2 || parents[0] !== source || parents[1] !== rootTag) {
-        fail('Epoch 8 adoption requires the exact root merge from the Epoch 5 anchor');
+    if (parents.length !== 2 || parents[0] !== source || !ancestor(root, rootTag, parents[1])) {
+        fail('Epoch 8 adoption requires a merge of the sealed core from the Epoch 5 anchor');
     }
     const files = JSON.parse(git(root, ['show', `${source}:${POLICY}`])).protectedCore;
     const oldCore = materialize(root, source, files, true);

--- a/scripts/ci/gate-admission/release-gate-verifier.mjs
+++ b/scripts/ci/gate-admission/release-gate-verifier.mjs
@@ -15,7 +15,6 @@ const REPOSITORY_ID = 1089943605;
 const APP_ID = 4837005;
 const PR_WORKFLOW = '.github/workflows/pr-quality-gate.yml';
 const CHECK_WORKFLOW = '.github/workflows/gate-checks.yml';
-const PR_EDIT_CONDITION = "github.event.action != 'edited' || github.event.changes.base != null";
 const QUALITY_USE = `${REPOSITORY}/.github/workflows/quality-gate.yml@master`;
 const BRANCH = 'refs/heads/master';
 const CORE = [
@@ -118,6 +117,7 @@ function validateRootPolicy(policy) {
         fail('Ruleset required check declarations are invalid or duplicated');
     }
     requireSubset(FLOOR.checks, contexts, 'Ruleset checks');
+    requireSubset(contexts, policy.qualityGate.requiredJobs, 'required check execution roles');
     for (const context of contexts) {
         if (rules.requiredCheckSources?.[context] !== APP_ID) {
             fail(`required check ${context} must be bound to the Gate App`);
@@ -250,14 +250,9 @@ function validateActionPins(rel, doc) {
 }
 
 function validateQualityJobs(policy, doc) {
-    for (const [id, job] of Object.entries(doc.jobs)) {
-        if (job.uses || job.strategy !== undefined || job.if !== undefined) {
-            fail(`Quality Gate job ${id} must execute directly and unconditionally for execution evidence`);
-        }
-    }
     for (const id of policy.qualityGate.requiredJobs) {
         const job = doc.jobs[id];
-        if (!job || job.if !== undefined || job.strategy !== undefined
+        if (!job || job.uses || job.if !== undefined || job.strategy !== undefined
             || (job.name !== undefined && job.name !== id)) {
             fail(`Quality Gate role ${id} must be unconditional and have a stable check identity`);
         }
@@ -267,18 +262,11 @@ function validateQualityJobs(policy, doc) {
 export function validatePullRequestCaller(doc) {
     if (!doc || doc.name !== 'Pull Request Quality Gate'
         || !same(triggers(doc), ['pull_request'])) fail('PR caller must use pull_request');
-    const event = doc.on.pull_request;
-    if (!same(event?.branches, ['master'])
-        || Object.keys(event).some((key) => !['branches', 'types'].includes(key))) {
-        fail('PR caller must cover all master PR paths');
-    }
+    const event = doc.on.pull_request || {};
     requireSubset(['opened', 'reopened', 'synchronize', 'edited'], event.types || [], 'PR events');
-    if ((event.types || []).some((type) => !['opened', 'reopened', 'synchronize',
-        'edited', 'ready_for_review'].includes(type))) fail('unsupported PR caller event');
     if (!same(Object.keys(doc.jobs), ['quality-gate'])) fail('PR caller must only invoke Quality Gate');
     const call = doc.jobs['quality-gate'];
-    if (call.uses !== QUALITY_USE || Object.keys(call).some((key) => !['uses', 'if'].includes(key))
-        || String(call.if).replace(/^\$\{\{\s*|\s*\}\}$/gu, '').trim() !== PR_EDIT_CONDITION) {
+    if (call.uses !== QUALITY_USE || Object.keys(call).some((key) => !['uses', 'if'].includes(key))) {
         fail('PR caller must invoke the protected Quality Gate without candidate inputs or steps');
     }
     if (!same(doc.permissions, { contents: 'read' }) || containsSecret(doc)) {
@@ -289,8 +277,8 @@ export function validatePullRequestCaller(doc) {
 function validateCheckPublisher(doc) {
     if (!doc || doc.name !== 'Gate Checks') fail('missing protected check publisher');
     if (triggers(doc).some((event) => !['workflow_run', 'push'].includes(event))
-        || !same(doc.on.workflow_run?.workflows, ['Pull Request Quality Gate', 'Quality Gate'])
-        || !same(doc.on.workflow_run?.types, ['in_progress', 'completed'])
+        || !same([...(doc.on.workflow_run?.workflows || [])].sort(), ['Pull Request Quality Gate', 'Quality Gate'])
+        || !same([...(doc.on.workflow_run?.types || [])].sort(), ['completed', 'in_progress'])
         || !same(doc.on.push?.branches, ['master'])) {
         fail('check credentials are restricted to protected workflow completion and master push');
     }
@@ -341,7 +329,8 @@ function workflowSecurityProblems(rel, doc, policy, providerPaths) {
         const provider = roots.has(id);
         const sensitive = permissionsWrite(job.permissions === undefined ? doc.permissions : job.permissions)
             || containsSecret(doc.env) || containsSecret(job) || environmentName(job) !== undefined;
-        const required = rel === policy.qualityGate.workflow || provider;
+        const required = provider || (rel === policy.qualityGate.workflow
+            && policy.qualityGate.requiredJobs.some((role) => dependsOn(jobs, role, new Set([id]))));
         if ((required || sensitive) && (/\b(?:always|failure|cancelled)\s*\(/iu.test(condition)
             || [job, ...(job.steps || [])].some((step) => step['continue-on-error'] !== undefined
                 && step['continue-on-error'] !== false))) {
@@ -394,8 +383,15 @@ function validateWorkflows(repo, ref, policy) {
         changed = false;
         for (const [rel, doc] of docs) {
             if (providerPaths.has(rel) || !triggers(doc).includes('workflow_call')) continue;
-            const hasProvider = Object.values(doc.jobs)
-                .some((job) => providerPaths.has(localWorkflow(job.uses)));
+            // 可复用 workflow 整体成功必须意味着 QG 已执行成功；仅包含一个可跳过的调用不够。
+            const unconditional = (id, seen = new Set()) => {
+                const job = doc.jobs[id];
+                if (!job || seen.has(id) || job.if !== undefined
+                    || (job.uses && !providerPaths.has(localWorkflow(job.uses)))) return false;
+                return needs(job).every((dep) => unconditional(dep, new Set([...seen, id])));
+            };
+            const hasProvider = Object.entries(doc.jobs)
+                .some(([id, job]) => providerPaths.has(localWorkflow(job.uses)) && unconditional(id));
             if (hasProvider && workflowSecurityProblems(rel, doc, policy, providerPaths).length === 0) {
                 providerPaths.add(rel);
                 changed = true;
@@ -453,10 +449,17 @@ function validateAdmission(repo, trusted, candidate, localFeedback) {
     }
     const root = resolveCommit(repo, ROOT_TAG, 'Epoch 8 root');
     const parents = (sha) => git(repo, ['rev-list', '--parents', '-n', '1', sha]).trim().split(/\s+/u).slice(1);
-    if (!same(parents(root), [trusted])) fail('Epoch 8 root must directly descend from its admission base');
-    if (candidate !== root && (!same(parents(candidate), [trusted, root])
-        || git(repo, ['rev-parse', `${candidate}^{tree}`]) !== git(repo, ['rev-parse', `${root}^{tree}`]))) {
-        fail('first admission is restricted to the exact root or its unchanged two-parent merge');
+    const rootParents = parents(root);
+    if (rootParents.length !== 1 || !ancestor(rootParents[0], trusted)
+        || json(repo, rootParents[0], POLICY).gateEpoch !== 5) {
+        fail('Epoch 8 root must directly descend from a protected Epoch 5 admission base');
+    }
+    validateCore(repo, root, candidate);
+    validateMonotonic(json(repo, root, POLICY), next);
+    const candidateParents = parents(candidate);
+    if (candidate !== root && (candidateParents.length !== 2 || candidateParents[0] !== trusted
+        || !ancestor(root, candidateParents[1]))) {
+        fail('first admission requires the root or a two-parent merge of its unchanged core descendants');
     }
 }
 
@@ -553,9 +556,9 @@ export function verifyRunIdentity({ run, merge, caller, protectedBase, proof }) 
     }
     const use = caller.jobs['quality-gate'].uses;
     const sources = run.referenced_workflows;
-    if (!Array.isArray(sources) || sources.length !== 1
-        || sources[0].path !== use || sources[0].sha !== protectedBase
-        || sources[0].ref !== 'refs/heads/master'
+    const qualitySources = (sources || []).filter((source) => source.path === use);
+    if (!Array.isArray(sources) || qualitySources.length !== 1
+        || qualitySources[0].sha !== protectedBase || qualitySources[0].ref !== 'refs/heads/master'
         || proof.runId !== String(run.id) || Number(proof.attempt) > run.run_attempt) {
         fail('Quality Gate execution did not use the tested protected base');
     }
@@ -568,22 +571,23 @@ export function verifyRunResults({ run, jobs, requiredJobs = FLOOR.checks, expec
     if (run.status !== 'completed' || run.conclusion !== 'success') {
         fail('Quality Gate run has not completed successfully');
     }
-    if (!Array.isArray(jobs) || jobs.length !== expectedJobs.length) {
-        fail('effective jobs do not exactly match the protected workflow');
+    if (!Array.isArray(jobs)) {
+        fail('missing effective jobs');
     }
     const ids = new Set();
     for (const job of jobs) {
         if (!Number.isSafeInteger(job.id) || job.id <= 0 || ids.has(job.id)
             || job.run_id !== run.id || job.head_sha !== run.head_sha
-            || job.status !== 'completed' || job.conclusion !== 'success') {
-            fail('job results are duplicated, foreign, missing, skipped or unsuccessful');
+            || job.status !== 'completed' || !job.name?.startsWith(jobPrefix)) {
+            fail('job results are duplicated, foreign or incomplete');
         }
         ids.add(job.id);
     }
     requireSubset(requiredJobs, expectedJobs, 'protected Quality Gate roles');
-    for (const role of expectedJobs) {
+    for (const role of requiredJobs) {
         const matches = jobs.filter((job) => job.name === `${jobPrefix}${role}`);
         if (matches.length !== 1) fail(`missing or ambiguous effective result for ${role}`);
+        if (matches[0].conclusion !== 'success') fail(`required role ${role} is skipped or unsuccessful`);
     }
 }
 

--- a/scripts/ci/gate-admission/resolve-trusted-base.mjs
+++ b/scripts/ci/gate-admission/resolve-trusted-base.mjs
@@ -21,15 +21,17 @@ export function resolveTrustedBase({ repo = '.', candidate, event, before, ref,
     };
     const tested = commit(candidate);
     const master = commit('refs/remotes/origin/master');
-    const protectedPredecessor = tested === master
-        ? commit(tested + '^1') : git(repo, ['merge-base', tested, master]);
+    const onMaster = git(repo, ['merge-base', tested, master]) === tested;
+    let protectedPredecessor = onMaster ? commit(tested + '^1') : git(repo, ['merge-base', tested, master]);
     let proposed = inputBase;
     if (event === 'pull_request') {
-        proposed = prBase;
         const parents = git(repo, ['rev-list', '--parents', '-n', '1', tested]).split(/\s+/u).slice(1);
         if (parents.length !== 2 || parents[0] !== commit(prBase) || parents[1] !== commit(prHead)) {
             throw new Error('PR candidate must have the event base and head as its two parents');
         }
+        // 开发分支是合并候选的父提交；只有它与 master 的共同历史能提供可信核心。
+        protectedPredecessor = git(repo, ['merge-base', commit(prBase), master]);
+        proposed = protectedPredecessor;
     } else if (!proposed && event === 'push' && ref === 'refs/heads/master') {
         proposed = before;
     } else if (!proposed && event === 'merge_group') {

--- a/scripts/ci/gate-checks.mjs
+++ b/scripts/ci/gate-checks.mjs
@@ -50,6 +50,8 @@ export function completePages(pages, key) {
         page.total_count !== expected || !Array.isArray(page[key]))) fail('inconsistent API pagination');
     const rows = pages.flatMap((page) => page[key]);
     if (rows.length !== expected) fail('incomplete API pagination');
+    const ids = rows.filter((row) => row?.id !== undefined).map((row) => row.id);
+    if (new Set(ids).size !== ids.length) fail('duplicated API pagination');
     return rows;
 }
 
@@ -62,33 +64,35 @@ function assertRun(run) {
 
 function expectedJobs(repo, ref) {
     const source = YAML.parse(git(repo, ['show', `${sha(ref)}:${QUALITY}`]));
-    return Object.entries(source.jobs).map(([id, job]) => {
-        if (job.uses || job.strategy || job.if !== undefined) fail('protected jobs must execute directly and unconditionally');
-        return job.name || id;
-    });
+    return Object.entries(source.jobs).filter(([, job]) => !job.uses && !job.strategy && job.if === undefined)
+        .map(([id, job]) => job.name || id);
 }
 
 export async function inspectRun({ repo, runId, api = github, core }) {
     const run = api(`${PREFIX}/actions/runs/${integer(runId)}`);
     assertRun(run);
+    if (run.id !== Number(runId)) fail('workflow response does not match the requested run');
     const jobs = completePages(api(`${PREFIX}/actions/runs/${run.id}/jobs?filter=latest&per_page=100`,
         { pages: true }), 'jobs');
     const contract = jobs.filter((job) => job.name === 'quality-gate / trusted-gate-contract');
     if (contract.length !== 1) fail('missing or ambiguous protected contract job');
     const proof = core.parseExecutionProof(api(`${PREFIX}/actions/jobs/${integer(contract[0].id)}/logs`, { raw: true }));
+    if (pullRequestNumber(run) !== Number(proof.pullRequest)) fail('run PR association differs from its execution proof');
     git(repo, ['fetch', '--no-tags', 'origin', sha(proof.merge)]);
     const read = (ref, rel) => git(repo, ['show', `${ref}:${rel}`]);
     const merge = api(`${PREFIX}/git/commits/${sha(proof.merge)}`);
     const caller = YAML.parse(read(proof.merge, CALLER));
-    core.verifyRunResults({ run, jobs, expectedJobs: expectedJobs(repo, proof.base) });
     const evidence = core.verifyRunIdentity({ run, merge, caller, proof, protectedBase: proof.base });
     const policy = core.verifyCandidate({ repo, trusted: proof.base, candidate: proof.merge });
+    core.verifyRunResults({ run, jobs, requiredJobs: policy.qualityGate.requiredJobs,
+        expectedJobs: expectedJobs(repo, proof.base) });
     verifyAttempts(run, jobs, api, contract[0].id, Number(proof.attempt));
     return { ...evidence, pullRequest: integer(proof.pullRequest), checks: policy.ruleset.requiredChecks,
         status: 'completed', conclusion: 'success' };
 }
 
 export function verifyAttempts(run, jobs, api, proofJob, proofAttempt) {
+    jobs = jobs.filter((job) => job.conclusion === 'success');
     // GitHub 会给复用的 job 分配新 ID；用原生执行时间与步骤记录追溯实际来源。
     const execution = (job) => {
         if (!Number.isFinite(Date.parse(job.started_at)) || !Number.isFinite(Date.parse(job.completed_at))
@@ -113,7 +117,8 @@ export function verifyAttempts(run, jobs, api, proofJob, proofAttempt) {
             return matches.length === 1;
         });
         if (!retained.length) continue;
-        const sources = (value) => (value.referenced_workflows || []).map(({ path, sha, ref }) => ({ path, sha, ref }));
+        const sources = (value) => (value.referenced_workflows || [])
+            .map(({ path, sha, ref }) => JSON.stringify([path, sha, ref])).sort();
         if (current.head_sha !== run.head_sha || current.id !== run.id || current.run_attempt !== attempt
             || current.event !== run.event || current.path !== run.path
             || JSON.stringify(sources(current)) !== JSON.stringify(sources(run))) {
@@ -135,32 +140,42 @@ export function inspectFullRun({ repo, runId, candidate, api = github, core }) {
     const run = api(`${PREFIX}/actions/runs/${integer(runId)}`);
     integer(run.run_attempt);
     if (run.id !== Number(runId) || run.repository?.id !== REPO_ID || run.repository?.full_name !== REPO
-        || run.event !== 'workflow_dispatch' || run.head_branch !== 'master' || run.head_sha !== sha(candidate)
-        || run.path?.split('@')[0] !== QUALITY || run.name !== 'Quality Gate'
-        || run.referenced_workflows?.length) fail('full verification must execute Quality Gate on the same protected master commit');
+        || run.event !== 'workflow_dispatch' || run.head_sha !== sha(candidate)
+        || run.path?.split('@')[0] !== QUALITY || run.name !== 'Quality Gate') {
+        fail('full verification must execute Quality Gate on the same protected master commit');
+    }
     const runs = completePages(api(`${PREFIX}/actions/workflows/quality-gate.yml/runs?event=workflow_dispatch&head_sha=${candidate}&per_page=100`,
-        { pages: true }), 'workflow_runs').filter((entry) => entry.head_branch === 'master');
+        { pages: true }), 'workflow_runs');
     if (!runs.length || Math.max(...runs.map((entry) => integer(entry.id))) !== run.id) fail('newer full verification superseded this run');
     git(repo, ['fetch', '--no-tags', 'origin', candidate]);
-    git(repo, ['merge-base', '--is-ancestor', candidate, 'refs/remotes/origin/master']);
+    if (git(repo, ['merge-base', candidate, 'refs/remotes/origin/master']) !== candidate) {
+        return { ignored: true, reason: 'full Quality Gate candidate is not in protected master history', runId: run.id };
+    }
     const parent = git(repo, ['rev-parse', `${candidate}^1`]);
-    core.verifyCandidate({ repo, trusted: parent, candidate });
+    const policy = core.verifyCandidate({ repo, trusted: parent, candidate });
     const jobs = completePages(api(`${PREFIX}/actions/runs/${run.id}/jobs?filter=latest&per_page=100`,
         { pages: true }), 'jobs');
-    core.verifyRunResults({ run, jobs, expectedJobs: expectedJobs(repo, candidate), jobPrefix: '' });
+    core.verifyRunResults({ run, jobs, requiredJobs: policy.qualityGate.requiredJobs,
+        expectedJobs: expectedJobs(repo, candidate), jobPrefix: '' });
     verifyAttempts(run, jobs, api);
     return { integrated: candidate, runId: run.id, attempt: run.run_attempt, verification: 'same-commit-full-quality-gate' };
 }
 
+function pullRequestNumber(run) {
+    // fork 的原生关联可能为空；run-name 携带既有 PR 编号，只用于路由，成功仍须执行证明。
+    const named = /^PR #([1-9][0-9]*)(?:\s|$)/u.exec(run.display_title || '');
+    const numbers = [...new Set((run.pull_requests || []).map((pr) => integer(pr.number)))];
+    if (named) return !numbers.length || numbers.includes(integer(named[1])) ? integer(named[1]) : undefined;
+    return numbers.length === 1 ? numbers[0] : undefined;
+}
+
 function openPullRequest(run, api) {
-    const numbers = run.pull_requests?.map((pr) => pr.number) || [];
-    const candidates = numbers.length
-        ? numbers.map((number) => api(`${PREFIX}/pulls/${integer(number)}`))
-        : api(`${PREFIX}/commits/${sha(run.head_sha)}/pulls?per_page=100`, { pages: true }).flat();
-    const matches = candidates.filter((pr) => pr.state === 'open' && pr.base?.ref === 'master'
-        && pr.base?.repo?.id === REPO_ID && pr.head?.sha === run.head_sha);
-    if (matches.length !== 1) fail('run does not identify one current master PR');
-    return matches[0];
+    const number = pullRequestNumber(run);
+    if (!number) fail('PR execution must identify its PR through run-name or native metadata');
+    const pr = api(`${PREFIX}/pulls/${number}`);
+    return pr.state === 'open' && pr.base?.ref === 'master'
+        && pr.base?.repo?.id === REPO_ID && pr.head?.sha === run.head_sha
+        && pr.head?.repo?.id === run.head_repository?.id && pr.head?.ref === run.head_branch ? pr : undefined;
 }
 
 function skippedCaller(run, api) {
@@ -176,13 +191,16 @@ function latestExecution(runs, api) {
     return runs.sort((a, b) => integer(b.id) - integer(a.id)).find((run) => !skippedCaller(run, api));
 }
 
-function assertLatestPullRequestRun(run, number, api) {
+function latestPullRequestRun(run, number, api) {
     const runs = completePages(api(`${PREFIX}/actions/workflows/pr-quality-gate.yml/runs?event=pull_request&head_sha=${sha(run.head_sha)}&per_page=100`,
         { pages: true }), 'workflow_runs');
-    const matching = runs.filter((entry) => entry.pull_requests?.some((pr) => pr.number === number)
-        || (!entry.pull_requests?.length && entry.head_branch === run.head_branch
-            && entry.head_repository?.id === run.head_repository?.id));
-    if (latestExecution(matching, api)?.id !== run.id) {
+    const matching = runs.filter((entry) => pullRequestNumber(entry) === number
+        && entry.head_branch === run.head_branch && entry.head_repository?.id === run.head_repository?.id);
+    return latestExecution(matching, api);
+}
+
+function assertLatestPullRequestRun(run, number, api) {
+    if (latestPullRequestRun(run, number, api)?.id !== run.id) {
         fail('a newer PR execution superseded this run');
     }
 }
@@ -190,14 +208,18 @@ function assertLatestPullRequestRun(run, number, api) {
 export async function checkEvent({ repo, event, eventName, core, api = github }) {
     const ownPolicy = JSON.parse(fs.readFileSync(path.join(repo, 'scripts/ci/release-gate-policy.json'), 'utf8'));
     if (eventName === 'workflow_run') {
-        const run = api(`${PREFIX}/actions/runs/${integer(event.workflow_run?.id)}`);
+        let run = api(`${PREFIX}/actions/runs/${integer(event.workflow_run?.id)}`);
         if (run.event === 'workflow_dispatch') {
             return inspectFullRun({ repo, runId: run.id, candidate: run.head_sha, api, core });
         }
         assertRun(run);
-        if (skippedCaller(run, api)) return { ignored: true, reason: 'PR caller did not start a quality execution', runId: run.id };
         const pr = openPullRequest(run, api);
-        assertLatestPullRequestRun(run, pr.number, api);
+        if (!pr) return { ignored: true, reason: 'no current master PR for this execution', runId: run.id };
+        // 同一 head 的发布由原生 concurrency 串行化；迟到事件也核对最新运行，避免覆盖新结果。
+        const latest = latestPullRequestRun(run, pr.number, api);
+        if (!latest) return { ignored: true, reason: 'no quality execution for the current PR', runId: run.id };
+        run = api(`${PREFIX}/actions/runs/${integer(latest.id)}`);
+        assertRun(run);
         if (run.status !== 'completed' || run.conclusion !== 'success') {
             return { merge: sha(pr.merge_commit_sha), head: sha(pr.head.sha), base: sha(pr.base.sha),
                 pullRequest: integer(pr.number), runId: run.id, attempt: run.run_attempt,
@@ -220,21 +242,30 @@ export async function checkEvent({ repo, event, eventName, core, api = github })
     }
     try {
     const head = sha(integrated.parents[1].sha);
+    const pulls = api(`${PREFIX}/commits/${integrated.sha}/pulls?per_page=100`, { pages: true }).flat();
+    const merged = pulls.filter((pr) => pr.merged_at && pr.merge_commit_sha === integrated.sha
+        && pr.base?.ref === 'master' && pr.base?.repo?.id === REPO_ID && pr.head?.sha === head);
+    if (merged.length !== 1) fail('integrated commit does not identify one merged master PR');
+    const pr = merged[0];
     const runs = completePages(api(`${PREFIX}/actions/workflows/pr-quality-gate.yml/runs?event=pull_request&head_sha=${head}&per_page=100`,
         { pages: true }), 'workflow_runs').sort((a, b) => b.id - a.id);
-    const selected = latestExecution(runs, api);
+    const selected = latestExecution(runs.filter((run) => pullRequestNumber(run) === pr.number
+        && run.head_repository?.id === pr.head?.repo?.id && run.head_branch === pr.head?.ref), api);
     if (!selected) fail('no PR execution for the integrated head');
     const evidence = await inspectRun({ repo, runId: selected.id, api, core });
     core.verifyIntegratedTree(evidence, integrated);
     const checks = completePages(api(`${PREFIX}/commits/${evidence.merge}/check-runs?filter=latest&per_page=100`,
         { pages: true }), 'check_runs');
-    core.verifyAppChecks({ checks, evidence });
+    if (evidence.pullRequest !== pr.number) fail('execution belongs to a different PR');
+    core.verifyAppChecks({ checks, evidence, requiredChecks: evidence.checks });
     return { ...evidence, integrated: integrated.sha };
     } catch (prError) {
         const full = completePages(api(`${PREFIX}/actions/workflows/quality-gate.yml/runs?event=workflow_dispatch&head_sha=${sha(integrated.sha)}&per_page=100`,
-            { pages: true }), 'workflow_runs').filter((run) => run.head_branch === 'master').sort((a, b) => b.id - a.id);
+            { pages: true }), 'workflow_runs').sort((a, b) => b.id - a.id);
         if (!full.length) fail(`PR evidence unavailable: ${prError.message}; run the existing manual Quality Gate on this master commit`);
-        return inspectFullRun({ repo, runId: full[0].id, candidate: integrated.sha, api, core });
+        const recovered = inspectFullRun({ repo, runId: full[0].id, candidate: integrated.sha, api, core });
+        if (recovered.integrated !== integrated.sha) fail('full verification does not cover the protected merge');
+        return recovered;
     }
 }
 
@@ -242,10 +273,13 @@ export function assertCurrentEvidence(evidence, api = github) {
     const run = api(`${PREFIX}/actions/runs/${integer(evidence.runId)}`);
     assertRun(run);
     const pr = api(`${PREFIX}/pulls/${integer(evidence.pullRequest)}`);
+    const status = run.status === 'completed' ? 'completed' : 'in_progress';
+    const conclusion = status === 'completed' ? (run.conclusion === 'success' ? 'success' : 'failure') : null;
     if (pr.state !== 'open' || pr.base?.repo?.id !== REPO_ID || pr.base?.ref !== 'master'
         || pr.base?.sha !== evidence.base || pr.head?.sha !== evidence.head || pr.merge_commit_sha !== evidence.merge
-        || run.run_attempt !== evidence.attempt || run.head_sha !== evidence.head
-        || (evidence.conclusion === 'success' && (run.status !== 'completed' || run.conclusion !== 'success'))) {
+        || pr.head?.repo?.id !== run.head_repository?.id || pr.head?.ref !== run.head_branch
+        || pullRequestNumber(run) !== evidence.pullRequest || run.run_attempt !== evidence.attempt || run.head_sha !== evidence.head
+        || evidence.status !== status || evidence.conclusion !== conclusion) {
         fail('PR or execution changed before check publication completed');
     }
     assertLatestPullRequestRun(run, evidence.pullRequest, api);
@@ -286,6 +320,7 @@ async function main() {
         fs.appendFileSync(process.env.GITHUB_OUTPUT, `publish=${Boolean(evidence.merge && process.env.GITHUB_EVENT_NAME === 'workflow_run')}\n`, 'utf8');
     }
     if (process.argv.includes('--publish')) {
+        if (evidence.ignored) { console.log(JSON.stringify(evidence)); return; }
         if (process.env.GITHUB_EVENT_NAME !== 'workflow_run' || !evidence.merge) fail('master verification does not publish checks');
         assertCurrentEvidence(evidence);
         try {

--- a/scripts/ci/prepare-pr-gate.mjs
+++ b/scripts/ci/prepare-pr-gate.mjs
@@ -24,7 +24,7 @@ export function prepare(repo) {
     publisher.deleteIn(['jobs', 'protected-base']);
     publisher.deleteIn(['jobs', 'quality-gate']);
     publisher.deleteIn(['jobs', 'checks', 'needs']);
-    publisher.setIn(['jobs', 'checks', 'if'], "github.event_name == 'push' || github.event.workflow_run.event == 'pull_request' || (github.event.workflow_run.event == 'workflow_dispatch' && github.event.workflow_run.head_branch == 'master' && github.event.action == 'completed')");
+    publisher.setIn(['jobs', 'checks', 'if'], "github.event_name == 'push' || github.event.workflow_run.event == 'pull_request' || (github.event.workflow_run.event == 'workflow_dispatch' && github.event.action == 'completed')");
     quality.set('on', { workflow_dispatch: { inputs: {
         trusted_base_sha: { description: 'Protected predecessor commit (optional)', required: false, type: 'string' },
     } }, workflow_call: { inputs: { trusted_base_sha: { required: false, type: 'string' } } } });
@@ -37,13 +37,63 @@ export function prepare(repo) {
                 step.deleteIn(['env', 'INPUT_ROOT_CANDIDATE_SHA']);
             }
             const run = step.get('run', true);
-            if (run) run.value = run.value.replace(
-                ' --root-admission "$INPUT_ROOT_ADMISSION" --root-candidate-sha "$INPUT_ROOT_CANDIDATE_SHA"', '');
+            if (!run) continue;
+            if (run.value.includes('node scripts/ci/resolve-trusted-base.mjs ')) {
+                run.value = run.value.slice(run.value.indexOf('node scripts/ci/resolve-trusted-base.mjs '))
+                    .replace('"$TRUSTED_BASE_SHA"', '"$INPUT_TRUSTED_BASE_SHA"')
+                    .replace(' --root-admission "$INPUT_ROOT_ADMISSION" --root-candidate-sha "$INPUT_ROOT_CANDIDATE_SHA"', '');
+            }
+            if (run.value.includes('if git cat-file -e "$BASE_SHA:scripts/ci/release-gate-policy.json"')) {
+                // YAML scalar 已去掉缩进；只保留当前受保护 policy 的物化路径。
+                const from = run.value.indexOf('if git cat-file');
+                const end = run.value.indexOf('while IFS= read -r rel; do');
+                run.value = run.value.slice(0, from) + [
+                    'git show "$BASE_SHA:scripts/ci/release-gate-policy.json" > "$RUNNER_TEMP/gate-policy.json"',
+                    'GATE_EPOCH=$(node -e \'console.log(require(process.argv[1]).gateEpoch)\' "$RUNNER_TEMP/gate-policy.json")',
+                    'node -e \'const p=require(process.argv[1]); console.log(p.protectedCore.join("\\n"))\' "$RUNNER_TEMP/gate-policy.json" > "$RUNNER_TEMP/gate-files.txt"',
+                    '',
+                ].join('\n') + run.value.slice(end);
+            }
+            if (run.value.includes('elif [ "$GATE_MODE" = "ROOT_ADMISSION" ]')) {
+                run.value = run.value.split('\n').find((line) => line.includes('node "$GATE_DIR/scripts/ci/release-gate-verifier.mjs"')).trim() + '\n';
+            }
         }
+    }
+    // 复用同一 protected predecessor 算法；历史 master 提交仍使用自己的严格前驱。
+    for (const name of ['release.yml', 'publish-plugins.yml', 'build-stable-ffmpeg.yml']) {
+        const file = path.join(repo, '.github/workflows', name);
+        const doc = YAML.parseDocument(fs.readFileSync(file, 'utf8'));
+        if (doc.errors.length) throw new Error(`invalid workflow YAML: ${name}`);
+        const step = doc.getIn(['jobs', 'trusted-base', 'steps']).items.find((entry) => entry.get('id') === 'base');
+        step.commentBefore = ' 从受保护默认分支历史解析候选的严格前驱；历史提交仍使用自己的父提交。';
+        step.set('run', [
+            'set -euo pipefail',
+            ...(name === 'publish-plugins.yml' ? [
+                'if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ "$GITHUB_REF" != "refs/heads/master" ]; then',
+                '  echo "manual publication requires the protected master branch" >&2',
+                '  exit 1',
+                'fi',
+            ] : []),
+            'git fetch --no-tags origin "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"',
+            'tip="$(git rev-parse "refs/remotes/origin/$DEFAULT_BRANCH")"',
+            'if git merge-base --is-ancestor "$GITHUB_SHA" "$tip"; then',
+            '  base="$(git rev-parse "$GITHUB_SHA^1")"',
+            'else',
+            '  base="$(git merge-base "$GITHUB_SHA" "$tip")"',
+            'fi',
+            'echo "sha=$base" >> "$GITHUB_OUTPUT"',
+            '',
+        ].join('\n'));
+        if (name === 'publish-plugins.yml') {
+            doc.deleteIn(['jobs', 'trusted-base', 'if']);
+            doc.deleteIn(['jobs', 'quality-gate', 'if']);
+        }
+        fs.writeFileSync(file, doc.toString(), 'utf8');
     }
     const caller = {
         name: 'Pull Request Quality Gate',
-        on: { pull_request: { branches: ['master'], types: ['opened', 'reopened', 'synchronize', 'edited'] } },
+        'run-name': 'PR #${{ github.event.pull_request.number }}',
+        on: { pull_request: { types: ['opened', 'reopened', 'synchronize', 'edited'] } },
         permissions: { contents: 'read' },
         concurrency: { group: "pr-quality-${{ github.event.pull_request.number }}-${{ github.event.action == 'edited' && github.event.changes.base == null }}", 'cancel-in-progress': true },
         jobs: { 'quality-gate': {

--- a/scripts/ci/test/pr-gate.test.mjs
+++ b/scripts/ci/test/pr-gate.test.mjs
@@ -50,6 +50,7 @@ function fixture() {
             uses: 'Sywyar/PixivDownloader/.github/workflows/quality-gate.yml@master',
         } } };
     const run = { id: 123, run_attempt: 2, run_started_at: '2026-09-05T08:02:00Z', head_sha: H, name: caller.name,
+        display_title: 'PR #42', head_branch: 'feature', head_repository: { id: 12345 },
         repository: { id: 1089943605, full_name: 'Sywyar/PixivDownloader' },
         event: 'pull_request', path: '.github/workflows/pr-quality-gate.yml',
         status: 'completed', conclusion: 'success', referenced_workflows: [{
@@ -99,7 +100,6 @@ test('foreign, stale, skipped and fabricated jobs cannot substitute for the prot
         (f) => { f.proof.base = H; },
         (f) => { f.proof.runId = '124'; },
         (f) => { f.proof.attempt = '3'; },
-        (f) => { f.caller.jobs['quality-gate'].if = 'false'; },
         (f) => { f.caller.jobs.fake = { 'runs-on': 'ubuntu-latest', steps: [{ run: 'true' }] }; },
         (f) => { f.jobs[0].conclusion = 'skipped'; },
         (f) => { f.jobs[0].conclusion = 'neutral'; },
@@ -144,7 +144,8 @@ test('execution records fail closed when missing, duplicated, malformed or from 
 test('API pagination and check publication cannot accept a partial response or another App', () => {
     assert.deepEqual(completePages([{ total_count: 2, jobs: [1] }, { total_count: 2, jobs: [2] }], 'jobs'), [1, 2]);
     for (const pages of [[], [{ jobs: [] }], [{ total_count: 2, jobs: [1] }],
-        [{ total_count: 2, jobs: [1] }, { total_count: 3, jobs: [2] }]]) {
+        [{ total_count: 2, jobs: [1] }, { total_count: 3, jobs: [2] }],
+        [{ total_count: 2, jobs: [{ id: 1 }] }, { total_count: 2, jobs: [{ id: 1 }] }]]) {
         assert.throws(() => completePages(pages, 'jobs'));
     }
     const f = fixture();
@@ -168,9 +169,9 @@ test('publication rechecks the current PR and newest run even when fork run asso
     f.run.head_branch = 'feature';
     f.run.head_repository = { id: 12345 };
     f.run.pull_requests = [];
-    const evidence = { ...verifyRunIdentity(f), pullRequest: 42, conclusion: 'success' };
+    const evidence = { ...verifyRunIdentity(f), pullRequest: 42, status: 'completed', conclusion: 'success' };
     const pr = { state: 'open', base: { sha: B, ref: 'master', repo: { id: 1089943605 } },
-        head: { sha: H }, merge_commit_sha: M };
+        head: { sha: H, ref: 'feature', repo: { id: 12345 } }, merge_commit_sha: M };
     const api = (endpoint, options) => endpoint.includes('/jobs?') ? [{ total_count: f.jobs.length, jobs: f.jobs }] : options?.pages
         ? [{ total_count: 1, workflow_runs: [f.run] }]
         : endpoint.endsWith('/pulls/42') ? pr : f.run;
@@ -188,12 +189,15 @@ test('publication rechecks the current PR and newest run even when fork run asso
     assert.throws(() => assertCurrentEvidence(evidence, (endpoint, options) => endpoint.includes('/workflows/')
         ? [{ total_count: 2, workflow_runs: [f.run, { ...f.run, id: 124 }] }] : api(endpoint, options)), /newer PR/u);
     assert.throws(() => assertCurrentEvidence(evidence, () => { throw new Error('API unavailable'); }), /API unavailable/u);
+    assert.throws(() => assertCurrentEvidence({ ...evidence, status: 'in_progress', conclusion: null }, api), /changed/u);
+    assert.throws(() => assertCurrentEvidence({ ...evidence, conclusion: 'failure' }, api), /changed/u);
 });
 
-test('text-only PR edits do not publish success or supersede verified execution of the same merge', async () => {
+test('late text-only PR edits reconcile the latest execution without publishing a false success', async () => {
     const f = fixture();
+    Object.assign(f.run, { head_branch: 'feature', head_repository: { id: 12345 } });
     const skipped = { ...f.run, id: 124, pull_requests: [{ number: 42 }] };
-    const evidence = { ...verifyRunIdentity(f), pullRequest: 42, conclusion: 'success' };
+    f.run.status = 'in_progress'; f.run.conclusion = null;
     f.run.pull_requests = [{ number: 42 }];
     const api = (endpoint) => {
         if (endpoint.endsWith('/actions/runs/123')) return f.run;
@@ -202,18 +206,69 @@ test('text-only PR edits do not publish success or supersede verified execution 
             name: 'quality-gate', run_id: 124, head_sha: H, status: 'completed', conclusion: 'skipped' }] }];
         if (endpoint.includes('/runs/123/jobs')) return [{ total_count: 6, jobs: f.jobs }];
         if (endpoint.includes('/workflows/')) return [{ total_count: 2, workflow_runs: [skipped, f.run] }];
-        if (endpoint.endsWith('/pulls/42')) return { state: 'open', base: { sha: B, ref: 'master', repo: { id: 1089943605 } },
-            head: { sha: H }, merge_commit_sha: M };
+        if (endpoint.endsWith('/pulls/42')) return { number: 42, state: 'open', base: { sha: B, ref: 'master', repo: { id: 1089943605 } },
+            head: { sha: H, ref: 'feature', repo: { id: 12345 } }, merge_commit_sha: M };
         throw new Error(`unexpected edit API request: ${endpoint}`);
     };
-    assertCurrentEvidence(evidence, api);
     const result = await checkEvent({ repo: SOURCE_ROOT, eventName: 'workflow_run',
         event: { workflow_run: { id: 124 } }, core, api });
-    assert.equal(result.ignored, true);
-    assert.equal(result.merge, undefined);
+    assert.equal(result.runId, 123);
+    assert.equal(result.status, 'in_progress');
+    assert.equal(result.conclusion, null);
 });
 
-test('protected predecessor admits only its approved core and exact root merge; ordinary workflow maintenance remains possible', async () => {
+test('fork runs match the PR repository and branch; development targets and closed PRs need no App checks', async () => {
+    const f = fixture();
+    Object.assign(f.run, { head_branch: 'feature', head_repository: { id: 12345 }, pull_requests: [],
+        status: 'in_progress', conclusion: null });
+    const pr = { number: 42, state: 'open', base: { sha: B, ref: 'master', repo: { id: 1089943605 } },
+        head: { sha: H, ref: 'feature', repo: { id: 12345 } }, merge_commit_sha: M };
+    const other = structuredClone(pr); other.number = 43; other.head.repo.id = 54321;
+    const development = structuredClone(pr); development.number = 44; development.base.ref = 'refactor/gui';
+    const devRun = { ...f.run, id: 125, display_title: 'PR #44' };
+    const otherRun = { ...f.run, id: 124, display_title: 'PR #43', head_repository: { id: 54321 } };
+    const api = (endpoint) => {
+        if (endpoint.endsWith('/pulls/42')) return pr;
+        if (endpoint.endsWith('/pulls/43')) return other;
+        if (endpoint.endsWith('/pulls/44')) return development;
+        if (endpoint.includes('/workflows/')) return [{ total_count: 3, workflow_runs: [devRun, otherRun, f.run] }];
+        if (endpoint.endsWith('/actions/runs/123')) return f.run;
+        if (endpoint.endsWith('/actions/runs/125')) return devRun;
+        throw new Error(`unexpected PR association request: ${endpoint}`);
+    };
+    const inspect = () => checkEvent({ repo: SOURCE_ROOT, eventName: 'workflow_run',
+        event: { workflow_run: { id: 123 } }, core, api });
+    assert.equal((await inspect()).pullRequest, 42);
+    assert.equal((await inspect()).runId, 123, '同 fork 同 head 的开发目标运行不得抢占 master PR');
+    assert.equal((await checkEvent({ repo: SOURCE_ROOT, eventName: 'workflow_run',
+        event: { workflow_run: { id: 125 } }, core, api })).ignored, true);
+    f.run.display_title = 'PR #43';
+    assert.equal((await inspect()).ignored, true, '运行名称不能替代 head 仓库与分支核对');
+    f.run.display_title = 'PR #42';
+    pr.base.ref = 'refactor/gui/swing-plugin-boundary';
+    assert.equal((await inspect()).ignored, true);
+    pr.base.ref = 'master'; pr.state = 'closed';
+    assert.equal((await inspect()).ignored, true);
+});
+
+test('PR listener maintenance and helper jobs do not change the protected execution identity', () => {
+    for (const change of [
+        (f) => { delete f.caller.on.pull_request.branches; },
+        (f) => { f.caller.on.pull_request.branches.push('refactor/**'); },
+        (f) => { delete f.caller.jobs['quality-gate'].if; },
+        (f) => { f.caller.jobs['quality-gate'].if = "github.event.action!='edited'||github.event.changes.base!=null"; },
+        (f) => { f.run.referenced_workflows.push({ path: 'owner/repo/.github/workflows/helper.yml@' + H, sha: H }); },
+        (f) => { f.jobs.push({ ...f.jobs[0], id: 99, name: 'quality-gate / diagnostic', conclusion: 'skipped', steps: [] }); },
+        (f) => { f.jobs.push({ ...f.jobs[0], id: 99, name: 'quality-gate / helper (linux)' }); },
+    ]) {
+        const f = fixture(); change(f);
+        verifyRunIdentity(f); verifyRunResults(f);
+    }
+    const f = fixture();
+    assert.throws(() => verifyRunResults({ ...f, requiredJobs: [...roles, 'new-required-test'], expectedJobs: roles }), /roles/u);
+});
+
+test('protected predecessor admits only its approved core, permits ordinary root repairs, and verifies real execution', async () => {
     const source = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
     const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv gate admission '));
     const git = (args, input) => execFileSync('git', ['-C', repo, ...args],
@@ -289,6 +344,30 @@ test('protected predecessor admits only its approved core and exact root merge; 
         }
         assert.equal(verifyCandidate({ repo, trusted: base, candidate: merge }).gateEpoch, 8);
         assert.equal(verifyCandidate({ repo, trusted: base, candidate: root }).gateEpoch, 8);
+        const repairFile = path.join(repo, '.github/workflows/root-diagnostics.yml');
+        fs.writeFileSync(repairFile, YAML.stringify({ name: 'Diagnostics', on: { workflow_dispatch: {} },
+            permissions: { contents: 'read' }, jobs: { report: { 'runs-on': 'ubuntu-latest', steps: [{ run: 'echo report' }] } } }));
+        const repair = commit('ordinary maintenance after sealing the core');
+        const repairTree = git(['rev-parse', repair + '^{tree}']);
+        const advancedBase = git(['commit-tree', git(['rev-parse', base + '^{tree}']), '-p', base], 'protected master advanced\n');
+        git(['update-ref', 'refs/remotes/origin/master', advancedBase]);
+        const repairMerge = git(['commit-tree', repairTree, '-p', advancedBase, '-p', repair], 'retested repaired root descendant\n');
+        assert.equal(verifyCandidate({ repo, trusted: advancedBase, candidate: repairMerge }).gateEpoch, 8);
+        git(['branch', '-M', 'master']);
+        git(['update-ref', 'refs/heads/master', repairMerge]);
+        git(['update-ref', 'refs/remotes/origin/master', repairMerge]);
+        git(['config', '--local', 'pixiv.release.trustedGateEpoch', '5']);
+        git(['config', '--local', 'pixiv.release.trustedGateRef', advancedBase]);
+        const adoptionEnv = { ...process.env }; delete adoptionEnv.CI;
+        const repairedAdoption = spawnSync(process.execPath,
+            [path.join(source, CORE_DIRECTORY, 'release-gate-trust.mjs'), '--adopt-root', '--ref', repairMerge],
+            { cwd: repo, env: adoptionEnv, encoding: 'utf8' });
+        assert.equal(repairedAdoption.status, 0, repairedAdoption.stderr || repairedAdoption.stdout);
+        assert.equal(git(['config', '--get', 'pixiv.release.trustedGateRef']), repairMerge);
+        fs.unlinkSync(repairFile);
+        git(['update-ref', 'refs/heads/master', root]);
+        git(['read-tree', root]);
+        git(['update-ref', 'refs/remotes/origin/master', base]);
         for (const request of [
             { event: 'pull_request', candidate: merge, prBase: base, prHead: root },
             { event: 'push', candidate: root, ref: 'refs/heads/feature' },
@@ -322,6 +401,28 @@ test('protected predecessor admits only its approved core and exact root merge; 
         const evidence = await inspectRun({ repo, runId: 123, api, core });
         assert.equal(evidence.merge, merge);
         assert.equal(evidence.attempt, 2);
+        const integrated = git(['commit-tree', tree, '-p', base, '-p', root], 'actual integrated merge\n');
+        const mergedPr = { number: 42, state: 'closed', merged_at: '2026-09-05T09:00:00Z', merge_commit_sha: integrated,
+            base: { ref: 'master', repo: { id: 1089943605 } }, head: { sha: root, ref: 'feature', repo: { id: 12345 } } };
+        const masterApi = (endpoint, options) => {
+            if (endpoint.endsWith(`/git/commits/${integrated}`)) return { ...f.merge, sha: integrated,
+                tree: { sha: tree }, parents: [{ sha: base }, { sha: root }] };
+            if (endpoint.includes(`/commits/${integrated}/pulls`)) return [[mergedPr]];
+            if (endpoint.includes('/workflows/pr-quality-gate.yml/runs')) return [{ total_count: 2, workflow_runs: [
+                { ...f.run, id: 124, display_title: 'PR #43', pull_requests: [] }, { ...f.run, pull_requests: [] },
+            ] }];
+            if (endpoint.includes('/check-runs?')) return [{ total_count: roles.length, check_runs: roles.map((name, id) => ({
+                id: id + 1000, name, head_sha: merge, status: 'completed', conclusion: 'success', app: { id: 4837005 },
+                details_url: 'https://github.com/Sywyar/PixivDownloader/actions/runs/123/attempts/2',
+            })) }];
+            return api(endpoint, options);
+        };
+        assert.equal((await checkEvent({ repo, eventName: 'push', core, api: masterApi,
+            event: { ref: 'refs/heads/master', before: base, after: integrated } })).integrated, integrated);
+        await assert.rejects(inspectRun({ repo, runId: 123, core, api: (endpoint, options) => {
+            const response = api(endpoint, options);
+            return endpoint.endsWith('/actions/runs/123') ? { ...response, display_title: 'PR #43' } : response;
+        } }), /PR association differs/u);
         await assert.rejects(inspectRun({ repo, runId: 123, core, api: (endpoint, options) => {
             const response = api(endpoint, options);
             return endpoint.endsWith('/attempts/1') ? { ...response, referenced_workflows: [] } : response;
@@ -337,6 +438,48 @@ test('protected predecessor admits only its approved core and exact root merge; 
         git(['read-tree', merge]);
         git(['update-ref', 'refs/remotes/origin/master', merge]);
         assert.equal(resolveTrustedBase({ repo, event: 'push', candidate: merge, before: base, ref: 'refs/heads/master' }).base, base);
+        const later = git(['commit-tree', tree, '-p', merge], 'later protected merge\n');
+        git(['update-ref', 'refs/remotes/origin/master', later]);
+        for (const inputBase of [undefined, base]) {
+            assert.equal(resolveTrustedBase({ repo, event: 'workflow_dispatch', candidate: merge, inputBase }).base, base);
+        }
+        const development = git(['commit-tree', tree, '-p', merge], 'development base\n');
+        const contribution = git(['commit-tree', tree, '-p', development], 'fork contribution\n');
+        const developmentMerge = git(['commit-tree', tree, '-p', development, '-p', contribution], 'fork PR to development\n');
+        assert.equal(resolveTrustedBase({ repo, event: 'pull_request', candidate: developmentMerge,
+            prBase: development, prHead: contribution }).base, merge);
+        assert.throws(() => resolveTrustedBase({ repo, event: 'pull_request', candidate: developmentMerge,
+            prBase: development, prHead: contribution, inputBase: development }), /protected predecessor/u);
+        assert.equal(verifyCandidate({ repo, trusted: merge, candidate: developmentMerge }).gateEpoch, 8);
+        git(['update-ref', 'refs/heads/master', later]);
+        const outputDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv base output '));
+        try {
+            for (const workflowName of ['release.yml', 'publish-plugins.yml', 'build-stable-ffmpeg.yml']) {
+                const doc = YAML.parse(fs.readFileSync(path.join(repo, '.github/workflows', workflowName), 'utf8'));
+                const resolve = doc.jobs['trusted-base'].steps.find((step) => step.id === 'base');
+                const output = path.join(outputDirectory, workflowName);
+                const result = spawnSync('bash', ['-e', '-o', 'pipefail', '-c', resolve.run], {
+                    cwd: repo, encoding: 'utf8', env: { ...process.env, DEFAULT_BRANCH: 'master',
+                        GITHUB_SHA: merge, GITHUB_EVENT_NAME: 'workflow_dispatch', GITHUB_REF: 'refs/heads/master',
+                        GITHUB_OUTPUT: output.replaceAll('\\', '/') },
+                });
+                assert.equal(result.status, 0, result.stderr);
+                assert.equal(fs.readFileSync(output, 'utf8').trim(), `sha=${base}`);
+            }
+            const doc = YAML.parse(fs.readFileSync(path.join(repo, '.github/workflows/quality-gate.yml'), 'utf8'));
+            const resolver = doc.jobs['trusted-gate-contract'].steps.find((step) => step.env?.EVENT_PR_BASE_REF);
+            const output = path.join(outputDirectory, 'development-env');
+            const result = spawnSync('bash', ['-e', '-o', 'pipefail', '-c', resolver.run], {
+                cwd: repo, encoding: 'utf8', env: { ...process.env, DEFAULT_BRANCH: 'master',
+                    GITHUB_SHA: developmentMerge, GITHUB_EVENT_NAME: 'pull_request', GITHUB_REF: 'refs/pull/42/merge',
+                    EVENT_PR_BASE_SHA: development, EVENT_PR_HEAD_SHA: contribution, EVENT_PR_BASE_REF: 'refactor/feature',
+                    RUNNER_TEMP: outputDirectory.replaceAll('\\', '/'), GITHUB_ENV: output.replaceAll('\\', '/') },
+            });
+            assert.equal(result.status, 0, result.stderr);
+            assert.match(fs.readFileSync(output, 'utf8'), new RegExp(`^BASE_SHA=${merge}$`, 'm'));
+        } finally { fs.rmSync(outputDirectory, { recursive: true, force: true }); }
+        git(['update-ref', 'refs/heads/master', merge]);
+        git(['update-ref', 'refs/remotes/origin/master', merge]);
         git(['config', '--local', 'pixiv.release.trustedGateEpoch', '5']);
         git(['config', '--local', 'pixiv.release.trustedGateRef', base]);
         const env = { ...process.env };
@@ -364,6 +507,11 @@ test('protected predecessor admits only its approved core and exact root merge; 
             throw new Error(`unexpected full-gate API request: ${endpoint}`);
         };
         assert.equal(inspectFullRun({ repo, runId: 123, candidate: merge, api: fullApi, core }).integrated, merge);
+        full.head_branch = 'v1.14.0';
+        assert.equal(inspectFullRun({ repo, runId: 123, candidate: merge, api: fullApi, core }).integrated, merge);
+        full.head_sha = later; full.head_branch = 'feature';
+        assert.equal(inspectFullRun({ repo, runId: 123, candidate: later, api: fullApi, core }).ignored, true);
+        full.head_sha = merge; full.head_branch = 'master';
         const recovered = await checkEvent({ repo, eventName: 'push', event: { ref: 'refs/heads/master', before: base, after: merge }, api: fullApi, core });
         assert.equal(recovered.verification, 'same-commit-full-quality-gate');
         assert.throws(() => inspectFullRun({ repo, runId: 123, candidate: root, api: fullApi, core }), /same protected master commit/u);
@@ -425,6 +573,64 @@ test('protected predecessor admits only its approved core and exact root merge; 
         }
         fs.writeFileSync(publisherPath, publisher);
         const quality = YAML.parse(fs.readFileSync(workflow, 'utf8'));
+        const helpers = structuredClone(quality);
+        helpers.jobs.diagnostics = { 'runs-on': 'ubuntu-latest', if: 'always()', steps: [{ run: 'echo diagnostic' }] };
+        helpers.jobs.matrix = { 'runs-on': '${{ matrix.os }}', strategy: { matrix: { os: ['ubuntu-latest', 'windows-latest'] } },
+            steps: [{ run: 'echo helper' }] };
+        fs.writeFileSync(workflow, YAML.stringify(helpers));
+        assert.equal(verifyCandidate({ repo, trusted: merge, candidate: commit('ordinary quality helpers') }).gateEpoch, 8);
+        fs.writeFileSync(workflow, YAML.stringify(quality));
+
+        const wrapperFile = path.join(repo, '.github/workflows/wrapped-quality.yml');
+        const consumerFile = path.join(repo, '.github/workflows/privileged-consumer.yml');
+        const wrapper = { name: 'Wrapped quality', on: { workflow_call: {} }, permissions: { contents: 'read' }, jobs: {
+            gate: { uses: './.github/workflows/quality-gate.yml' },
+            noop: { 'runs-on': 'ubuntu-latest', steps: [{ run: 'true' }] },
+        } };
+        fs.writeFileSync(consumerFile, YAML.stringify({ name: 'Consumer', on: { workflow_dispatch: {} },
+            permissions: { contents: 'read' }, jobs: { gate: { uses: './.github/workflows/wrapped-quality.yml' },
+                publish: { needs: 'gate', environment: 'release', permissions: { contents: 'write' },
+                    'runs-on': 'ubuntu-latest', steps: [{ run: 'true' }] } } }));
+        for (const change of [
+            (doc) => { doc.jobs.gate.if = 'false'; },
+            (doc) => { doc.jobs.noop.if = 'false'; doc.jobs.gate.needs = 'noop'; },
+        ]) {
+            const doc = structuredClone(wrapper); change(doc);
+            fs.writeFileSync(wrapperFile, YAML.stringify(doc));
+            assert.throws(() => verifyCandidate({ repo, trusted: merge, candidate: commit('skippable wrapped quality') }), /before Quality Gate success/u);
+        }
+        fs.writeFileSync(wrapperFile, YAML.stringify(wrapper));
+        assert.equal(verifyCandidate({ repo, trusted: merge, candidate: commit('unconditional wrapped quality') }).gateEpoch, 8);
+        fs.unlinkSync(wrapperFile); fs.unlinkSync(consumerFile);
+
+        const policyFile = path.join(repo, 'scripts/ci/release-gate-policy.json');
+        const policyText = fs.readFileSync(policyFile, 'utf8');
+        const promoted = JSON.parse(policyText);
+        promoted.qualityGate.requiredJobs.push('new-required-test');
+        promoted.ruleset.requiredChecks.push('new-required-test');
+        promoted.ruleset.requiredCheckSources['new-required-test'] = 4837005;
+        const newQuality = structuredClone(quality);
+        newQuality.jobs['new-required-test'] = { 'runs-on': 'ubuntu-latest', steps: [{ run: 'false' }] };
+        fs.writeFileSync(policyFile, JSON.stringify(promoted));
+        fs.writeFileSync(workflow, YAML.stringify(newQuality));
+        const requiredHead = commit('new required execution role');
+        const requiredTree = git(['rev-parse', requiredHead + '^{tree}']);
+        const requiredMerge = git(['commit-tree', requiredTree, '-p', merge, '-p', requiredHead], 'required role candidate\n');
+        const required = fixture();
+        required.run.head_sha = requiredHead;
+        required.run.referenced_workflows[0].sha = merge;
+        required.proof = { ...required.proof, base: merge, head: requiredHead, merge: requiredMerge };
+        required.jobs.forEach((job) => { job.head_sha = requiredHead; });
+        const requiredApi = (endpoint) => {
+            if (endpoint.endsWith('/actions/runs/123')) return required.run;
+            if (endpoint.includes('/jobs?')) return [{ total_count: 6, jobs: required.jobs }];
+            if (endpoint.endsWith('/logs')) return `GATE_EXECUTION ${JSON.stringify(required.proof)}`;
+            if (endpoint.endsWith(`/git/commits/${requiredMerge}`)) return { sha: requiredMerge, tree: { sha: requiredTree },
+                parents: [{ sha: merge }, { sha: requiredHead }] };
+            throw new Error(`unexpected required-role API request: ${endpoint}`);
+        };
+        await assert.rejects(inspectRun({ repo, runId: 123, api: requiredApi, core }), /protected Quality Gate roles removed new-required-test/u);
+        fs.writeFileSync(policyFile, policyText);
         quality.jobs['java-tests'].steps[0]['continue-on-error'] = '${{ true }}';
         fs.writeFileSync(workflow, YAML.stringify(quality));
         assert.throws(() => verifyCandidate({ repo, trusted: merge, candidate: commit('suppressed quality failure') }), /suppress/u);

--- a/scripts/ci/test/quality-gate-workflow.test.mjs
+++ b/scripts/ci/test/quality-gate-workflow.test.mjs
@@ -78,6 +78,8 @@ test('PR concurrency cancels only earlier validation of the same PR and workflow
         assert.equal(caller.concurrency['cancel-in-progress'], true);
         const first = { event: { pull_request: { number: 1 } } };
         const second = { event: { pull_request: { number: 2 } } };
+        assert.equal(evaluate(caller['run-name'], first), 'PR #1');
+        assert.equal(evaluate(caller['run-name'], second), 'PR #2');
         assert.notEqual(evaluate(caller.concurrency.group, first), evaluate(caller.concurrency.group, second));
         const textEdit = { event: { ...first.event, action: 'edited', changes: {} } };
         const baseEdit = { event: { ...textEdit.event, changes: { base: {} } } };
@@ -104,14 +106,17 @@ test('PR concurrency cancels only earlier validation of the same PR and workflow
     }
 });
 
-test('check publication queues each upstream run independently, including text-only edits of the same head', () => {
+test('check publication serializes writers for the same head without canceling active publication', () => {
     const { concurrency } = load('.github/workflows/gate-checks.yml');
     const group = (github) => concurrency.group.replace(/\$\{\{(.*?)\}\}/g,
         (_, expression) => String(vm.runInNewContext(expression, { github })));
     const upstream = { event: { workflow_run: { id: 10, head_sha: 'same-head' } }, sha: 'protected-base' };
     assert.equal(concurrency['cancel-in-progress'], false);
     assert.equal(group(upstream), group({ ...upstream, event: { workflow_run: { ...upstream.event.workflow_run, run_attempt: 2 } } }));
-    assert.notEqual(group(upstream), group({ ...upstream, event: { workflow_run: { id: 11, head_sha: 'same-head' } } }));
+    const sameHead = { ...upstream, event: { workflow_run: { id: 11, head_sha: 'same-head' } } };
+    assert.equal(group(upstream), group(sameHead));
+    assert.equal(concurrency.queue, 'max');
+    assert.notEqual(group(upstream), group({ ...upstream, event: { workflow_run: { id: 12, head_sha: 'other-head' } } }));
     const master = { event: { workflow_run: {} }, sha: 'integrated-commit' };
     assert.notEqual(group(upstream), group(master));
     assert.notEqual(group(master), group({ ...master, sha: 'next-integrated-commit' }));
@@ -126,7 +131,7 @@ test('主线手动全量验证只在完成后核对证据，PR 进行中事件�
         ['workflow_run', 'pull_request', 'feature', 'completed', true],
         ['workflow_run', 'workflow_dispatch', 'master', 'in_progress', false],
         ['workflow_run', 'workflow_dispatch', 'master', 'completed', true],
-        ['workflow_run', 'workflow_dispatch', 'feature', 'completed', false],
+        ['workflow_run', 'workflow_dispatch', 'feature', 'completed', true],
     ]) {
         assert.equal(vm.runInNewContext(condition, { github: {
             event_name, event: { action, workflow_run: { event, head_branch } },
@@ -149,7 +154,7 @@ test('Quality Gate preserves required roles and the active event contract', () =
         assert.ok(doc.jobs['check-shared-snippets']);
         assert.deepEqual(triggers(doc).sort(), ['workflow_call', 'workflow_dispatch']);
     }
-    const javaSteps = doc.jobs['java-tests'].steps;
+    const javaSteps = Object.values(doc.jobs).flatMap((job) => job.steps || []);
     const sdkResolve = javaSteps.find((step) => step.env?.INPUT_TRUSTED_BASE_SHA !== undefined);
     const releaseBuild = javaSteps.find((step) => /\bverify\b/.test(step.run || ''));
     const releaseBoundary = javaSteps.find((step) => /DistributionPackagingBoundaryTest/.test(step.run || ''));


### PR DESCRIPTION
## 变更内容

修正 PR 准入准备中的执行关联与历史提交复核。同一 fork 分支同时向 master 和开发分支提 PR 时，用原生运行名称携带 PR 编号，再结合 head 仓库、分支及受保护执行证明选择结果。只对当前开放的 master PR 签发 App 检查，每项成功检查都必须有对应职责的实际成功执行。

签发 workflow 按 head SHA 使用 GitHub 原生并发队列，核对最新 run、attempt、状态与结论。历史 master 提交使用自己的严格前驱，现有全量手动 QG 可以通过指向该提交的分支或 tag 复核。

准备核心继续由当前受保护前驱批准，首次准入只固定核心身份及单调 policy，允许普通 workflow 修补和保留 root 历史的主线同步。生成器移除旧准入死分支，保留现有质量与发布职责。本 PR 保持当前活动 Gate，不执行激活。

## 验证

- [x] 本地完整 Node 测试，以及最新 PR 关联与 workflow 聚焦回归通过
- [x] 当前准备源码的 trusted contract / parity 通过
- [x] i18n 检查通过
- [x] 最终生成候选的完整 Node 测试与 parity 通过
- [x] 当前 PR merge candidate 的 required checks 全部通过

本地 actionlint 1.7.12 尚不识别 GitHub 已文档化的 `queue` 字段，未忽略或隐藏该诊断。当前 `Gate Checks` 只订阅新的 PR caller，须在启用该 caller 的激活 PR 中核对队列的实际运行；本 PR 的普通 QG 成功不能冒充签发器已经执行。

PR QG 的完整六项已通过。重复 feature push 的 Java job 曾主动取消，但其同名检查仍被平台计入合并要求，正常合并被拒绝；恢复后的 attempt 2 已完整成功，当前全部 required checks 通过，未修改或绕过 Ruleset。

未运行实际发布。本次只修改 CI 与准入准备，不产生应用用户可见变化，因此不添加 CHANGELOG 条目。中英文网络访问说明已单独提交并推送至既有在线文档分支。
