### PR TITLE
fix(release): 保留 Spring 发行产物的反射与代理结构

### DIFF
--- a/build-support/proguard/plugin.pro
+++ b/build-support/proguard/plugin.pro
@@ -2,7 +2,8 @@
     public <init>(org.pf4j.PluginWrapper);
 }
 
--keep,includedescriptorclasses,allowoptimization @top.sywyar.pixivdownload.plugin.api.plugin.PluginManagedBean class * { *; }
+# child context 的受管 Bean 同样需要保留 Spring 代理结构。
+-keep,includedescriptorclasses @top.sywyar.pixivdownload.plugin.api.plugin.PluginManagedBean class * { *; }
 -keep,includedescriptorclasses,allowoptimization class * implements top.sywyar.pixivdownload.plugin.api.plugin.PixivPluginProvider { *; }
 
 -adaptresourcefilecontents plugin.properties,META-INF/spring/**

--- a/build-support/proguard/spring.pro
+++ b/build-support/proguard/spring.pro
@@ -1,15 +1,31 @@
--keep,includedescriptorclasses,allowoptimization @org.springframework.boot.autoconfigure.SpringBootApplication class * { *; }
--keep,includedescriptorclasses,allowoptimization @org.springframework.context.annotation.Configuration class * { *; }
--keep,includedescriptorclasses,allowoptimization @org.springframework.stereotype.Component class * { *; }
--keep,includedescriptorclasses,allowoptimization @org.springframework.stereotype.Service class * { *; }
--keep,includedescriptorclasses,allowoptimization @org.springframework.stereotype.Repository class * { *; }
--keep,includedescriptorclasses,allowoptimization @org.springframework.stereotype.Controller class * { *; }
--keep,includedescriptorclasses,allowoptimization @org.springframework.web.bind.annotation.RestController class * { *; }
--keep,includedescriptorclasses,allowoptimization @org.springframework.web.bind.annotation.RestControllerAdvice class * { *; }
--keep,includedescriptorclasses,allowoptimization @org.springframework.boot.context.properties.ConfigurationProperties class * { *; }
--keep,includedescriptorclasses,allowoptimization @org.apache.ibatis.annotations.Mapper interface * { *; }
+# Spring 反射与 CGLIB 代理依赖入口的可见性和可覆写性；不能允许优化器改写这些结构。
+-keep,includedescriptorclasses @org.springframework.boot.autoconfigure.SpringBootApplication class * { *; }
+-keep,includedescriptorclasses @org.springframework.context.annotation.Configuration class * { *; }
+-keep,includedescriptorclasses @org.springframework.stereotype.Component class * { *; }
+-keep,includedescriptorclasses @org.springframework.stereotype.Service class * { *; }
+-keep,includedescriptorclasses @org.springframework.stereotype.Repository class * { *; }
+-keep,includedescriptorclasses @org.springframework.stereotype.Controller class * { *; }
+-keep,includedescriptorclasses @org.springframework.web.bind.annotation.RestController class * { *; }
+-keep,includedescriptorclasses @org.springframework.web.bind.annotation.RestControllerAdvice class * { *; }
+-keep,includedescriptorclasses @org.springframework.boot.context.properties.ConfigurationProperties class * { *; }
+-keep,includedescriptorclasses @org.springframework.scheduling.annotation.Async class * { *; }
+-keep,includedescriptorclasses @org.springframework.transaction.annotation.Transactional class * { *; }
+-keep,includedescriptorclasses @org.apache.ibatis.annotations.Mapper interface * { *; }
 
--keepclassmembers,includedescriptorclasses,allowoptimization class * {
+# @Conditional 由 Spring 反射实例化，条件类的无参构造器不要求 public。
+-keep,includedescriptorclasses class * implements org.springframework.context.annotation.Condition {
+    <init>();
+}
+
+# 显式 @Bean 装配的普通类也可能需要代理，包括没有组件注解的非 public 事务方法。
+-keepclasseswithmembers,includedescriptorclasses class * {
+    @org.springframework.scheduling.annotation.Async <methods>;
+}
+-keepclasseswithmembers,includedescriptorclasses class * {
+    @org.springframework.transaction.annotation.Transactional <methods>;
+}
+
+-keepclassmembers,includedescriptorclasses class * {
     @org.springframework.context.annotation.Bean <methods>;
     @org.springframework.context.event.EventListener <methods>;
     @org.springframework.scheduling.annotation.Scheduled <methods>;
@@ -28,7 +44,7 @@
 -dontnote org.apache.ibatis.annotations.**
 -dontnote com.fasterxml.jackson.annotation.**
 
--keepclassmembers,includedescriptorclasses,allowoptimization class * {
+-keepclassmembers,includedescriptorclasses class * {
     public <init>(...);
     public <fields>;
     public <methods>;

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/DistributionPackagingBoundaryTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/DistributionPackagingBoundaryTest.java
@@ -4,6 +4,14 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.BeanUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.type.classreading.SimpleMetadataReaderFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.annotation.Transactional;
 import top.sywyar.pixivdownload.plugin.api.gui.DesktopUiProvider;
 import top.sywyar.pixivdownload.plugin.api.gui.GuiThemeContribution;
 import top.sywyar.pixivdownload.plugin.api.plugin.PixivFeaturePlugin;
@@ -39,6 +47,7 @@ import java.util.jar.JarFile;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * 插件分发打包边界守卫：把「主程序 boot jar 只含核心 + 内置插件、外置插件单独分发」这一发布形态不变量
@@ -371,12 +380,14 @@ class DistributionPackagingBoundaryTest {
     }
 
     @Test
-    @DisplayName("boot jar 条目黑名单：不含外置插件实现包、静态资源、i18n 与私有依赖")
+    @DisplayName("boot jar 保留宿主契约与 Spring 运行时结构，不含外置插件实现和私有依赖")
     void bootJarEntriesExcludeExternalPluginPayloads(@TempDir Path tempDir) throws Exception {
         Path bootJar = locateBootJar();
         requireAvailable(bootJar != null,
                 "boot jar 尚未生成（需 package 阶段），无法执行 jar 条目级边界验证");
 
+        assertThat(assertSpringRuntimeStructure(bootJar))
+                .as("实际 boot jar 必须包含需要 CGLIB 增强的配置类").isPositive();
         List<String> entries = jarEntryNames(bootJar);
         assertThat(entries).as("宿主一方模块应合并进优化后的 BOOT-INF/classes")
                 .contains(
@@ -816,6 +827,68 @@ class DistributionPackagingBoundaryTest {
         assertThat(metadata.getProperty("shrink")).isEqualTo("true");
         assertThat(metadata.getProperty("optimize")).isEqualTo("true");
         assertThat(metadata.getProperty("obfuscate")).isEqualTo("false");
+        assertSpringRuntimeStructure(jar);
+    }
+
+    private static int assertSpringRuntimeStructure(Path jar) {
+        int fullConfigurations = 0;
+        var readers = new SimpleMetadataReaderFactory();
+        try (JarFile jarFile = new JarFile(jar.toFile())) {
+            var entries = jarFile.entries();
+            while (entries.hasMoreElements()) {
+                JarEntry entry = entries.nextElement();
+                String name = entry.getName();
+                if (!name.endsWith(".class") || !(name.startsWith("top/sywyar/")
+                        || name.startsWith("BOOT-INF/classes/top/sywyar/"))) {
+                    continue;
+                }
+                try (InputStream input = jarFile.getInputStream(entry)) {
+                    byte[] bytecode = input.readAllBytes();
+                    var type = readers.getMetadataReader(new ByteArrayResource(bytecode))
+                            .getAnnotationMetadata();
+                    if (type.isInterface()) {
+                        continue;
+                    }
+                    if (List.of(type.getInterfaceNames()).contains(Condition.class.getName())) {
+                        // 单独定义产物类，避免父 classloader 的开发 classes 掩盖构造器收缩。
+                        Class<?> condition = new ClassLoader(DistributionPackagingBoundaryTest.class.getClassLoader()) {
+                            Class<?> artifactClass() {
+                                return defineClass(type.getClassName(), bytecode, 0, bytecode.length);
+                            }
+                        }.artifactClass();
+                        assertThatCode(() -> BeanUtils.instantiateClass(condition))
+                                .as("%s!/%s 必须允许 Spring 反射实例化条件类", jar, name)
+                                .doesNotThrowAnyException();
+                    }
+                    var configuration = type.getAnnotations().get(Configuration.class);
+                    boolean fullConfiguration = configuration.isPresent()
+                            && configuration.getBoolean("proxyBeanMethods");
+                    if (fullConfiguration) {
+                        fullConfigurations++;
+                    }
+                    boolean classAdvice = type.isAnnotated(Async.class.getName())
+                            || type.isAnnotated(Transactional.class.getName());
+                    boolean needsProxy = fullConfiguration || classAdvice;
+                    for (var method : type.getDeclaredMethods()) {
+                        boolean intercepted = (fullConfiguration && method.isAnnotated(Bean.class.getName()))
+                                || method.isAnnotated(Async.class.getName())
+                                || method.isAnnotated(Transactional.class.getName());
+                        if (intercepted && !method.isStatic()) {
+                            needsProxy = true;
+                            assertThat(method.isOverridable())
+                                    .as("%s!/%s#%s 必须允许 Spring 代理覆写", jar, name, method.getMethodName())
+                                    .isTrue();
+                        }
+                    }
+                    if (needsProxy) {
+                        assertThat(type.isFinal()).as("%s!/%s 必须允许 Spring 创建子类代理", jar, name).isFalse();
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("无法验证发行 JAR 的 Spring 运行时结构: " + jar, e);
+        }
+        return fullConfigurations;
     }
 
     private static void assertContractClassesPresent(List<String> entries, String module) {


### PR DESCRIPTION
## 变更内容

修复 ProGuard 优化后发行包无法启动的问题：Spring 配置类和需要代理的方法被改为不可覆写，条件类的无参构造器也可能被移除。共享 keep 规则保留这些运行时结构，并在现有产物边界测试中直接检查应用及官方插件 JAR，使用 Spring 实际实例化产物中的条件类。

## 验证

- [x] `mvn -B -ntp verify -Pofficial-surveys -DskipTests` 完整构建成功，包含 ProGuard 最终产物。
- [x] `DistributionPackagingBoundaryTest` 在要求真实 artifact 的模式下通过：19 项测试，失败、错误和跳过均为 0。
- [x] 新增检查可拒绝原 Nightly 的 final 配置类，以及缺少条件类无参构造器的产物。
- [x] 使用打包目录中的 JVM 完成真实 setup、健康检查、登录与插件状态验收；13 个外置插件全部 STARTED，未进入恢复模式。测试使用现有安装器对精确 SHA-256 确认的本地未签名插件；应用及插件与最终构建的 14 个 SHA-256 全部一致。
- [x] [PR 完整 Quality Gate](https://github.com/Sywyar/PixivDownloader/actions/runs/34184888532) 成功；六项 required checks 在当前 head 与原测试合并对象上均由指定 App 签发，并通过执行来源、双亲和内容树复核。
- [ ] 正式签名 Java 标准包、full-offline 包及 Windows 安装器的完整 Actions E2E；本地 JVM 验证不代替这项验收。

未修改 workflow 或 Gate。相对最新正式版 v1.13.1，本次修复未发布构建流程中的回归，CHANGELOG 不新增条目；README 和在线使用文档无需调整。本地未签名打包产生旧 provenance 的独立问题另行处理。
