### PR TITLE
perf(ci): 并行执行 Java 测试与 ProGuard 产物验证

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -18,6 +18,14 @@ permissions:
 
 jobs:
   java-tests:
+    needs: [java-unit-tests, release-artifacts]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Confirm Java verification completed
+        run: echo "Java tests, SDK contract and release artifact verification succeeded."
+
+  java-unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -52,14 +60,6 @@ jobs:
         run: mvn -B -ntp -pl pixivdownload-official-plugins -am compile -Dexec.skip=true
       - name: Run Java tests
         run: mvn -B -ntp test -Dexec.skip=true -Duser.language=en -Duser.country=US
-      - name: Build release artifacts with ProGuard
-        run: mvn -B -ntp verify -Pofficial-surveys -DskipTests
-      - name: Verify packaged release boundaries
-        run: |
-          mvn -B -ntp -pl pixivdownload-app -am test -Dtest=DistributionPackagingBoundaryTest -Dsurefire.failIfNoSpecifiedTests=false -Ddistribution.packaging.require-artifacts=true -Dexec.skip=true
-          REPORT=$(find pixivdownload-app/target/surefire-reports -name '*DistributionPackagingBoundaryTest.txt' -print -quit)
-          test -n "$REPORT"
-          grep -Eq 'Tests run: [1-9][0-9]*, Failures: 0, Errors: 0, Skipped: 0' "$REPORT"
       - name: Package SDK contract artifacts
         run: mvn -B -ntp -pl
           pixivdownload-sdk-info,pixivdownload-plugin-api,pixivdownload-core-api,pixivdownload-sdk-bom
@@ -74,6 +74,34 @@ jobs:
           node scripts/ci/sdk-api-surface.mjs --module sdk-info=pixivdownload-sdk-info/target --module plugin-api=pixivdownload-plugin-api/target --module core-api=pixivdownload-core-api/target --output "$RUNNER_TEMP/sdk-candidate-surface.txt"
           node scripts/ci/sdk-contract.mjs --repo-root . --base-ref "$SDK_BASE_SHA" --candidate-ref "$GITHUB_SHA" --base-surface "$RUNNER_TEMP/sdk-base-surface.txt" --candidate-surface "$RUNNER_TEMP/sdk-candidate-surface.txt" --base-sdk-root "$BASE_DIR" --candidate-sdk-root . --report "$RUNNER_TEMP/sdk-contract-report.json"
           cat "$RUNNER_TEMP/sdk-contract-report.json"
+
+  release-artifacts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout tested commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+      - name: Set up JDK 17
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          java-version: '17'
+          distribution: temurin
+          cache: maven
+      - name: Set up Node.js 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24'
+      - name: Build release artifacts with ProGuard
+        run: mvn -B -ntp verify -Pofficial-surveys -DskipTests
+      - name: Verify packaged release boundaries
+        run: |
+          mvn -B -ntp -pl pixivdownload-app -am test -Dtest=DistributionPackagingBoundaryTest -Dsurefire.failIfNoSpecifiedTests=false -Ddistribution.packaging.require-artifacts=true -Dexec.skip=true
+          REPORT=$(find pixivdownload-app/target/surefire-reports -name '*DistributionPackagingBoundaryTest.txt' -print -quit)
+          test -n "$REPORT"
+          grep -Eq 'Tests run: [1-9][0-9]*, Failures: 0, Errors: 0, Skipped: 0' "$REPORT"
 
   javascript-tests:
     runs-on: ubuntu-latest

--- a/scripts/ci/test/quality-gate-workflow.test.mjs
+++ b/scripts/ci/test/quality-gate-workflow.test.mjs
@@ -187,6 +187,36 @@ test('Quality Gate preserves required roles and the active event contract', () =
     }
 });
 
