### PR TITLE
fix(release): 修复 Nightly 插件加载与发行物验收

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Verify packaged release boundaries
         uses: ./.github/actions/verify-release-boundaries
         with:
-          additional_tests: StagedFileDeletionTest#rejectsWindowsJunctionBeforeStaging,WorkDeletionFileRollbackTest#novelJunctionAbortsFilesAndSoftDelete,DeleteStagingManifestTest#rejectsWindowsJunctionParentDuringRecovery
+          additional_tests: StagedFileDeletionTest#rejectsWindowsJunctionBeforeStaging,WorkDeletionFileRollbackTest#novelJunctionAbortsFilesAndSoftDelete,DeleteStagingManifestTest#rejectsWindowsJunctionParentDuringRecovery,PluginReleaseScriptsTest#releaseArtifactCleanupHandlesSealedPermissions+releaseArtifactFailurePrintsDiagnosticTail
 
   javascript-tests:
     runs-on: ubuntu-latest

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
@@ -1119,6 +1119,88 @@ class PluginReleaseScriptsTest {
     }
 
     @Test
+    @DisplayName("发行物验收清理封存快照权限并拒绝越界和目录链接")
+    void releaseArtifactCleanupHandlesSealedPermissions(@TempDir Path tempDir) throws Exception {
+        assumeTrue(System.getProperty("os.name").startsWith("Windows"));
+        String output = runPowerShell(releaseAcceptanceFunctions() + "$WorkRoot = '" + psQuote(tempDir) + "'\n" + """
+                $context = New-TestSessionRoot
+                $load = New-Item -ItemType Directory -Path (Join-Path $context.Session 'snapshot/load')
+                $file = Join-Path $load.FullName 'plugin.jar'
+                [IO.File]::WriteAllText($file, 'sealed bytes')
+                foreach ($path in @($file, $load.FullName)) {
+                    $acl = Get-Acl -LiteralPath $path
+                    $acl.SetAccessRuleProtection($true, $false)
+                    $rule = [Security.AccessControl.FileSystemAccessRule]::new(
+                        [Security.Principal.WindowsIdentity]::GetCurrent().User,
+                        'ReadAndExecute, ChangePermissions, Synchronize', 'Allow')
+                    $acl.SetAccessRule($rule)
+                    Set-Acl -LiteralPath $path -AclObject $acl
+                }
+                Remove-TestSessionRoot $context
+                if (Test-Path -LiteralPath $context.Session) { throw 'Sealed session was not removed' }
+                $outside = New-Item -ItemType Directory -Path (Join-Path $WorkRoot 'outside')
+                $sentinel = Join-Path $outside.FullName 'sentinel.txt'
+                [IO.File]::WriteAllText($sentinel, 'preserved')
+                try {
+                    Remove-TestSessionRoot ([pscustomobject]@{Base=$WorkRoot; Session=$outside.FullName})
+                    throw 'Unsafe root accepted'
+                } catch {
+                    if ($_.Exception.Message -notlike '*unsafe test session root*') { throw }
+                }
+                $context = New-TestSessionRoot
+                $link = Join-Path $context.Session 'linked-directory'
+                New-Item -ItemType Junction -Path $link -Target $outside.FullName | Out-Null
+                try {
+                    Remove-TestSessionRoot $context
+                    throw 'Reparse point accepted'
+                } catch {
+                    if ($_.Exception.Message -notlike '*reparse points*') { throw }
+                } finally {
+                    [IO.Directory]::Delete($link)
+                    Remove-TestSessionRoot $context
+                }
+                if ([IO.File]::ReadAllText($sentinel) -ne 'preserved') { throw 'Outside content changed' }
+                'CLEANUP-PASS'
+                """);
+        assertThat(output).contains("CLEANUP-PASS");
+    }
+
+    @Test
+    @DisplayName("发行物启动失败输出原始错误和有界日志尾部")
+    void releaseArtifactFailurePrintsDiagnosticTail(@TempDir Path tempDir) throws Exception {
+        assumeTrue(System.getProperty("os.name").startsWith("Windows"));
+        Files.writeString(tempDir.resolve("plugins-manifest.json"), "[{\"id\":\"probe\"}]", StandardCharsets.UTF_8);
+        Files.writeString(tempDir.resolve("run.bat"), "@echo off\r\necho OMITTED-LOG-HEAD\r\n"
+                + "for /l %%i in (1,1,205) do echo diagnostic-line-%%i\r\nexit /b 17\r\n",
+                StandardCharsets.UTF_8);
+        CommandResult result = runPowerShellResult(releaseAcceptanceFunctions()
+                + "$root = '" + psQuote(tempDir) + "'\n" + """
+                $Username = 'release-e2e'
+                $Password = 'ReleaseE2ePassword2026'
+                Test-ApplicationLayout -Label 'failed-fixture' -Root $root -Launcher (Join-Path $root 'run.bat') `
+                    -RuntimeRoot (Join-Path $root 'runtime') -LogRoot (Join-Path $root 'e2e')
+                """);
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.output()).contains("setup failed with exit code 17", "diagnostic-line-205")
+                .doesNotContain("OMITTED-LOG-HEAD");
+    }
+
+    private static String releaseAcceptanceFunctions() {
+        return """
+                $ErrorActionPreference = 'Stop'
+                $tokens = $null
+                $errors = $null
+                $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+                    (Join-Path (Get-Location) 'scripts/test-release-artifacts.ps1'), [ref]$tokens, [ref]$errors)
+                if ($errors.Count -ne 0) { throw 'Invalid acceptance script' }
+                foreach ($function in $ast.FindAll({param($node)
+                    $node -is [System.Management.Automation.Language.FunctionDefinitionAst]}, $false)) {
+                    . ([scriptblock]::Create($function.Extent.Text))
+                }
+                """;
+    }
+
+    @Test
     @DisplayName("真实分发入口接受合并的 SDK 契约并拒绝插件实现、资源和私有依赖")
     void distributionAssemblerChecksExactPrebuiltJar(@TempDir Path tempDir) throws Exception {
         Path jar = tempDir.resolve("candidate.jar");

--- a/pixivdownload-plugin-runtime/src/main/java/top/sywyar/pixivdownload/plugin/runtime/PluginRuntimeManager.java
+++ b/pixivdownload-plugin-runtime/src/main/java/top/sywyar/pixivdownload/plugin/runtime/PluginRuntimeManager.java
@@ -1,9 +1,11 @@
 package top.sywyar.pixivdownload.plugin.runtime;
 
 import org.pf4j.DefaultPluginManager;
+import org.pf4j.DefaultVersionManager;
 import org.pf4j.PluginManager;
 import org.pf4j.PluginState;
 import org.pf4j.PluginWrapper;
+import org.pf4j.VersionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import top.sywyar.pixivdownload.plugin.runtime.artifact.PluginArtifactLoadPlan;
@@ -19,6 +21,7 @@ import top.sywyar.pixivdownload.plugin.runtime.artifact.PreparedPluginArtifact;
 import top.sywyar.pixivdownload.plugin.runtime.context.PluginContextModule;
 import top.sywyar.pixivdownload.plugin.runtime.descriptor.PluginDescriptor;
 import top.sywyar.pixivdownload.plugin.runtime.descriptor.PluginExecutionMode;
+import top.sywyar.pixivdownload.plugin.runtime.descriptor.VersionRequirement;
 import top.sywyar.pixivdownload.plugin.runtime.install.model.PluginPackageInspection;
 import top.sywyar.pixivdownload.plugin.runtime.install.model.PluginPackageLimits;
 import top.sywyar.pixivdownload.plugin.runtime.install.model.PluginPackageOrigin;
@@ -1071,7 +1074,20 @@ public class PluginRuntimeManager {
 
     private void ensureManager(Path root) {
         if (pluginManager == null) {
-            pluginManager = new DefaultPluginManager(root);
+            pluginManager = new DefaultPluginManager(root) {
+                @Override
+                protected VersionManager createVersionManager() {
+                    return new DefaultVersionManager() {
+                        @Override
+                        public boolean checkVersionConstraint(String version, String constraint) {
+                            VersionRequirement actual = VersionRequirement.parse(version);
+                            return actual.present() && actual.valid()
+                                    && VersionRequirement.parse(constraint)
+                                            .isSatisfiedBy(actual.major(), actual.minor());
+                        }
+                    };
+                }
+            };
         }
     }
 

--- a/pixivdownload-plugin-runtime/src/test/java/top/sywyar/pixivdownload/plugin/runtime/PluginRuntimeManagerTest.java
+++ b/pixivdownload-plugin-runtime/src/test/java/top/sywyar/pixivdownload/plugin/runtime/PluginRuntimeManagerTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.pf4j.PluginManager;
 import org.pf4j.PluginState;
 import org.pf4j.PluginWrapper;
@@ -1124,6 +1126,50 @@ class PluginRuntimeManagerTest {
         }
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "1.0.0, 1.0, true",
+            "1.0.0-nightly.20260908.125.1, 1.0, true",
+            "1.2.3, 1.1, true",
+            "1.2.3-beta.1, >=1.1, true",
+            "2.0.0, 1.0, false",
+            "1.0.0, 1.1, false"
+    })
+    @DisplayName("真实插件加载与启动扫描使用相同的主次版本兼容规则")
+    void dependencyVersionsAgreeWithRuntimeAdmission(String version, String requirement, boolean compatible)
+            throws IOException {
+        Path plugins = tempDir.resolve("versioned-dependencies");
+        Path provider = plugins.resolve("provider.jar");
+        Path dependent = plugins.resolve("dependent.jar");
+        writeDependencyOrderProbeJar(provider, "provider", version, List.of());
+        writeDependencyOrderProbeJar(dependent, "dependent",
+                List.of(new PluginDependencyRef("provider", requirement, false)));
+        writeLocalProvenance(plugins, provider, "provider", version);
+        writeLocalProvenance(plugins, dependent, "dependent", PROBE_VERSION);
+        PluginRuntimeManager manager = new PluginRuntimeManager(plugins);
+        try {
+            manager.loadPlugin(provider);
+            if (compatible) {
+                manager.loadPlugin(dependent);
+            } else {
+                assertThatThrownBy(() -> manager.loadPlugin(dependent))
+                        .isInstanceOf(PluginRuntimeOperationException.class);
+            }
+            manager.shutdown();
+            PluginRuntimeStatus status = manager.start();
+            if (compatible) {
+                assertThat(status.failures()).isEmpty();
+                assertThat(status.startedPluginIds()).containsExactly("provider", "dependent");
+            } else {
+                assertThat(status.startedPluginIds()).containsExactly("provider");
+                assertThat(status.failures()).singleElement().satisfies(failure ->
+                        assertThat(failure.reason()).contains("required dependency provider needs version"));
+            }
+        } finally {
+            manager.shutdown();
+        }
+    }
+
     @Test
     @DisplayName("启动扫描：缺少必需依赖时跳过依赖方，不把半加载包交给 PF4J")
     void startupSkipsPluginWithMissingRequiredDependencyBeforePf4jLoad() throws IOException {
@@ -1958,10 +2004,15 @@ class PluginRuntimeManagerTest {
 
     private static void writeDependencyOrderProbeJar(Path jar, String pluginId,
                                                      List<PluginDependencyRef> dependencies) throws IOException {
+        writeDependencyOrderProbeJar(jar, pluginId, PROBE_VERSION, dependencies);
+    }
+
+    private static void writeDependencyOrderProbeJar(Path jar, String pluginId, String version,
+                                                     List<PluginDependencyRef> dependencies) throws IOException {
         Files.createDirectories(jar.getParent());
         try (OutputStream out = Files.newOutputStream(jar);
              ZipOutputStream zos = new ZipOutputStream(out)) {
-            addDependencyOrderDescriptor(zos, pluginId, dependencies);
+            addDependencyOrderDescriptor(zos, pluginId, version, dependencies);
             addClassEntry(zos, DependencyOrderProbePlugin.class, "");
             addClassEntry(zos, DependencyOrderProbeFeaturePlugin.class, "");
         }
@@ -2100,9 +2151,14 @@ class PluginRuntimeManagerTest {
 
     private static void addDependencyOrderDescriptor(ZipOutputStream zos, String pluginId,
                                                      List<PluginDependencyRef> dependencies) throws IOException {
+        addDependencyOrderDescriptor(zos, pluginId, PROBE_VERSION, dependencies);
+    }
+
+    private static void addDependencyOrderDescriptor(ZipOutputStream zos, String pluginId, String version,
+                                                     List<PluginDependencyRef> dependencies) throws IOException {
         StringBuilder props = new StringBuilder()
                 .append("plugin.id=").append(pluginId).append('\n')
-                .append("plugin.version=").append(PROBE_VERSION).append('\n')
+                .append("plugin.version=").append(version).append('\n')
                 .append("plugin.requires=1.0\n")
                 .append("plugin.class=").append(DependencyOrderProbePlugin.class.getName()).append('\n')
                 .append("plugin.provider=test\n")

--- a/scripts/ci/test/quality-gate-workflow.test.mjs
+++ b/scripts/ci/test/quality-gate-workflow.test.mjs
@@ -236,6 +236,7 @@ test('QG 覆盖 Compose、SDK 消费者和两种 PowerShell，并顺序复用构
     const boundaryCall = artifacts.find(step => step.uses === './.github/actions/verify-release-boundaries');
     assert.deepEqual(boundaryCall.with.additional_tests.split(',').sort(),
         ['DeleteStagingManifestTest#rejectsWindowsJunctionParentDuringRecovery',
+            'PluginReleaseScriptsTest#releaseArtifactCleanupHandlesSealedPermissions+releaseArtifactFailurePrintsDiagnosticTail',
             'StagedFileDeletionTest#rejectsWindowsJunctionBeforeStaging',
             'WorkDeletionFileRollbackTest#novelJunctionAbortsFilesAndSoftDelete']);
     const sources = executionSteps(jobs['java-unit-tests']);

--- a/scripts/test-release-artifacts.ps1
+++ b/scripts/test-release-artifacts.ps1
@@ -65,6 +65,18 @@ function Remove-TestSessionRoot {
         (Split-Path -Leaf $candidate) -notlike "pixiv-release-e2e-*") {
         throw "Refusing to remove unsafe test session root: $candidate"
     }
+    $entries = @((Get-Item -LiteralPath $candidate -Force)) +
+        @(Get-ChildItem -LiteralPath $candidate -Force -Recurse)
+    if (@($entries | Where-Object {
+        $_.Attributes -band [System.IO.FileAttributes]::ReparsePoint
+    }).Count -ne 0) {
+        throw "Refusing to change permissions in a test session containing reparse points: $candidate"
+    }
+    # Forced process termination leaves plugin snapshots sealed read-only.
+    & icacls.exe $candidate /reset /T /L /Q | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to restore test session permissions: $candidate"
+    }
     Remove-Item -LiteralPath $candidate -Recurse -Force
 }
 
@@ -238,20 +250,19 @@ function Test-ApplicationLayout {
     $manifestPath = Get-ManifestPath $Root
     $expectedPluginIds = @(Read-ExpectedPluginIds $manifestPath)
     Set-IsolatedRuntimeEnvironment $RuntimeRoot
-    $setup = Start-ArtifactProcess -Launcher $Launcher -WorkingDirectory $Root -Arguments @(
-        "--setup",
-        "--username=$Username",
-        "--password=$Password",
-        "--mode=solo",
-        "--proxy-enabled=false"
-    ) -LogPrefix "$LogRoot-setup" -Wait
-    if ($setup.ExitCode -ne 0) {
-        throw "$Label setup failed with exit code $($setup.ExitCode)"
-    }
-
-    $port = Get-FreePort
     $application = $null
     try {
+        $setup = Start-ArtifactProcess -Launcher $Launcher -WorkingDirectory $Root -Arguments @(
+            "--setup",
+            "--username=$Username",
+            "--password=$Password",
+            "--mode=solo",
+            "--proxy-enabled=false"
+        ) -LogPrefix "$LogRoot-setup" -Wait
+        if ($setup.ExitCode -ne 0) {
+            throw "$Label setup failed with exit code $($setup.ExitCode)"
+        }
+        $port = Get-FreePort
         $application = Start-ArtifactProcess -Launcher $Launcher -WorkingDirectory $Root -Arguments @(
             "--no-gui",
             "--server.address=127.0.0.1",
@@ -260,6 +271,16 @@ function Test-ApplicationLayout {
         Wait-ForHealthyApplication -Port $port -Process $application -Label $Label
         Assert-PluginRuntimeStatus -Port $port -ExpectedPluginIds $expectedPluginIds -Label $Label
         Write-Host "PASS: $Label ($($expectedPluginIds.Count) external plugin(s))" -ForegroundColor Green
+    } catch {
+        Write-Host "FAIL: $Label - $($_.Exception.Message)"
+        foreach ($log in @("$LogRoot-setup.stdout.log", "$LogRoot-setup.stderr.log",
+                "$LogRoot-application.stdout.log", "$LogRoot-application.stderr.log")) {
+            if (Test-Path -LiteralPath $log -PathType Leaf) {
+                Write-Host "Log: $log (last 200 lines)"
+                Get-Content -LiteralPath $log -Encoding UTF8 -Tail 200
+            }
+        }
+        throw
     } finally {
         Stop-ArtifactProcess $application
     }


### PR DESCRIPTION
## 变更内容

修复 Nightly 发行物验收失败：PF4J 加载现在复用宿主已有的主次版本兼容规则，使 `notification@1.0` 等依赖能够接受兼容的 nightly 版本，mail、push 和 multi-mode-decision-survey 可正常启动。跨主版本或低于要求的次版本仍被拒绝。

E2E 在强制结束应用后恢复测试会话的继承 ACL，再清理封存快照；仅处理指定父目录下本次创建的会话，并拒绝 reparse point。setup 或运行验收失败时，在清理前输出原始错误和四份日志各自末尾 200 行。

## 影响范围

- [x] 变更仅涉及插件依赖加载、发行物 E2E、对应回归测试及 Windows CI 接线。
- [x] 已检查文档和 CHANGELOG：相对最新正式发布 v1.13.1，本次修复属于未发布功能及内部验收，无需新增发布条目或修改使用说明。

## 验证

- [x] 插件运行时、版本解析、依赖计划和状态回归：102 项通过；新增用例在旧实现下复现 nightly 和较新次版本依赖加载失败。
- [x] `mvn -B -ntp verify -Pofficial-surveys -DskipTests`：25 模块构建及 ProGuard 产物成功。
- [x] 按 Windows QG 的同一选择器执行发行 artifact 边界、Junction 和 PowerShell 清理、越界拒绝、失败日志回归：24 项通过，无跳过。
- [x] Windows PowerShell 5.1 与 PowerShell 7 语法检查通过。
- [x] 新核心与 Nightly #125 的原始官方签名插件组装后，Java 标准包及 full-offline 包均完成初始化、启动、登录及全部 13 个外置插件 STARTED 验收，测试会话清理成功。
- [x] `git diff --check`、本地 commit/push hooks 和远端 Ruleset doctor 通过。
- [x] 完整 JavaScript 测试（本机 Git Bash 环境）、i18n 检查和 Gate parity 通过。
- [x] 当前 PR 测试合并对象的完整 Quality Gate 及六项绑定 App 的 required checks 全部成功。
- [x] 合并后的 [Nightly #126](https://github.com/Sywyar/PixivDownloader/actions/runs/34199577742) 全部 16 个任务成功：Java 标准包、full-offline 包、Windows 安装器均完成真实运行验收，每种均启动 13 个外置插件；安装器卸载和测试会话清理成功。
- [x] `1.14.0-nightly.20260908.126.1` 已发布，nightly 标签指向合并提交 `8fcb834f2a1e2ffc67fe289261559b64c07d1a34`；5 个附件齐全，下载的更新清单通过官方应用更新用途验签，安装器 URL、大小和 SHA-256 与已发布附件一致。

Quality Gate 只追加两个 Windows 测试选择器，并同步清单断言；既有权限、触发器、required roles、失败传播和 Ruleset 保持不变。
