### PR TITLE
fix(release): 修复发行验收探针的启动竞态

### DIFF
--- a/scripts/release-e2e/ReleaseProbeAgent.java
+++ b/scripts/release-e2e/ReleaseProbeAgent.java
@@ -117,10 +117,16 @@ public final class ReleaseProbeAgent {
     }
 
     private static Class<?> launcher() {
+        Class<?> launcher = findLauncher();
+        if (launcher != null) return launcher;
+        throw new IllegalStateException("Application entry has not loaded");
+    }
+
+    private static Class<?> findLauncher() {
         for (Class<?> type : instrumentation.getAllLoadedClasses()) {
             if (type.getName().equals("top.sywyar.pixivdownload.gui.GuiLauncher")) return type;
         }
-        throw new IllegalStateException("Application entry has not loaded");
+        return null;
     }
 
     private static ClassLoader pluginLoader(String id) throws Exception {
@@ -138,7 +144,10 @@ public final class ReleaseProbeAgent {
     }
 
     private static String desktop() throws Exception {
-        Object ui = ((AtomicReference<?>) field(launcher(), null, "ACTIVE_UI")).get();
+        Class<?> launcher = findLauncher();
+        // premain 观测器可先于应用入口响应；未加载只表示桌面仍需等待。
+        if (launcher == null) return "\"applicationLoaded\":false";
+        Object ui = ((AtomicReference<?>) field(launcher, null, "ACTIVE_UI")).get();
         String provider = "";
         if (ui != null) {
             Object source = field(ui.getClass(), ui, "activeSource");
@@ -188,7 +197,7 @@ public final class ReleaseProbeAgent {
             }
             colors = content.size();
         }
-        return "\"pid\":" + ProcessHandle.current().pid() + ",\"provider\":" + quote(provider)
+        return "\"applicationLoaded\":true,\"pid\":" + ProcessHandle.current().pid() + ",\"provider\":" + quote(provider)
                 + ",\"bootstrapPrompts\":" + desktop.bootstrapPrompts() + ",\"contentColors\":" + colors
                 + ",\"bootstrapTextRendered\":" + desktop.bootstrapTextRendered()
                 + ",\"windows\":" + desktop.windows();

--- a/scripts/release-e2e/fixtures/DelayedLauncher.java
+++ b/scripts/release-e2e/fixtures/DelayedLauncher.java
@@ -1,0 +1,20 @@
+package top.sywyar.pixivdownload.gui;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** 用文件握手控制入口类加载，让真实观测器稳定遇到启动中的应用。 */
+public final class DelayedLauncher {
+    public static void main(String[] args) throws Exception {
+        Path directory = Path.of(args[0]);
+        while (!Files.exists(directory.resolve("load"))) Thread.sleep(20);
+        Class.forName("top.sywyar.pixivdownload.gui.GuiLauncher");
+        while (!Files.exists(directory.resolve("exit"))) Thread.sleep(20);
+    }
+}
+
+/** 仅在隔离测试 JVM 中提供观测器实际读取的入口状态。 */
+final class GuiLauncher {
+    private static final AtomicReference<Object> ACTIVE_UI = new AtomicReference<>();
+}

--- a/scripts/release-e2e/runtime.ps1
+++ b/scripts/release-e2e/runtime.ps1
@@ -162,6 +162,7 @@ function Wait-ReleaseDesktop {
 
 function Test-ReleaseDesktopReady {
     param($Desktop, [string]$Provider, [switch]$BootstrapPrompt)
+    if (-not $Desktop.applicationLoaded) { return $false }
     $rendered = if ($BootstrapPrompt) { $Desktop.bootstrapTextRendered } else { $Desktop.contentColors -gt 8 }
     return $Desktop.provider -eq $Provider -and $Desktop.bootstrapPrompts -eq [int][bool]$BootstrapPrompt `
         -and @($Desktop.windows).Count -gt 0 -and $rendered

--- a/scripts/release-e2e/runtime.test.ps1
+++ b/scripts/release-e2e/runtime.test.ps1
@@ -46,13 +46,53 @@ try {
         Remove-Item -LiteralPath (Join-Path $probe 'request.txt')
     }
 
-    $good = [pscustomobject]@{provider='gui-compose'; bootstrapPrompts=0; contentColors=30; windows=@('window')}
+    $agentRoot = Join-Path $context.Session 'startup-agent'
+    $agentClasses = Join-Path $agentRoot 'classes'
+    $startupProbe = Join-Path $agentRoot 'probe'
+    New-Item -ItemType Directory -Path $agentClasses, $startupProbe | Out-Null
+    & javac --release 17 -encoding UTF-8 -d $agentClasses `
+        (Join-Path $PSScriptRoot 'ReleaseProbeAgent.java') `
+        (Join-Path $PSScriptRoot 'fixtures/DelayedLauncher.java')
+    if ($LASTEXITCODE -ne 0) { throw 'Cannot compile startup observer regression.' }
+    $manifest = Join-Path $agentRoot 'manifest.mf'
+    [IO.File]::WriteAllText($manifest, "Premain-Class: releasee2e.ReleaseProbeAgent`n`n", [Text.Encoding]::ASCII)
+    $agentJar = Join-Path $agentRoot 'observer.jar'
+    & jar --create --file $agentJar --manifest $manifest -C $agentClasses .
+    if ($LASTEXITCODE -ne 0) { throw 'Cannot package startup observer regression.' }
+    $child = Start-Process java -ArgumentList @(
+        "-javaagent:`"$agentJar=$startupProbe`"", '-cp', "`"$agentClasses`"",
+        'top.sywyar.pixivdownload.gui.DelayedLauncher', "`"$startupProbe`""
+    ) -PassThru -WindowStyle Hidden -RedirectStandardOutput (Join-Path $agentRoot 'stdout.log') `
+        -RedirectStandardError (Join-Path $agentRoot 'stderr.log')
+    $children += $child
+    $null = $child.Handle
+    Connect-ReleaseProbe $child $startupProbe
+    $desktop = Invoke-ReleaseProbe $child $startupProbe 'desktop'
+    if ($desktop.applicationLoaded) { throw 'Observer loaded the application entry prematurely.' }
+    Assert-Rejected { Wait-ReleaseDesktop $child $startupProbe '' -BootstrapPrompt -TimeoutSeconds 1 } 'did not render'
+    Assert-Rejected { Invoke-ReleaseProbe $child $startupProbe 'shutdown' } 'Application entry has not loaded'
+    New-Item -ItemType File -Path (Join-Path $startupProbe 'load') | Out-Null
+    $deadline = [DateTime]::UtcNow.AddSeconds(15)
+    do {
+        $desktop = Invoke-ReleaseProbe $child $startupProbe 'desktop'
+        if ($desktop.applicationLoaded) { break }
+        if ([DateTime]::UtcNow -ge $deadline) { throw 'Observer did not see the delayed entry load.' }
+        Start-Sleep -Milliseconds 50
+    } while ($true)
+    if (Test-ReleaseDesktopReady $desktop '' -BootstrapPrompt) { throw 'Loaded entry without a window was accepted.' }
+    Assert-Rejected { Invoke-ReleaseProbe $child $startupProbe 'unknown-command' } 'Unknown probe command'
+    New-Item -ItemType File -Path (Join-Path $startupProbe 'exit') | Out-Null
+    Wait-ArtifactProcessExit $child 'Delayed entry fixture' 15
+    if ($child.ExitCode -ne 0) { throw "Delayed entry fixture failed with code $($child.ExitCode)." }
+    Assert-Rejected { Wait-ReleaseDesktop $child $startupProbe '' -BootstrapPrompt -TimeoutSeconds 1 } 'exited'
+
+    $good = [pscustomobject]@{applicationLoaded=$true; provider='gui-compose'; bootstrapPrompts=0; contentColors=30; windows=@('window')}
     if (-not (Test-ReleaseDesktopReady $good 'gui-compose')) { throw 'Rendered GUI rejected.' }
     foreach ($bad in @(
-        [pscustomobject]@{provider='gui-swing'; bootstrapPrompts=0; contentColors=30; windows=@('window')},
-        [pscustomobject]@{provider='gui-compose'; bootstrapPrompts=0; contentColors=1; windows=@('window')},
-        [pscustomobject]@{provider='gui-compose'; bootstrapPrompts=0; contentColors=30; windows=@()},
-        [pscustomobject]@{provider=''; bootstrapPrompts=1; contentColors=30; windows=@('dialog'); bootstrapTextRendered=$true}
+        [pscustomobject]@{applicationLoaded=$true; provider='gui-swing'; bootstrapPrompts=0; contentColors=30; windows=@('window')},
+        [pscustomobject]@{applicationLoaded=$true; provider='gui-compose'; bootstrapPrompts=0; contentColors=1; windows=@('window')},
+        [pscustomobject]@{applicationLoaded=$true; provider='gui-compose'; bootstrapPrompts=0; contentColors=30; windows=@()},
+        [pscustomobject]@{applicationLoaded=$true; provider=''; bootstrapPrompts=1; contentColors=30; windows=@('dialog'); bootstrapTextRendered=$true}
     )) {
         if (Test-ReleaseDesktopReady $bad 'gui-compose') { throw 'Wrong, blank or absent GUI accepted.' }
     }
@@ -69,6 +109,19 @@ try {
     Assert-Rejected { Wait-ReleaseDesktop $parent $probe 'gui-compose' -TimeoutSeconds 1 } 'did not render'
     function Invoke-ReleaseProbe { throw 'EDT unresponsive' }
     Assert-Rejected { Wait-ReleaseDesktop $parent $probe 'gui-compose' -TimeoutSeconds 1 } 'EDT unresponsive'
+    foreach ($bootstrap in @($false, $true)) {
+        $ready = if ($bootstrap) { $bad } else { $good }
+        $bad.bootstrapPrompts = 1
+        $script:desktopReads = 0
+        function Invoke-ReleaseProbe {
+            if (++$script:desktopReads -eq 1) { return [pscustomobject]@{applicationLoaded=$false} }
+            return $ready
+        }
+        $observed = Wait-ReleaseDesktop $parent $probe $ready.provider -BootstrapPrompt:$bootstrap -TimeoutSeconds 3
+        if ($script:desktopReads -ne 2 -or -not $observed.applicationLoaded) {
+            throw 'Desktop wait did not retry startup readiness.'
+        }
+    }
     Set-Item Function:Invoke-ReleaseProbe $savedProbe
 
     # Drive the real observation loop with a process which exits after readiness.


### PR DESCRIPTION
## 变更内容

发行验收的 Java agent 在 premain 中启动，可能先于 GuiLauncher 加载响应请求，导致 windows-installer-no-gui 将正常启动过程误判为失败。桌面探针现返回应用入口是否已加载，等待逻辑在原有期限内继续轮询；真实观测器异常、提前退出、窗口未渲染及事件线程阻塞仍会失败。

增加独立 JVM 中的延迟加载回归，覆盖入口尚未加载、加载完成但无窗口、提前退出及命令异常。

## 验证

- [x] 新增真实观测器回归在修复前复现原异常，修复后通过 Windows PowerShell 5.1 和 PowerShell 7 验证。
- [x] 两种 PowerShell 的脚本语法检查通过。
- [x] i18n 检查及 Gate parity 通过。
- [x] 全量 JavaScript 测试通过：297 项成功，零失败、零跳过；Windows 本地执行使用 Git Bash。
- [x] PR Quality Gate 34297029267 及六项 App required checks 全部通过；已核对当前 head、实际被测合并对象、双亲、内容树与执行来源。

本次只修复内部发行验收，不改变用户产物行为，无需新增 CHANGELOG 条目。

## 关联

修复 [Nightly Build 34279799774](https://github.com/Sywyar/PixivDownloader/actions/runs/34279799774) 中的启动竞态。