+test('Java tests and ProGuard run independently and both gate the required Java result', () => {
+    const { jobs } = load('.github/workflows/quality-gate.yml');
+    const owner = (pattern) => {
+        const matches = Object.keys(jobs).filter((id) => jobs[id].steps?.some((step) => pattern.test(step.run || '')));
+        assert.equal(matches.length, 1, `one execution owner for ${pattern}`);
+        return matches[0];
+    };
+    const ancestors = (id, visited = new Set()) => {
+        assert.ok(jobs[id], `dependency ${id} exists`);
+        if (visited.has(id)) return visited;
+        visited.add(id);
+        for (const dependency of [jobs[id].needs || []].flat()) ancestors(dependency, visited);
+        return visited;
+    };
+    const tests = owner(/\bmvn\b[^\n]*\btest\b[^\n]*-Duser\.language=/u);
+    const build = owner(/\bmvn\b[^\n]*\bverify\b/u);
+    assert.notEqual(tests, build);
+    assert.equal(ancestors(tests).has(build), false);
+    assert.equal(ancestors(build).has(tests), false);
+    const required = ancestors('java-tests');
+    for (const id of [tests, build, owner(/DistributionPackagingBoundaryTest/u), owner(/sdk-contract\.mjs/u)]) {
+        assert.ok(required.has(id), `java-tests must require ${id}`);
+    }
+    for (const id of required) {
+        assert.equal(jobs[id].if, undefined, `${id} must preserve dependency success`);
+        assert.ok(Number.isInteger(jobs[id]['timeout-minutes']) && jobs[id]['timeout-minutes'] > 0);
+        assert.ok(jobs[id]['continue-on-error'] === undefined || jobs[id]['continue-on-error'] === false);
+    }
+});
+
 test('发布链：所有凭据与写权限只在 release Environment 的门禁后使用', () => {
     const publish = load('.github/workflows/publish-plugins.yml');
     const publishAction = load('.github/actions/publish-official-plugins/action.yml');


### PR DESCRIPTION
## 变更内容

完整 Quality Gate 将 Java 测试 / SDK 合同与 ProGuard 构建 / 分发产物边界验证拆为两个并行 job，缩短两组验证串行等待的时间。两组分别从同一源码 checkout 独立执行，既有 `java-tests` required role 通过原生 `needs` 等待全部成功。

保留完整验证命令和产物要求。新增回归检查覆盖两组职责独立运行、必需检查的依赖覆盖和失败传播。两个 runner 分别恢复 Maven 依赖缓存，冷缓存可能增加重复下载和累计运行时间。

同一源码树的首次运行对照：[串行 PR QG](https://github.com/Sywyar/PixivDownloader/actions/runs/34044337988) 与 [并行分支 QG](https://github.com/Sywyar/PixivDownloader/actions/runs/34044347348) 均成功，三个 Java runner 命中相同 Maven 缓存键。完整 QG 的执行窗口从 23 分 08 秒降至 14 分 38 秒，减少 8 分 30 秒（36.7%）；累计 runner 时间从 25 分 56 秒增加至 29 分 03 秒，增加 3 分 07 秒（12.0%）。执行窗口按最早 job 开始到最后 job 完成计算，累计时间为各 job 时长之和，均不含排队和 App 证据核对。这是一组实测，后续耗时仍会受 runner 与缓存状况影响。

## 验证

- [x] QG workflow 聚焦回归：13 项通过
- [x] 完整 JavaScript 测试：296 项通过，零失败、零跳过
- [x] `npm run i18n:check` 通过，现有 1518 项 warning
- [x] `npm run gate:parity` 通过
- [x] 全量 `mvn -B -ntp verify -Pofficial-surveys -DskipTests` 通过
- [x] 构建后要求真实 artifact 的 `DistributionPackagingBoundaryTest`：19 项通过，零失败、零跳过
- [x] 当前 PR 的六项 App required checks 全部通过，head 与被测合并提交的来源证据复核通过
- [x] 分支 Quality Gate 的 8 项任务全部成功，实际并行运行与耗时对照完成

本次仅调整 CI 编排，无产品可见变化，README 与 CHANGELOG 不适用。中英文在线网络访问说明已通过 gh-pages 提交 `4c72aa83` 同步。
