### PR TITLE
fix(release): 按原生工作流元数据核对运行身份

### DIFF
--- a/scripts/ci/gate-checks.mjs
+++ b/scripts/ci/gate-checks.mjs
@@ -62,6 +62,16 @@ function assertRun(run) {
         || run.name !== 'Pull Request Quality Gate') fail('foreign or unexpected workflow run');
 }
 
+function readRun(runId, api) {
+    const run = api(`${PREFIX}/actions/runs/${integer(runId)}`);
+    if (run.id !== Number(runId)) fail('workflow response does not match the requested run');
+    const workflow = api(`${PREFIX}/actions/workflows/${integer(run.workflow_id)}`);
+    if (workflow.id !== run.workflow_id || workflow.path !== run.path?.split('@')[0]
+        || typeof workflow.name !== 'string') fail('workflow metadata does not match the run');
+    // run.name 可包含自定义运行标题；核心消费的是同一原生 workflow 的名称。
+    return { ...run, name: workflow.name };
+}
+
 function expectedJobs(repo, ref) {
     const source = YAML.parse(git(repo, ['show', `${sha(ref)}:${QUALITY}`]));
     return Object.entries(source.jobs).filter(([, job]) => !job.uses && !job.strategy && job.if === undefined)
@@ -69,9 +79,8 @@ function expectedJobs(repo, ref) {
 }
 
 export async function inspectRun({ repo, runId, api = github, core }) {
-    const run = api(`${PREFIX}/actions/runs/${integer(runId)}`);
+    const run = readRun(runId, api);
     assertRun(run);
-    if (run.id !== Number(runId)) fail('workflow response does not match the requested run');
     const jobs = completePages(api(`${PREFIX}/actions/runs/${run.id}/jobs?filter=latest&per_page=100`,
         { pages: true }), 'jobs');
     const contract = jobs.filter((job) => job.name === 'quality-gate / trusted-gate-contract');
@@ -137,7 +146,7 @@ export function verifyAttempts(run, jobs, api, proofJob, proofAttempt) {
 }
 
 export function inspectFullRun({ repo, runId, candidate, api = github, core }) {
-    const run = api(`${PREFIX}/actions/runs/${integer(runId)}`);
+    const run = readRun(runId, api);
     integer(run.run_attempt);
     if (run.id !== Number(runId) || run.repository?.id !== REPO_ID || run.repository?.full_name !== REPO
         || run.event !== 'workflow_dispatch' || run.head_sha !== sha(candidate)
@@ -208,7 +217,7 @@ function assertLatestPullRequestRun(run, number, api) {
 export async function checkEvent({ repo, event, eventName, core, api = github }) {
     const ownPolicy = JSON.parse(fs.readFileSync(path.join(repo, 'scripts/ci/release-gate-policy.json'), 'utf8'));
     if (eventName === 'workflow_run') {
-        let run = api(`${PREFIX}/actions/runs/${integer(event.workflow_run?.id)}`);
+        let run = readRun(event.workflow_run?.id, api);
         if (run.event === 'workflow_dispatch') {
             return inspectFullRun({ repo, runId: run.id, candidate: run.head_sha, api, core });
         }
@@ -218,7 +227,7 @@ export async function checkEvent({ repo, event, eventName, core, api = github })
         // 同一 head 的发布由原生 concurrency 串行化；迟到事件也核对最新运行，避免覆盖新结果。
         const latest = latestPullRequestRun(run, pr.number, api);
         if (!latest) return { ignored: true, reason: 'no quality execution for the current PR', runId: run.id };
-        run = api(`${PREFIX}/actions/runs/${integer(latest.id)}`);
+        run = readRun(latest.id, api);
         assertRun(run);
         if (run.status !== 'completed' || run.conclusion !== 'success') {
             return { merge: sha(pr.merge_commit_sha), head: sha(pr.head.sha), base: sha(pr.base.sha),
@@ -270,7 +279,7 @@ export async function checkEvent({ repo, event, eventName, core, api = github })
 }
 
 export function assertCurrentEvidence(evidence, api = github) {
-    const run = api(`${PREFIX}/actions/runs/${integer(evidence.runId)}`);
+    const run = readRun(evidence.runId, api);
     assertRun(run);
     const pr = api(`${PREFIX}/pulls/${integer(evidence.pullRequest)}`);
     const status = run.status === 'completed' ? 'completed' : 'in_progress';

--- a/scripts/ci/test/pr-gate.test.mjs
+++ b/scripts/ci/test/pr-gate.test.mjs
@@ -49,7 +49,7 @@ function fixture() {
             if: "github.event.action != 'edited' || github.event.changes.base != null",
             uses: 'Sywyar/PixivDownloader/.github/workflows/quality-gate.yml@master',
         } } };
-    const run = { id: 123, run_attempt: 2, run_started_at: '2026-09-05T08:02:00Z', head_sha: H, name: caller.name,
+    const run = { id: 123, workflow_id: 999, run_attempt: 2, run_started_at: '2026-09-05T08:02:00Z', head_sha: H, name: caller.name,
         display_title: 'PR #42', head_branch: 'feature', head_repository: { id: 12345 },
         repository: { id: 1089943605, full_name: 'Sywyar/PixivDownloader' },
         event: 'pull_request', path: '.github/workflows/pr-quality-gate.yml',
@@ -65,7 +65,8 @@ function fixture() {
         started_at: '2026-09-05T08:00:10Z', completed_at: '2026-09-05T08:01:00Z',
         steps: [{ number: 1, name: 'Execute check', status: 'completed', conclusion: 'success',
             started_at: '2026-09-05T08:00:10Z', completed_at: '2026-09-05T08:01:00Z' }] }));
-    return { run, proof, merge, jobs, caller, protectedBase: B };
+    const workflow = { id: run.workflow_id, name: caller.name, path: run.path };
+    return { run, proof, merge, jobs, caller, workflow, protectedBase: B };
 }
 
 test('protected job evidence binds head, base, tested merge, integrated tree and App source', () => {
@@ -172,10 +173,18 @@ test('publication rechecks the current PR and newest run even when fork run asso
     const evidence = { ...verifyRunIdentity(f), pullRequest: 42, status: 'completed', conclusion: 'success' };
     const pr = { state: 'open', base: { sha: B, ref: 'master', repo: { id: 1089943605 } },
         head: { sha: H, ref: 'feature', repo: { id: 12345 } }, merge_commit_sha: M };
-    const api = (endpoint, options) => endpoint.includes('/jobs?') ? [{ total_count: f.jobs.length, jobs: f.jobs }] : options?.pages
+    const api = (endpoint, options) => endpoint.endsWith('/workflows/999') ? f.workflow
+        : endpoint.includes('/jobs?') ? [{ total_count: f.jobs.length, jobs: f.jobs }] : options?.pages
         ? [{ total_count: 1, workflow_runs: [f.run] }]
         : endpoint.endsWith('/pulls/42') ? pr : f.run;
     assertCurrentEvidence(evidence, api);
+    f.run.name = 'PR #42';
+    assertCurrentEvidence(evidence, api);
+    assert.equal(f.run.name, 'PR #42', '读取 workflow 身份不得篡改原生运行标题');
+    for (const change of [
+        { id: 1000 }, { path: '.github/workflows/foreign.yml' }, { name: 'Foreign workflow' },
+    ]) assert.throws(() => assertCurrentEvidence(evidence, (endpoint, options) =>
+        endpoint.endsWith('/workflows/999') ? { ...f.workflow, ...change } : api(endpoint, options)));
     for (const mutate of [
         () => { f.run.run_attempt++; },
         () => { pr.base.sha = H; },
@@ -186,7 +195,7 @@ test('publication rechecks the current PR and newest run even when fork run asso
         assert.throws(() => assertCurrentEvidence(evidence, api));
         Object.assign(f.run, savedRun); Object.assign(pr, savedPr);
     }
-    assert.throws(() => assertCurrentEvidence(evidence, (endpoint, options) => endpoint.includes('/workflows/')
+    assert.throws(() => assertCurrentEvidence(evidence, (endpoint, options) => endpoint.includes('/workflows/pr-quality-gate.yml/runs')
         ? [{ total_count: 2, workflow_runs: [f.run, { ...f.run, id: 124 }] }] : api(endpoint, options)), /newer PR/u);
     assert.throws(() => assertCurrentEvidence(evidence, () => { throw new Error('API unavailable'); }), /API unavailable/u);
     assert.throws(() => assertCurrentEvidence({ ...evidence, status: 'in_progress', conclusion: null }, api), /changed/u);
@@ -200,6 +209,7 @@ test('late text-only PR edits reconcile the latest execution without publishing 
     f.run.status = 'in_progress'; f.run.conclusion = null;
     f.run.pull_requests = [{ number: 42 }];
     const api = (endpoint) => {
+        if (endpoint.endsWith('/workflows/999')) return f.workflow;
         if (endpoint.endsWith('/actions/runs/123')) return f.run;
         if (endpoint.endsWith('/actions/runs/124')) return skipped;
         if (endpoint.includes('/runs/124/jobs')) return [{ total_count: 1, jobs: [{ id: 99,
@@ -228,6 +238,7 @@ test('fork runs match the PR repository and branch; development targets and clos
     const devRun = { ...f.run, id: 125, display_title: 'PR #44' };
     const otherRun = { ...f.run, id: 124, display_title: 'PR #43', head_repository: { id: 54321 } };
     const api = (endpoint) => {
+        if (endpoint.endsWith('/workflows/999')) return f.workflow;
         if (endpoint.endsWith('/pulls/42')) return pr;
         if (endpoint.endsWith('/pulls/43')) return other;
         if (endpoint.endsWith('/pulls/44')) return development;
@@ -388,6 +399,7 @@ test('protected predecessor admits only its approved core, permits ordinary root
         Object.assign(f.jobs[0].steps[0], { started_at: f.jobs[0].started_at, completed_at: f.jobs[0].completed_at });
         const contractId = f.jobs.find((job) => job.name === 'quality-gate / trusted-gate-contract').id;
         const api = (endpoint, options = {}) => {
+            if (endpoint.endsWith('/workflows/999')) return f.workflow;
             if (endpoint.endsWith('/actions/runs/123')) return f.run;
             if (endpoint.includes(`/actions/jobs/${contractId}/logs`)) return `GATE_EXECUTION ${JSON.stringify(f.proof)}`;
             if (endpoint.endsWith(`/git/commits/${merge}`)) return { sha: merge, tree: { sha: tree }, parents: [{ sha: base }, { sha: root }] };
@@ -398,6 +410,7 @@ test('protected predecessor admits only its approved core, permits ordinary root
             if (options.pages && endpoint.includes('/jobs?filter=latest')) return [{ total_count: 6, jobs: f.jobs }];
             throw new Error(`unexpected test API request: ${endpoint}`);
         };
+        f.run.name = 'PR #42';
         const evidence = await inspectRun({ repo, runId: 123, api, core });
         assert.equal(evidence.merge, merge);
         assert.equal(evidence.attempt, 2);
@@ -492,10 +505,11 @@ test('protected predecessor admits only its approved core, permits ordinary root
         assert.equal(git(['config', '--get', 'pixiv.release.trustedGateRef']), merge);
         assert.equal(fs.existsSync(path.join(repo, '.git/config.lock')), false);
         const full = { ...f.run, event: 'workflow_dispatch', head_branch: 'master', head_sha: merge,
-            path: '.github/workflows/quality-gate.yml', name: 'Quality Gate', referenced_workflows: [] };
+            path: '.github/workflows/quality-gate.yml', name: 'Manual verification', referenced_workflows: [] };
         const fullJobs = f.jobs.map((job) => ({ ...job, name: job.name.replace('quality-gate / ', ''), head_sha: merge }));
         const originalFullJobs = originalJobs.map((job) => ({ ...job, name: job.name.replace('quality-gate / ', ''), head_sha: merge }));
         const fullApi = (endpoint, options = {}) => {
+            if (endpoint.endsWith('/workflows/999')) return { id: 999, name: 'Quality Gate', path: full.path };
             if (endpoint.includes('/workflows/pr-quality-gate.yml/runs')) return [{ total_count: 0, workflow_runs: [] }];
             if (endpoint.includes('/workflows/quality-gate.yml/runs')) return [{ total_count: 1, workflow_runs: [full] }];
             if (endpoint.endsWith('/actions/runs/123') || endpoint.endsWith('/attempts/2')) return full;
@@ -622,6 +636,7 @@ test('protected predecessor admits only its approved core, permits ordinary root
         required.proof = { ...required.proof, base: merge, head: requiredHead, merge: requiredMerge };
         required.jobs.forEach((job) => { job.head_sha = requiredHead; });
         const requiredApi = (endpoint) => {
+            if (endpoint.endsWith('/workflows/999')) return required.workflow;
             if (endpoint.endsWith('/actions/runs/123')) return required.run;
             if (endpoint.includes('/jobs?')) return [{ total_count: 6, jobs: required.jobs }];
             if (endpoint.endsWith('/logs')) return `GATE_EXECUTION ${JSON.stringify(required.proof)}`;


### PR DESCRIPTION
## 变更内容

自定义 `run-name` 会使 GitHub 运行 API 的 `name` 返回运行标题，原有检查因此将合法 PR 拒绝为未知工作流。适配器改为通过原生 `workflow_id` 读取同仓库 workflow，核对 ID、路径和名称后提供工作流身份；`display_title` 继续用于 PR 编号关联。

PR 签发、签发前复核和手动全量验证共用该读取入口。仓库、事件、被测提交、受保护 reusable 来源和实际执行证明继续校验；三份可信核心不变。

## 验证

- [x] PR 执行聚焦回归 11 项通过，含自定义标题与错误 workflow ID、路径、名称的拒绝。
- [x] i18n、Gate parity 通过；真实 PR API 数据正确识别为运行中，未签发成功。
- [x] 完整 Node 测试 294 项通过。
- [x] 当前 PR required checks 全部成功；PR 全量 CI 34022898027 与 push 全量 CI 34022859543 均通过。

本次为内部 CI 修复，不添加 CHANGELOG 或 README 条目。中英文网络访问说明同步补充 workflow 元数据读取；未触发发布。
