### PR TITLE
perf(ci): 并行构建与发行验收并减少插件重复编译

### DIFF
--- a/.github/actions/build-release-java/action.yml
+++ b/.github/actions/build-release-java/action.yml
@@ -1,0 +1,93 @@
+name: Build release Java artifacts
+description: Build and verify production artifacts before distributing the app shell
+
+inputs:
+  release_version:
+    description: Application version embedded in the executable JAR
+    required: true
+  distribution_version:
+    description: Version used in staged JAR and distribution filenames
+    required: true
+  plugin_credential_master_key_base64:
+    description: Base64-encoded production plugin credential master key
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up JDK 17
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+      with:
+        java-version: '17'
+        distribution: temurin
+        cache: maven
+
+    - name: Prepare production plugin credential key filter
+      shell: pwsh
+      env:
+        PIXIVDOWNLOAD_PLUGIN_CREDENTIAL_MASTER_KEY_BASE64: ${{ inputs.plugin_credential_master_key_base64 }}
+      run: |
+        $filterPath = Join-Path $env:RUNNER_TEMP "pixivdownload-plugin-credential-key-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT.properties"
+        [System.IO.File]::AppendAllText(
+          $env:GITHUB_ENV,
+          "PLUGIN_CREDENTIAL_FILTER=$filterPath`n",
+          (New-Object System.Text.UTF8Encoding($false)))
+        ./scripts/write-plugin-credential-key-filter.ps1 -OutputPath $filterPath
+
+    - name: Build JAR
+      shell: bash
+      env:
+        RELEASE_VERSION: ${{ inputs.release_version }}
+      run: >
+        mvn verify -Pofficial-surveys -DskipTests "-Dapp.release.version=$RELEASE_VERSION"
+        "-Dplugin.credential.filter=$PLUGIN_CREDENTIAL_FILTER"
+
+    - name: Verify packaged distribution boundaries
+      uses: ./.github/actions/verify-release-boundaries
+      with:
+        require_production_credential_key: 'true'
+
+    - name: Stage executable JAR
+      shell: bash
+      env:
+        DISTRIBUTION_VERSION: ${{ inputs.distribution_version }}
+      run: |
+        BOOT_JARS=()
+        while IFS= read -r f; do BOOT_JARS+=("$f"); done < <(ls pixivdownload-app/target/PixivDownload-*-boot.jar 2>/dev/null || true)
+        if [ "${#BOOT_JARS[@]}" -eq 0 ]; then
+          while IFS= read -r f; do BOOT_JARS+=("$f"); done < <(ls pixivdownload-app/target/PixivDownload-*.jar 2>/dev/null | grep -vE '(-sources\.jar|-javadoc\.jar|-original\.jar)$' || true)
+        fi
+        if [ "${#BOOT_JARS[@]}" -ne 1 ]; then
+          echo "Expected exactly one executable app jar, found ${#BOOT_JARS[@]}:" >&2
+          printf '%s\n' "${BOOT_JARS[@]}" >&2
+          exit 1
+        fi
+        BOOT_JAR=${BOOT_JARS[0]}
+        mkdir -p build/release-jars
+        OUTPUT_JAR="build/release-jars/PixivDownload-${DISTRIBUTION_VERSION}.jar"
+        cp "$BOOT_JAR" "$OUTPUT_JAR"
+        test -s "$OUTPUT_JAR"
+        jar tf "$OUTPUT_JAR" | grep -q '^BOOT-INF/' || {
+          echo "Selected jar is not a Spring Boot executable jar: $OUTPUT_JAR" >&2
+          exit 1
+        }
+        STAGED_COUNT=$(ls build/release-jars/*.jar 2>/dev/null | wc -l)
+        test "$STAGED_COUNT" -eq 1
+        ls -l build/release-jars/
+
+    - name: Upload internal app-shell JAR
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: app-shell-jar
+        path: build/release-jars/*.jar
+        if-no-files-found: error
+
+    - name: Upload release signature tool
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: release-signature-tool
+        path: |
+          pixivdownload-plugin-signature/target/pixivdownload-plugin-signature-*.jar
+          !pixivdownload-plugin-signature/target/*-sources.jar
+          !pixivdownload-plugin-signature/target/*-javadoc.jar
+        if-no-files-found: error

--- a/.github/actions/package-release-java/action.yml
+++ b/.github/actions/package-release-java/action.yml
@@ -1,20 +1,10 @@
 name: Package release Java artifacts
-description: Build the app shell and assemble signed Java distributions
+description: Assemble signed Java distributions from verified release inputs
 
 inputs:
-  release_version:
-    description: Application version embedded in the executable JAR
-    required: true
   distribution_version:
     description: Version used in staged JAR and distribution filenames
     required: true
-  plugin_credential_master_key_base64:
-    description: Base64-encoded production plugin credential master key
-    required: true
-  plugin_manifest_commit:
-    description: Optional commit containing the Nightly plugin manifest
-    required: false
-    default: ''
 
 runs:
   using: composite
@@ -24,92 +14,24 @@ runs:
       with:
         java-version: '17'
         distribution: temurin
-        cache: maven
 
-    - name: Prepare production plugin credential key filter
-      shell: pwsh
-      env:
-        PIXIVDOWNLOAD_PLUGIN_CREDENTIAL_MASTER_KEY_BASE64: ${{ inputs.plugin_credential_master_key_base64 }}
-      run: |
-        $filterPath = Join-Path $env:RUNNER_TEMP "pixivdownload-plugin-credential-key-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT.properties"
-        [System.IO.File]::AppendAllText(
-          $env:GITHUB_ENV,
-          "PLUGIN_CREDENTIAL_FILTER=$filterPath`n",
-          (New-Object System.Text.UTF8Encoding($false)))
-        ./scripts/write-plugin-credential-key-filter.ps1 -OutputPath $filterPath
-
-    - name: Build JAR
-      shell: bash
-      env:
-        RELEASE_VERSION: ${{ inputs.release_version }}
-      run: >
-        mvn verify -Pofficial-surveys -DskipTests "-Dapp.release.version=$RELEASE_VERSION"
-        "-Dplugin.credential.filter=$PLUGIN_CREDENTIAL_FILTER"
-
-    - name: Verify packaged distribution boundaries
-      uses: ./.github/actions/verify-release-boundaries
-      with:
-        require_production_credential_key: 'true'
-
-    - name: Stage executable JAR
-      shell: bash
-      env:
-        DISTRIBUTION_VERSION: ${{ inputs.distribution_version }}
-      run: |
-        BOOT_JARS=()
-        while IFS= read -r f; do BOOT_JARS+=("$f"); done < <(ls pixivdownload-app/target/PixivDownload-*-boot.jar 2>/dev/null || true)
-        if [ "${#BOOT_JARS[@]}" -eq 0 ]; then
-          while IFS= read -r f; do BOOT_JARS+=("$f"); done < <(ls pixivdownload-app/target/PixivDownload-*.jar 2>/dev/null | grep -vE '(-sources\.jar|-javadoc\.jar|-original\.jar)$' || true)
-        fi
-        if [ "${#BOOT_JARS[@]}" -ne 1 ]; then
-          echo "Expected exactly one executable app jar, found ${#BOOT_JARS[@]}:" >&2
-          printf '%s\n' "${BOOT_JARS[@]}" >&2
-          exit 1
-        fi
-        BOOT_JAR=${BOOT_JARS[0]}
-        mkdir -p build/release-jars
-        OUTPUT_JAR="build/release-jars/PixivDownload-${DISTRIBUTION_VERSION}.jar"
-        cp "$BOOT_JAR" "$OUTPUT_JAR"
-        test -s "$OUTPUT_JAR"
-        jar tf "$OUTPUT_JAR" | grep -q '^BOOT-INF/' || {
-          echo "Selected jar is not a Spring Boot executable jar: $OUTPUT_JAR" >&2
-          exit 1
-        }
-        STAGED_COUNT=$(ls build/release-jars/*.jar 2>/dev/null | wc -l)
-        test "$STAGED_COUNT" -eq 1
-        ls -l build/release-jars/
-
-    - name: Upload internal app-shell JAR
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+    - name: Download internal app-shell JAR
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: app-shell-jar
-        path: build/release-jars/*.jar
-        if-no-files-found: error
+        path: build/release-jars
 
-    - name: Stage official plugin inputs from signed catalog
-      shell: pwsh
-      env:
-        PLUGIN_MANIFEST_COMMIT: ${{ inputs.plugin_manifest_commit }}
-      run: |
-        $signatureTools = @(Get-ChildItem pixivdownload-plugin-signature/target/pixivdownload-plugin-signature-*.jar -File |
-          Where-Object { $_.Name -notlike "*-sources.jar" -and $_.Name -notlike "*-javadoc.jar" } |
-          Sort-Object LastWriteTime -Descending)
-        if ($signatureTools.Count -lt 1) {
-          throw "Could not find pixivdownload-plugin-signature tool jar."
-        }
-        $stageArgs = @{
-          OutputDir = "build/plugin-inputs"
-          SignatureToolJar = $signatureTools[0].FullName
-          IncludeOptional = $true
-          RequireProguard = $true
-        }
-        if (-not [string]::IsNullOrWhiteSpace($env:PLUGIN_MANIFEST_COMMIT)) {
-          if ($env:PLUGIN_MANIFEST_COMMIT -notmatch '^[0-9a-f]{40}$') {
-            throw "Invalid plugin manifest commit: $env:PLUGIN_MANIFEST_COMMIT"
-          }
-          $stageArgs["ManifestUrl"] = "https://raw.githubusercontent.com/Sywyar/PixivDownloader-plugins/$env:PLUGIN_MANIFEST_COMMIT/nightly-manifest.json"
-        }
-        ./scripts/stage-official-plugin-inputs-from-catalog.ps1 @stageArgs
+    - name: Download plugin inputs
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: plugin-inputs
+        path: build/plugin-inputs
+
+    - name: Download release signature tool
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: release-signature-tool
+        path: artifacts/signature-tool
 
     - name: Assemble Java distributions
       shell: pwsh
@@ -120,10 +42,10 @@ runs:
         if ($jars.Count -ne 1) {
           throw "Expected exactly one staged app-shell JAR under build/release-jars, found $($jars.Count)"
         }
-        $signatureTools = @(Get-ChildItem pixivdownload-plugin-signature/target/pixivdownload-plugin-signature-*.jar -File |
+        $signatureTools = @(Get-ChildItem artifacts/signature-tool/pixivdownload-plugin-signature-*.jar -File |
           Where-Object { $_.Name -notlike "*-sources.jar" -and $_.Name -notlike "*-javadoc.jar" } |
           Sort-Object LastWriteTime -Descending)
-        if ($signatureTools.Count -lt 1) {
+        if ($signatureTools.Count -ne 1) {
           throw "Could not find pixivdownload-plugin-signature tool jar."
         }
         ./scripts/package-java-distributions.ps1 `
@@ -132,13 +54,6 @@ runs:
           -PrebuiltPluginsDir build/plugin-inputs `
           -SignatureToolJar $signatureTools[0].FullName `
           -OutputDir build/plugin-distributions
-
-    - name: Upload plugin inputs artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-      with:
-        name: plugin-inputs
-        path: build/plugin-inputs/*
-        if-no-files-found: error
 
     - name: Upload java distributions artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/actions/package-windows-installer/action.yml
+++ b/.github/actions/package-windows-installer/action.yml
@@ -31,9 +31,11 @@ runs:
         name: plugin-inputs
         path: artifacts/plugin-inputs
 
-    - name: Build plugin signature tool
-      shell: powershell
-      run: .\mvnw.cmd "-pl" "pixivdownload-plugin-signature" "-am" "package" "-DskipTests" "-Dexec.skip=true"
+    - name: Download release signature tool
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: release-signature-tool
+        path: artifacts/signature-tool
 
     - name: Package Windows setup
       shell: pwsh
@@ -45,10 +47,10 @@ runs:
           throw "Expected exactly one executable JAR artifact under artifacts/app-shell-jar, found $($jars.Count)"
         }
         $pluginsDir = (Resolve-Path artifacts/plugin-inputs).Path
-        $signatureTools = @(Get-ChildItem pixivdownload-plugin-signature/target/pixivdownload-plugin-signature-*.jar -File |
+        $signatureTools = @(Get-ChildItem artifacts/signature-tool/pixivdownload-plugin-signature-*.jar -File |
           Where-Object { $_.Name -notlike "*-sources.jar" -and $_.Name -notlike "*-javadoc.jar" } |
           Sort-Object LastWriteTime -Descending)
-        if ($signatureTools.Count -lt 1) {
+        if ($signatureTools.Count -ne 1) {
           throw "Could not find pixivdownload-plugin-signature tool jar."
         }
         ./scripts/package-local.ps1 `

--- a/.github/actions/stage-release-plugins/action.yml
+++ b/.github/actions/stage-release-plugins/action.yml
@@ -1,0 +1,43 @@
+name: Stage release plugin inputs
+description: Verify the published catalog and upload signed plugins for both distribution formats
+
+inputs:
+  plugin_manifest_commit:
+    description: Optional commit containing the Nightly plugin manifest
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Stage official plugin inputs from signed catalog
+      shell: pwsh
+      env:
+        PLUGIN_MANIFEST_COMMIT: ${{ inputs.plugin_manifest_commit }}
+      run: |
+        $signatureTools = @(Get-ChildItem pixivdownload-plugin-signature/target/pixivdownload-plugin-signature-*.jar -File |
+          Where-Object { $_.Name -notlike "*-sources.jar" -and $_.Name -notlike "*-javadoc.jar" } |
+          Sort-Object LastWriteTime -Descending)
+        if ($signatureTools.Count -lt 1) {
+          throw "Could not find pixivdownload-plugin-signature tool jar."
+        }
+        $stageArgs = @{
+          OutputDir = "build/plugin-inputs"
+          SignatureToolJar = $signatureTools[0].FullName
+          IncludeOptional = $true
+          RequireProguard = $true
+        }
+        if (-not [string]::IsNullOrWhiteSpace($env:PLUGIN_MANIFEST_COMMIT)) {
+          if ($env:PLUGIN_MANIFEST_COMMIT -notmatch '^[0-9a-f]{40}$') {
+            throw "Invalid plugin manifest commit: $env:PLUGIN_MANIFEST_COMMIT"
+          }
+          $stageArgs["ManifestUrl"] = "https://raw.githubusercontent.com/Sywyar/PixivDownloader-plugins/$env:PLUGIN_MANIFEST_COMMIT/nightly-manifest.json"
+        }
+        ./scripts/stage-official-plugin-inputs-from-catalog.ps1 @stageArgs
+
+    - name: Upload plugin inputs artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: plugin-inputs
+        path: build/plugin-inputs/*
+        if-no-files-found: error

--- a/.github/actions/test-release-artifacts/action.yml
+++ b/.github/actions/test-release-artifacts/action.yml
@@ -5,6 +5,13 @@ inputs:
   release_version:
     description: Version embedded in the release artifacts
     required: true
+  distribution:
+    description: Distribution to exercise on this runner
+    required: true
+  distribution_version:
+    description: Optional filename version when it differs from the embedded release version
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -16,12 +23,14 @@ runs:
         distribution: temurin
 
     - name: Download Windows installer artifact
+      if: inputs.distribution == 'windows-installer'
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: windows-installer
         path: artifacts/windows-installer
 
     - name: Download Java distribution artifacts
+      if: inputs.distribution == 'java-standard' || inputs.distribution == 'full-offline'
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: java-distributions
@@ -31,25 +40,30 @@ runs:
       shell: pwsh
       env:
         RELEASE_VERSION: ${{ inputs.release_version }}
+        DISTRIBUTION: ${{ inputs.distribution }}
+        DISTRIBUTION_VERSION: ${{ inputs.distribution_version || inputs.release_version }}
       run: |
-        $installers = @(Get-ChildItem artifacts/windows-installer/*-setup.exe -File)
-        $javaZips = @(Get-ChildItem artifacts/java-distributions/PixivDownload-*-java.zip -File)
-        $offlineZips = @(Get-ChildItem artifacts/java-distributions/PixivDownload-*-full-offline.zip -File)
-        if ($installers.Count -ne 1 -or $javaZips.Count -ne 1 -or $offlineZips.Count -ne 1) {
-          throw "Expected one installer, one Java ZIP and one full-offline ZIP."
+        $acceptanceArgs = @{
+          Version = $env:DISTRIBUTION_VERSION
+          Distribution = $env:DISTRIBUTION
+          ReportRoot = "$env:RUNNER_TEMP/release-e2e-reports"
         }
-        ./scripts/test-release-artifacts.ps1 `
-          -Version $env:RELEASE_VERSION `
-          -InstallerPath $installers[0].FullName `
-          -JavaZipPath $javaZips[0].FullName `
-          -FullOfflineZipPath $offlineZips[0].FullName `
-          -ReportRoot "$env:RUNNER_TEMP/release-e2e-reports"
+        switch ($env:DISTRIBUTION) {
+          'windows-installer' { $pattern = 'artifacts/windows-installer/*-setup.exe'; $parameter = 'InstallerPath' }
+          'java-standard' { $pattern = 'artifacts/java-distributions/PixivDownload-*-java.zip'; $parameter = 'JavaZipPath' }
+          'full-offline' { $pattern = 'artifacts/java-distributions/PixivDownload-*-full-offline.zip'; $parameter = 'FullOfflineZipPath' }
+          default { throw "Unsupported release distribution: $env:DISTRIBUTION" }
+        }
+        $artifacts = @(Get-ChildItem $pattern -File)
+        if ($artifacts.Count -ne 1) { throw "Expected exactly one $env:DISTRIBUTION artifact." }
+        $acceptanceArgs[$parameter] = $artifacts[0].FullName
+        ./scripts/test-release-artifacts.ps1 @acceptanceArgs
 
     - name: Upload release runtime evidence
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
-        name: release-e2e-evidence
+        name: release-e2e-evidence-${{ inputs.distribution }}
         path: ${{ runner.temp }}/release-e2e-reports/
         if-no-files-found: error
         retention-days: 7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -116,8 +116,13 @@ jobs:
           cross_repo_release_token: ${{ secrets.CROSS_REPO_RELEASE_TOKEN }}
           nightly_build_version: ${{ needs.resolve-version.outputs.version }}
 
+      - name: Stage signed release plugin inputs
+        uses: ./.github/actions/stage-release-plugins
+        with:
+          plugin_manifest_commit: ${{ steps.publish.outputs.manifest_commit }}
+
   build-jar:
-    needs: [resolve-version, publish-plugin-artifacts]
+    needs: [resolve-version, publish-plugins]
     if: needs.resolve-version.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     environment: release
@@ -134,16 +139,30 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
 
-      - name: Package release Java artifacts
-        uses: ./.github/actions/package-release-java
+      - name: Build release Java artifacts
+        uses: ./.github/actions/build-release-java
         with:
           release_version: ${{ needs.resolve-version.outputs.version }}
           distribution_version: ${{ needs.resolve-version.outputs.version }}
           plugin_credential_master_key_base64: ${{ secrets.PIXIVDOWNLOAD_PLUGIN_CREDENTIAL_MASTER_KEY_BASE64 }}
-          plugin_manifest_commit: ${{ needs.publish-plugin-artifacts.outputs.manifest_commit }}
+
+  package-java:
+    needs: [resolve-version, build-jar, publish-plugin-artifacts]
+    if: needs.resolve-version.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Package release Java artifacts
+        uses: ./.github/actions/package-release-java
+        with:
+          distribution_version: ${{ needs.resolve-version.outputs.version }}
 
   build-windows-installer:
-    needs: [resolve-version, build-jar]
+    needs: [resolve-version, build-jar, publish-plugin-artifacts]
     if: needs.resolve-version.outputs.has_changes == 'true'
     runs-on: windows-latest
     environment: release
@@ -166,10 +185,14 @@ jobs:
           release_version: ${{ needs.resolve-version.outputs.version }}
 
   release-artifact-e2e:
-    needs: [resolve-version, build-jar, build-windows-installer]
+    needs: [resolve-version, build-jar, package-java, build-windows-installer]
     if: needs.resolve-version.outputs.has_changes == 'true'
     runs-on: windows-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        distribution: [java-standard, full-offline, windows-installer]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -179,10 +202,11 @@ jobs:
       - name: Test final release artifacts
         uses: ./.github/actions/test-release-artifacts
         with:
+          distribution: ${{ matrix.distribution }}
           release_version: ${{ needs.resolve-version.outputs.version }}
 
   release-nightly:
-    needs: [resolve-version, publish-plugins, publish-plugin-artifacts, build-jar, build-windows-installer, release-artifact-e2e]
+    needs: [resolve-version, publish-plugins, publish-plugin-artifacts, build-jar, package-java, build-windows-installer, release-artifact-e2e]
     if: needs.resolve-version.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     environment: release

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   java-tests:
-    needs: [java-unit-tests, release-artifacts]
+    needs: [java-unit-tests, sdk-tests, release-artifacts]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -26,6 +26,30 @@ jobs:
         run: echo "Java tests, SDK contract and release artifact verification succeeded."
 
   java-unit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout tested commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+      - name: Set up JDK 17
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          java-version: '17'
+          distribution: temurin
+          cache: maven
+      - name: Set up Node.js 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24'
+      - name: Compile external plugin test fixtures
+        run: mvn -B -ntp -pl pixivdownload-official-plugins -am compile -Dexec.skip=true
+      - name: Run Java tests
+        run: mvn -B -ntp test -Dexec.skip=true -Duser.language=en -Duser.country=US
+
+  sdk-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -56,10 +80,6 @@ jobs:
         run: |
           node scripts/ci/resolve-trusted-base.mjs --repo-root . --event-name "$GITHUB_EVENT_NAME" --candidate "$GITHUB_SHA" --before "$EVENT_BEFORE" --ref "$GITHUB_REF" --pr-head "$EVENT_PR_HEAD_SHA" --pr-base "$EVENT_PR_BASE_SHA" --merge-group-base "$EVENT_MERGE_GROUP_BASE_SHA" --input-base "$INPUT_TRUSTED_BASE_SHA" --default-branch "$DEFAULT_BRANCH" --mode > "$RUNNER_TEMP/sdk-gate-base.json"
           node -e 'const j=require(process.argv[1]); console.log(`SDK_BASE_SHA=${j.base}`)' "$RUNNER_TEMP/sdk-gate-base.json" >> "$GITHUB_ENV"
-      - name: Compile external plugin test fixtures
-        run: mvn -B -ntp -pl pixivdownload-official-plugins -am compile -Dexec.skip=true
-      - name: Run Java tests
-        run: mvn -B -ntp test -Dexec.skip=true -Duser.language=en -Duser.country=US
       - name: Verify SDK, templates and isolated consumers
         uses: ./.github/actions/verify-sdk
         with:
@@ -119,7 +139,9 @@ jobs:
         run: ./scripts/ci/check-powershell.ps1
       - name: Test release runtime acceptance guards
         shell: pwsh
-        run: ./scripts/release-e2e/runtime.test.ps1
+        run: |
+          ./scripts/release-e2e/runtime.test.ps1
+          ./scripts/ci/test/workflow-orchestration.test.ps1
       - name: Verify packaged release boundaries
         uses: ./.github/actions/verify-release-boundaries
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,8 +94,11 @@ jobs:
           plugin_signing_private_key_pem_base64: ${{ secrets.PLUGIN_SIGNING_PRIVATE_KEY_PEM_BASE64 }}
           cross_repo_release_token: ${{ secrets.CROSS_REPO_RELEASE_TOKEN }}
 
+      - name: Stage signed release plugin inputs
+        uses: ./.github/actions/stage-release-plugins
+
   build-jar:
-    needs: [ validate-release-tag, publish-plugin-artifacts ]
+    needs: [ validate-release-tag, publish-plugins ]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: release
@@ -113,15 +116,30 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
-      - name: Package release Java artifacts
-        uses: ./.github/actions/package-release-java
+      - name: Build release Java artifacts
+        uses: ./.github/actions/build-release-java
         with:
           release_version: ${{ needs.validate-release-tag.outputs.version }}
           distribution_version: ${{ github.ref_name }}
           plugin_credential_master_key_base64: ${{ secrets.PIXIVDOWNLOAD_PLUGIN_CREDENTIAL_MASTER_KEY_BASE64 }}
 
+  package-java:
+    needs: [validate-release-tag, build-jar, publish-plugin-artifacts]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Package release Java artifacts
+        uses: ./.github/actions/package-release-java
+        with:
+          distribution_version: ${{ github.ref_name }}
+
   build-windows-installer:
-    needs: build-jar
+    needs: [build-jar, publish-plugin-artifacts]
     if: github.event_name == 'push'
     runs-on: windows-latest
     environment: release
@@ -143,10 +161,14 @@ jobs:
           release_version: ${{ needs.build-jar.outputs.version }}
 
   release-artifact-e2e:
-    needs: [ build-jar, build-windows-installer ]
+    needs: [ build-jar, package-java, build-windows-installer ]
     if: github.event_name == 'push'
     runs-on: windows-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        distribution: [java-standard, full-offline, windows-installer]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -156,6 +178,8 @@ jobs:
       - name: Test final release artifacts
         uses: ./.github/actions/test-release-artifacts
         with:
+          distribution: ${{ matrix.distribution }}
+          distribution_version: ${{ matrix.distribution == 'windows-installer' && needs.build-jar.outputs.version || github.ref_name }}
           release_version: ${{ needs.build-jar.outputs.version }}
 
   release:
@@ -164,6 +188,7 @@ jobs:
         publish-plugins,
         publish-plugin-artifacts,
         build-jar,
+        package-java,
         build-windows-installer,
         release-artifact-e2e
       ]

--- a/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
+++ b/pixivdownload-app/src/test/java/top/sywyar/pixivdownload/plugin/catalog/PluginReleaseScriptsTest.java
@@ -976,7 +976,7 @@ class PluginReleaseScriptsTest {
     @Test
     @DisplayName("release/nightly 通过共享动作只上传一个 app-shell JAR，安装器消费同一 artifact")
     void releaseWorkflowsUploadOnlyStagedAppShellJar() throws Exception {
-        String javaAction = action("package-release-java");
+        String javaAction = action("build-release-java");
         String windowsAction = action("package-windows-installer");
 
         assertThat(javaAction).contains(
@@ -1017,10 +1017,13 @@ class PluginReleaseScriptsTest {
     @DisplayName("release/nightly 经共享动作发布 java-standard 与 full-offline 签名分发布局")
     void releaseWorkflowsPublishJavaDistributions() throws Exception {
         String javaAction = action("package-release-java");
-        assertThat(javaAction).contains(
-                "Stage official plugin inputs from signed catalog",
+        String pluginInputs = action("stage-release-plugins");
+        assertThat(pluginInputs).contains(
                 "stage-official-plugin-inputs-from-catalog.ps1",
                 "IncludeOptional = $true",
+                "name: plugin-inputs",
+                "path: build/plugin-inputs/*");
+        assertThat(javaAction).contains(
                 "Assemble Java distributions",
                 "package-java-distributions.ps1",
                 "-PrebuiltJar $jars[0].FullName",
@@ -1030,8 +1033,7 @@ class PluginReleaseScriptsTest {
                 "build/plugin-distributions/PixivDownload-*-java.zip",
                 "build/plugin-distributions/PixivDownload-*-full-offline.zip",
                 "if-no-files-found: error",
-                "name: plugin-inputs",
-                "path: build/plugin-inputs/*");
+                "name: plugin-inputs");
         for (String name : List.of("release.yml", "nightly.yml")) {
             String workflow = workflow(name);
 
@@ -1089,10 +1091,7 @@ class PluginReleaseScriptsTest {
                 "name: windows-installer",
                 "name: java-distributions",
                 "Install and start final release artifacts",
-                "./scripts/test-release-artifacts.ps1",
-                "-InstallerPath $installers[0].FullName",
-                "-JavaZipPath $javaZips[0].FullName",
-                "-FullOfflineZipPath $offlineZips[0].FullName");
+                "./scripts/test-release-artifacts.ps1");
 
         for (String name : List.of("release.yml", "nightly.yml")) {
             String workflow = workflow(name);
@@ -1654,8 +1653,6 @@ class PluginReleaseScriptsTest {
         assertThat(nightly).contains("workflow_dispatch:");
         assertThat(releaseJob)
                 .contains(
-                        "needs: [resolve-version, publish-plugins, publish-plugin-artifacts, build-jar, "
-                                + "build-windows-installer, release-artifact-e2e]",
                         "if: needs.resolve-version.outputs.has_changes == 'true'")
                 .doesNotContain("always()");
         assertThat(releaseStep).contains(

--- a/scripts/ci/test/quality-gate-workflow.test.mjs
+++ b/scripts/ci/test/quality-gate-workflow.test.mjs
@@ -212,6 +212,12 @@ test('Java tests and ProGuard run independently and both gate the required Java 
     assert.notEqual(tests, build);
     assert.equal(ancestors(tests).has(build), false);
     assert.equal(ancestors(build).has(tests), false);
+    const sdk = owner(/sdk-contract\.mjs/u);
+    assert.notEqual(sdk, tests);
+    for (const [a, b] of [[tests, sdk], [build, sdk]]) {
+        assert.equal(ancestors(a).has(b), false);
+        assert.equal(ancestors(b).has(a), false);
+    }
     const required = ancestors('java-tests');
     for (const id of [tests, build, owner(/DistributionPackagingBoundaryTest/u), owner(/sdk-contract\.mjs/u)]) {
         assert.ok(required.has(id), `java-tests must require ${id}`);
@@ -241,7 +247,7 @@ test('QG 覆盖 Compose、SDK 消费者和两种 PowerShell，并顺序复用构
             'PluginReleaseScriptsTest#releaseArtifactCleanupHandlesSealedPermissions+releaseArtifactFailurePrintsDiagnosticTail',
             'StagedFileDeletionTest#rejectsWindowsJunctionBeforeStaging',
             'WorkDeletionFileRollbackTest#novelJunctionAbortsFilesAndSoftDelete']);
-    const sources = executionSteps(jobs['java-unit-tests']);
+    const sources = executionSteps(jobs['sdk-tests']);
     const stage = sources.findIndex(step => /altDeploymentRepository=sdk-staging/u.test(step.run || ''));
     const templates = sources.findIndex(step => /plugin-templates\/pom.xml/u.test(step.run || ''));
     const consumer = sources.findIndex(step => /sdk-consumer\.mjs/u.test(step.run || ''));
@@ -254,13 +260,13 @@ test('QG 覆盖 Compose、SDK 消费者和两种 PowerShell，并顺序复用构
     assert.deepEqual(scripts.map(step => step.shell).sort(), ['powershell', 'pwsh']);
     for (const [file, action] of [
         ['.github/workflows/publish-sdk.yml', './.github/actions/verify-sdk'],
-        ['.github/actions/package-release-java/action.yml', './.github/actions/verify-release-boundaries'],
+        ['.github/actions/build-release-java/action.yml', './.github/actions/verify-release-boundaries'],
     ]) {
         const doc = load(file);
         const steps = doc.runs?.steps || Object.values(doc.jobs).flatMap(job => job.steps || []);
         assert.ok(steps.some(step => step.uses === action), file);
     }
-    const release = load('.github/actions/package-release-java/action.yml').runs.steps
+    const release = load('.github/actions/build-release-java/action.yml').runs.steps
         .find(step => step.uses === './.github/actions/verify-release-boundaries');
     assert.equal(release.with.require_production_credential_key, 'true');
 });
@@ -268,7 +274,8 @@ test('QG 覆盖 Compose、SDK 消费者和两种 PowerShell，并顺序复用构
 test('发布链：所有凭据与写权限只在 release Environment 的门禁后使用', () => {
     const publish = load('.github/workflows/publish-plugins.yml');
     const publishAction = load('.github/actions/publish-official-plugins/action.yml');
-    const javaAction = load('.github/actions/package-release-java/action.yml');
+    const javaAction = load('.github/actions/build-release-java/action.yml');
+    const pluginInputs = load('.github/actions/stage-release-plugins/action.yml');
     const windowsAction = load('.github/actions/package-windows-installer/action.yml');
     const updateSigningAction = load('.github/actions/sign-update-manifest/action.yml');
     assert.equal(publish.jobs['quality-gate'].uses, './.github/workflows/quality-gate.yml');
@@ -344,8 +351,8 @@ test('发布链：所有凭据与写权限只在 release Environment 的门禁�
         assert.equal(job.steps.find((step) => step.uses === './.github/actions/publish-official-plugins')
             ?.name, 'Publish official plugins');
     }
-    assert.deepEqual(release.jobs['build-jar'].needs, ['validate-release-tag', 'publish-plugin-artifacts']);
-    assert.deepEqual(nightly.jobs['build-jar'].needs, ['resolve-version', 'publish-plugin-artifacts']);
+    assert.deepEqual(release.jobs['build-jar'].needs, ['validate-release-tag', 'publish-plugins']);
+    assert.deepEqual(nightly.jobs['build-jar'].needs, ['resolve-version', 'publish-plugins']);
     assert.ok(release.jobs.release.needs.includes('publish-plugin-artifacts'));
     assert.ok(nightly.jobs['release-nightly'].needs.includes('publish-plugin-artifacts'));
     for (const doc of [release, nightly]) {
@@ -367,17 +374,18 @@ test('发布链：所有凭据与写权限只在 release Environment 的门禁�
     assert.equal(nightly.jobs['publish-plugin-artifacts'].outputs.manifest_commit,
         '${{ steps.publish.outputs.manifest_commit }}');
     const releaseJava = release.jobs['build-jar'].steps
-        .find((step) => step.uses === './.github/actions/package-release-java');
+        .find((step) => step.uses === './.github/actions/build-release-java');
     const nightlyJava = nightly.jobs['build-jar'].steps
-        .find((step) => step.uses === './.github/actions/package-release-java');
+        .find((step) => step.uses === './.github/actions/build-release-java');
     assert.equal(releaseJava.with.release_version, '${{ needs.validate-release-tag.outputs.version }}');
     assert.equal(releaseJava.with.distribution_version, '${{ github.ref_name }}');
     assert.equal(releaseJava.with.plugin_manifest_commit, undefined);
     assert.equal(nightlyJava.with.release_version, '${{ needs.resolve-version.outputs.version }}');
     assert.equal(nightlyJava.with.distribution_version, '${{ needs.resolve-version.outputs.version }}');
-    assert.equal(nightlyJava.with.plugin_manifest_commit,
-        '${{ needs.publish-plugin-artifacts.outputs.manifest_commit }}');
-    assert.match(javaAction.runs.steps
+    assert.equal(nightly.jobs['publish-plugin-artifacts'].steps
+        .find(step => step.uses === './.github/actions/stage-release-plugins').with.plugin_manifest_commit,
+        '${{ steps.publish.outputs.manifest_commit }}');
+    assert.match(pluginInputs.runs.steps
         .find((step) => step.name === 'Stage official plugin inputs from signed catalog').run,
         /PLUGIN_MANIFEST_COMMIT\/nightly-manifest\.json/);
     for (const doc of [release, nightly]) {
@@ -426,6 +434,55 @@ test('SDK 发布链只在身份变化或显式恢复时通过同 SHA 门禁写�
         requiredJobs: ['release-plan', 'quality-gate', 'publish'],
         requiredTriggers: ['push', 'workflow_dispatch'],
     });
+});
+
+test('发行构建与插件发布并行，分发产物依赖完整且全部 E2E 成功后才能发布', () => {
+    for (const file of ['release', 'nightly']) {
+        const { jobs } = load(`.github/workflows/${file}.yml`);
+        const ancestors = (id, visited = new Set()) => {
+            assert.ok(jobs[id], `dependency ${id} exists`);
+            if (visited.has(id)) return visited;
+            visited.add(id);
+            for (const parent of [jobs[id].needs || []].flat()) ancestors(parent, visited);
+            return visited;
+        };
+        for (const [a, b] of [['build-jar', 'publish-plugin-artifacts'], ['package-java', 'build-windows-installer']]) {
+            assert.equal(ancestors(a).has(b), false);
+            assert.equal(ancestors(b).has(a), false);
+        }
+        const sharedArtifacts = ['app-shell-jar', 'plugin-inputs', 'release-signature-tool',
+            'java-distributions', 'windows-installer'];
+        for (const artifact of sharedArtifacts) {
+            const producers = Object.keys(jobs).filter(id => executionSteps(jobs[id]).some(step =>
+                step.uses?.startsWith('actions/upload-artifact@') && step.with?.name === artifact));
+            assert.equal(producers.length, 1, `one producer of ${artifact}`);
+            for (const id of Object.keys(jobs)) {
+                if (executionSteps(jobs[id]).some(step => step.uses?.startsWith('actions/download-artifact@')
+                    && step.with?.name === artifact)) {
+                    assert.ok(ancestors(id).has(producers[0]), `${id} waits for ${artifact}`);
+                }
+            }
+        }
+        const e2e = jobs['release-artifact-e2e'];
+        assert.deepEqual(e2e.strategy.matrix.distribution.sort(), ['full-offline', 'java-standard', 'windows-installer']);
+        assert.equal(e2e.strategy['fail-fast'], false);
+        const acceptance = e2e.steps.find(step => step.uses === './.github/actions/test-release-artifacts');
+        assert.equal(acceptance.with.distribution, '${{ matrix.distribution }}');
+        const publication = file === 'nightly' ? 'release-nightly' : 'release';
+        const required = ancestors(publication);
+        for (const id of ['publish-plugins', 'publish-plugin-artifacts', 'build-jar', 'package-java',
+            'build-windows-installer', 'release-artifact-e2e']) {
+            assert.ok(required.has(id));
+            assert.ok(jobs[id]['continue-on-error'] === undefined || jobs[id]['continue-on-error'] === false);
+            assert.doesNotMatch(jobs[id].if || '', /always\(|failure\(|cancelled\(/u);
+        }
+        assert.ok(ancestors('build-jar').has('publish-plugins'));
+    }
+    const evidence = load('.github/actions/test-release-artifacts/action.yml').runs.steps
+        .find(step => step.uses?.startsWith('actions/upload-artifact@'));
+    assert.equal(evidence.if, 'always()');
+    assert.equal(evidence.with.name, 'release-e2e-evidence-${{ inputs.distribution }}');
+    assert.equal(evidence.with['if-no-files-found'], 'error');
 });
 
 test('SDK 接收仓库 workflow 由主仓库只读编排且不持有跨仓库凭据', () => {
@@ -595,6 +652,8 @@ test('发布链：仅接受 Base64 私钥且不存在失败绕过', () => {
         '.github/workflows/publish-plugins.yml', '.github/workflows/build-stable-ffmpeg.yml',
         '.github/actions/publish-official-plugins/action.yml',
         '.github/actions/package-release-java/action.yml',
+        '.github/actions/build-release-java/action.yml',
+        '.github/actions/stage-release-plugins/action.yml',
         '.github/actions/package-windows-installer/action.yml',
         '.github/actions/sign-update-manifest/action.yml']) {
         const text = fs.readFileSync(path.join(ROOT, ...rel.split('/')), 'utf8');
@@ -615,8 +674,8 @@ test('发布链：仅接受 Base64 私钥且不存在失败绕过', () => {
 
 test('Nightly：共享变更门禁以语义输出控制全部昂贵任务', () => {
     const nightly = load('.github/workflows/nightly.yml');
-    for (const id of ['publish-plugins', 'publish-plugin-artifacts', 'build-jar', 'build-windows-installer',
-        'release-nightly']) {
+    for (const id of ['publish-plugins', 'publish-plugin-artifacts', 'build-jar', 'package-java', 'build-windows-installer',
+        'release-artifact-e2e', 'release-nightly']) {
         assert.equal(nightly.jobs[id].if, "needs.resolve-version.outputs.has_changes == 'true'");
     }
     const resolveScripts = nightly.jobs['resolve-version'].steps.map((step) => step.run || '').join('\n');

--- a/scripts/ci/test/workflow-orchestration.test.ps1
+++ b/scripts/ci/test/workflow-orchestration.test.ps1
@@ -1,0 +1,169 @@
+# Execute orchestration with local fixtures; publishing and application processes are replaced at their boundaries.
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$repo = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+
+function Read-Program {
+    param([string]$Path)
+    $errors = $null
+    $ast = [Management.Automation.Language.Parser]::ParseFile($Path, [ref]$null, [ref]$errors)
+    if ($errors.Count) { throw ($errors | Out-String) }
+    $functions = @($ast.EndBlock.Statements | Where-Object { $_ -is [Management.Automation.Language.FunctionDefinitionAst] })
+    $statements = @($ast.EndBlock.Statements | Where-Object {
+        $_ -notin $functions -and -not ($_ -is [Management.Automation.Language.PipelineAst] -and
+            $_.PipelineElements[0] -is [Management.Automation.Language.CommandAst] -and
+            $_.PipelineElements[0].InvocationOperator -eq 'Dot')
+    })
+    return [pscustomobject]@{
+        Functions = $functions
+        Main = [scriptblock]::Create($ast.ParamBlock.Extent.Text + "`n" + (($statements | ForEach-Object { $_.Extent.Text }) -join "`n"))
+    }
+}
+
+function Assert-Equal {
+    param($Actual, $Expected)
+    if (($Actual -join '|') -cne ($Expected -join '|')) { throw "Expected [$Expected], got [$Actual]" }
+}
+
+function Assert-Rejected {
+    param([scriptblock]$Action, [string]$Message)
+    try { & $Action } catch {
+        if ($_.Exception.Message -notlike "*$Message*") { throw }
+        return
+    }
+    throw "Expected rejection: $Message"
+}
+
+$tempBase = [IO.Path]::GetFullPath([IO.Path]::GetTempPath()).TrimEnd('\', '/')
+$fixture = Join-Path $tempBase ('pixiv-workflow-test-' + [Guid]::NewGuid().ToString('N'))
+[IO.Directory]::CreateDirectory($fixture) | Out-Null
+try {
+    & {
+        $program = Read-Program (Join-Path $repo 'scripts/test-release-artifacts.ps1')
+        foreach ($definition in $program.Functions) { . ([scriptblock]::Create($definition.Extent.Text)) }
+        $script:observed = [Collections.Generic.List[string]]::new()
+        $script:probes = [Collections.Generic.List[string]]::new()
+        function Expand-Archive {
+            param($LiteralPath, $DestinationPath)
+            [IO.Directory]::CreateDirectory($DestinationPath) | Out-Null
+            [IO.File]::WriteAllText((Join-Path $DestinationPath 'run.bat'), 'fixture')
+            [IO.File]::WriteAllText((Join-Path $DestinationPath "PixivDownload-$Version.jar"), 'fixture')
+        }
+        function Initialize-ReleaseProbe {
+            param($ApplicationJar, $Destination)
+            if (-not (Test-Path -LiteralPath $ApplicationJar -PathType Leaf)) { throw 'Missing application API input.' }
+            $script:probes.Add($ApplicationJar)
+            return @{ Agent = 'fixture'; Fixture = 'fixture' }
+        }
+        function Test-ApplicationScenario { param($Label) $script:observed.Add($Label) }
+        function Test-ReleaseAdverseLayouts { param($Label) $script:observed.Add("$Label-adverse") }
+        function Assert-NoInstalledCopy { }
+        function Wait-ArtifactProcessExit { }
+        function Start-Process {
+            param($FilePath, $ArgumentList, $WindowStyle, [switch]$PassThru)
+            if ($FilePath -like '*unins000.exe') { return @{ExitCode=0} }
+            $installDir = ($ArgumentList | Where-Object { $_ -like '/DIR=*' }).Substring(5).Trim('"')
+            foreach ($name in @('PixivDownload.exe', 'runtime/bin/server/jvm.dll', 'unins000.exe', "app/PixivDownload-$Version.jar")) {
+                $target = Join-Path $installDir $name
+                [IO.Directory]::CreateDirectory((Split-Path -Parent $target)) | Out-Null
+                [IO.File]::WriteAllText($target, 'fixture')
+            }
+            return @{ExitCode=0}
+        }
+        $inputFile = Join-Path $fixture 'input'
+        [IO.File]::WriteAllText($inputFile, 'fixture')
+        foreach ($distribution in @('java-standard', 'full-offline', 'windows-installer', 'all')) {
+            $script:observed.Clear(); $script:probes.Clear()
+            $parameters = @{ Version='1.2.3'; Distribution=$distribution; WorkRoot=$fixture }
+            if ($distribution -in @('all', 'java-standard')) { $parameters.JavaZipPath = $inputFile }
+            if ($distribution -in @('all', 'full-offline')) { $parameters.FullOfflineZipPath = $inputFile }
+            if ($distribution -in @('all', 'windows-installer')) { $parameters.InstallerPath = $inputFile }
+            & $program.Main @parameters
+            $expected = @(foreach ($kind in @('java-standard', 'full-offline', 'windows-installer')) {
+                if ($distribution -in @('all', $kind)) {
+                    foreach ($mode in @('headless', 'gui-compose', 'gui-swing')) { "$kind-$mode" }
+                    if ($kind -eq 'windows-installer') { "$kind-adverse" }
+                }
+            })
+            Assert-Equal $script:observed $expected
+            Assert-Equal $script:probes.Count 1
+            if ($distribution -eq 'windows-installer' -and $script:probes[0] -notlike '*installed*app*PixivDownload-1.2.3.jar') {
+                throw 'Installer shard did not initialize its probe from its own application.'
+            }
+        }
+        foreach ($distribution in @('java-standard', 'full-offline', 'windows-installer')) {
+            Assert-Rejected { & $program.Main -Version 1.2.3 -Distribution $distribution -WorkRoot $fixture } 'not found'
+        }
+        Assert-Rejected { & $program.Main -Version 1.2.3 -JavaZipPath $inputFile -FullOfflineZipPath $inputFile } 'packaged JVM'
+        Assert-Rejected { & $program.Main -Version 1.2.3 -Distribution unknown } 'ValidateSet'
+    }
+
+    & {
+        $program = Read-Program (Join-Path $repo 'scripts/publish-plugin-releases.ps1')
+        foreach ($definition in $program.Functions) { . ([scriptblock]::Create($definition.Extent.Text)) }
+        $script:builds = [Collections.Generic.List[object]]::new()
+        $script:writes = [Collections.Generic.List[string]]::new()
+        $script:buildExit = 0
+        $script:existing = $false
+        $plugins = @(@{Id='first'; Module='first'}, @{Id='second'; Module='second'})
+        foreach ($plugin in $plugins) {
+            $descriptor = Join-Path $fixture "$($plugin.Module)/src/main/resources/plugin.properties"
+            [IO.Directory]::CreateDirectory((Split-Path -Parent $descriptor)) | Out-Null
+            [IO.File]::WriteAllText($descriptor, 'plugin.version=1.0.0')
+        }
+        function Resolve-SignatureToolJar { return 'fixture' }
+        function Get-OfficialDistributionPlugins { param([switch]$IncludeOptional) return $plugins }
+        function Get-MavenCommand { return 'Invoke-FakeMaven' }
+        function Invoke-FakeMaven {
+            $script:builds.Add(@($args))
+            $global:LASTEXITCODE = $script:buildExit
+        }
+        function Find-ModulePluginArtifact { param($Plugin) return (Join-Path $fixture "$($Plugin.Module)/src/main/resources/plugin.properties") }
+        function Assert-OfficialPluginArtifact { return @{'plugin.version'='1.0.0'} }
+        function Assert-ProguardProcessedArtifact { }
+        function Get-OfficialPluginArtifactName { param($Plugin, $Version) return "$($Plugin.Id)-$Version.jar" }
+        function Get-NightlyPluginVersion { param($SourceVersion, $Suffix) return "$SourceVersion-$Suffix" }
+        function Set-StagedPluginVersion { }
+        function Write-StagedCompanionFiles {
+            param($StagedArtifact)
+            return @{Sha='fixture'; ShaFile="$StagedArtifact.sha256"; SigFile="$StagedArtifact.sig"}
+        }
+        function gh {
+            $global:LASTEXITCODE = 0
+            if ($args[1] -eq 'view') {
+                if (-not $script:existing) { $global:LASTEXITCODE = 1; return 'release not found' }
+                $id = $args[2] -replace '-v.*$', ''
+                return (@{assets=@(@{name="$id-1.0.0.jar"}, @{name="$id-1.0.0.jar.sha256"}, @{name="$id-1.0.0.jar.sig"})} | ConvertTo-Json -Compress)
+            }
+            $script:writes.Add(($args -join ' '))
+        }
+        foreach ($mode in @('nightly', 'force', 'stable', 'skip', 'failure')) {
+            $script:builds.Clear(); $script:writes.Clear()
+            $script:existing = $mode -eq 'skip'
+            $script:buildExit = if ($mode -eq 'failure') { 1 } else { 0 }
+            $parameters = @{ProjectRoot=$fixture; OfficialKeyId='fixture'; PrivateKeyFile=(Join-Path $fixture 'input')}
+            if ($mode -in @('nightly', 'failure')) { $parameters.NightlyBuildVersion = '1.2.3-nightly.20260909.1.1' }
+            if ($mode -eq 'force') { $parameters.Force = $true }
+            if ($mode -eq 'failure') {
+                Assert-Rejected { & $program.Main @parameters } 'Maven plugin build failed'
+                Assert-Equal $script:writes.Count 0
+            } else {
+                & $program.Main @parameters
+                Assert-Equal $script:builds.Count $(if ($mode -eq 'skip') { 0 } elseif ($mode -eq 'stable') { 2 } else { 1 })
+                Assert-Equal $script:writes.Count $(if ($mode -eq 'skip') { 0 } elseif ($mode -eq 'nightly') { 2 } else { 4 })
+                if ($mode -in @('nightly', 'force')) {
+                    Assert-Equal $script:builds[0] @('-Pofficial-surveys', '-pl', 'first,second', '-am', 'verify', '-DskipTests')
+                }
+            }
+        }
+    }
+    Write-Host 'PASS: independent release distributions, complete default acceptance, plugin build batching and failure propagation.'
+} finally {
+    $resolved = [IO.Path]::GetFullPath($fixture)
+    if ((Split-Path -Parent $resolved).TrimEnd('\', '/') -ne $tempBase -or
+        (Split-Path -Leaf $resolved) -notlike 'pixiv-workflow-test-*') { throw 'Unsafe fixture cleanup.' }
+    Remove-Item -LiteralPath $resolved -Recurse -Force
+}
+
+# The expected native-command failure must not become the runner's final exit code.
+$global:LASTEXITCODE = 0

--- a/scripts/publish-plugin-releases.ps1
+++ b/scripts/publish-plugin-releases.ps1
@@ -24,6 +24,7 @@
     With -NightlyBuildVersion, every official plugin is rebuilt from current source, its staged plugin.properties is
     rewritten to the derived Nightly version, and the fixed `<plugin-id>-nightly` Release has all old assets replaced.
     The matching tag is advanced by the publishing action only after the signed Nightly manifest is committed.
+    Nightly and Force build the official modules in one Maven reactor before staging individual artifacts.
 
     With -Force/-f, every official plugin is rebuilt for the source plugin.version. Existing expected release
     assets (artifact + .sha256 + .sig) are deleted before the freshly built files are uploaded, so a manual
@@ -129,21 +130,27 @@ function Get-ReleaseAssetState([string]$Tag) {
     return [pscustomobject]@{ Exists = $false; AssetNames = @() }
 }
 
+function Invoke-PluginBuild {
+    param([Parameter(Mandatory = $true)][string[]]$Modules)
+    Write-Host "==> Building plugin modules: $($Modules -join ', ')"
+    Push-Location $ProjectRoot
+    try {
+        & $mvn "-Pofficial-surveys" "-pl" ($Modules -join ',') "-am" "verify" "-DskipTests" |
+            ForEach-Object { Write-Host $_ }
+        if ($LASTEXITCODE -ne 0) { throw "Maven plugin build failed." }
+    } finally {
+        Pop-Location
+    }
+}
+
 function Build-StagedPluginArtifact {
     param(
         [Parameter(Mandatory = $true)]$Plugin,
         [Parameter(Mandatory = $true)][string]$Version,
         [Parameter(Mandatory = $true)][string]$AssetName
     )
-
-    Write-Host "==> Building only module $($Plugin.Module) for release $($Plugin.Id)-v$Version"
-    Push-Location $ProjectRoot
-    try {
-        & $mvn "-Pofficial-surveys" "-pl" $Plugin.Module "-am" "verify" "-DskipTests" |
-            ForEach-Object { Write-Host $_ }
-        if ($LASTEXITCODE -ne 0) { throw "Maven build failed for module $($Plugin.Module)." }
-    } finally {
-        Pop-Location
+    if (-not $buildAllPlugins) {
+        Invoke-PluginBuild -Modules @($Plugin.Module)
     }
 
     $builtArtifact = Find-ModulePluginArtifact $Plugin $ProjectRoot
@@ -294,6 +301,10 @@ $stageDir = Join-Path $ProjectRoot "build/release-plugins"
 New-Item -ItemType Directory -Force -Path $stageDir | Out-Null
 $plugins = @(Get-OfficialDistributionPlugins -IncludeOptional)
 $published = @()
+$buildAllPlugins = -not [string]::IsNullOrWhiteSpace($NightlyBuildVersion) -or $Force
+if ($buildAllPlugins) {
+    Invoke-PluginBuild -Modules @($plugins | ForEach-Object { $_.Module })
+}
 
 if (-not [string]::IsNullOrWhiteSpace($NightlyBuildVersion)) {
     foreach ($plugin in $plugins) {

--- a/scripts/test-release-artifacts.ps1
+++ b/scripts/test-release-artifacts.ps1
@@ -1,12 +1,14 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)][string]$Version,
-    [Parameter(Mandatory = $true)][string]$JavaZipPath,
-    [Parameter(Mandatory = $true)][string]$FullOfflineZipPath,
+    [string]$JavaZipPath,
+    [string]$FullOfflineZipPath,
     [string]$InstallerPath,
     [string]$AppImagePath,
     [string]$WorkRoot,
-    [string]$ReportRoot
+    [string]$ReportRoot,
+    [ValidateSet('all', 'java-standard', 'full-offline', 'windows-installer')]
+    [string]$Distribution = 'all'
 )
 
 $ErrorActionPreference = "Stop"
@@ -228,6 +230,15 @@ function Wait-ForHealthyApplication {
 function Test-ApplicationLayout {
     param([string]$Label, [string]$Root, [string]$Launcher, [string]$RuntimeRoot, [string]$LogRoot,
         [switch]$AdverseScenarios)
+    if ($null -eq $script:ReleaseTools) {
+        $jar = if (Test-Path -LiteralPath (Join-Path $Root 'app') -PathType Container) {
+            Join-Path $Root "app/PixivDownload-$Version.jar"
+        } else {
+            Join-Path $Root "PixivDownload-$Version.jar"
+        }
+        $jar = Resolve-RequiredFile $jar "$Label application JAR"
+        $script:ReleaseTools = Initialize-ReleaseProbe -ApplicationJar $jar -Destination (Join-Path $context.Session 'probe-tools')
+    }
     Test-ApplicationScenario -Label "$Label-headless" -Root $Root -Launcher $Launcher `
         -RuntimeRoot "$RuntimeRoot-headless" -LogRoot "$LogRoot-headless" -Headless
     foreach ($provider in @('gui-compose', 'gui-swing')) {
@@ -251,9 +262,6 @@ function Test-JavaArchive {
         -not (Test-Path -LiteralPath $jar -PathType Leaf)) {
         throw "$Label does not contain run.bat and the exact versioned application JAR"
     }
-    if ($null -eq $script:ReleaseTools) {
-        $script:ReleaseTools = Initialize-ReleaseProbe -ApplicationJar $jar -Destination (Join-Path $context.Session 'probe-tools')
-    }
     Test-ApplicationLayout -Label $Label -Root $Destination -Launcher $launcher `
         -RuntimeRoot (Join-Path $Destination ".e2e-runtime") -LogRoot (Join-Path $Destination "e2e")
 }
@@ -273,15 +281,23 @@ function Assert-PackagedRuntime {
 . (Join-Path $PSScriptRoot 'release-e2e/runtime.ps1')
 . (Join-Path $PSScriptRoot 'release-e2e/scenarios.ps1')
 
-$resolvedJavaZip = Resolve-RequiredFile $JavaZipPath "Java distribution"
-$resolvedFullOfflineZip = Resolve-RequiredFile $FullOfflineZipPath "Full-offline distribution"
-$resolvedInstaller = if ([string]::IsNullOrWhiteSpace($InstallerPath)) {
+$resolvedJavaZip = if ($Distribution -in @('all', 'java-standard')) {
+    Resolve-RequiredFile $JavaZipPath "Java distribution"
+} else { '' }
+$resolvedFullOfflineZip = if ($Distribution -in @('all', 'full-offline')) {
+    Resolve-RequiredFile $FullOfflineZipPath "Full-offline distribution"
+} else { '' }
+$resolvedInstaller = if ($Distribution -eq 'windows-installer') {
+    Resolve-RequiredFile $InstallerPath "Windows installer"
+} elseif ($Distribution -ne 'all' -or [string]::IsNullOrWhiteSpace($InstallerPath)) {
     ""
 } else {
     Resolve-RequiredFile $InstallerPath "Windows installer"
 }
-$resolvedAppImage = Resolve-OptionalDirectory $AppImagePath "Windows app image"
-if ([string]::IsNullOrWhiteSpace($resolvedInstaller) -and [string]::IsNullOrWhiteSpace($resolvedAppImage)) {
+$resolvedAppImage = if ($Distribution -eq 'all') {
+    Resolve-OptionalDirectory $AppImagePath "Windows app image"
+} else { '' }
+if ($Distribution -eq 'all' -and [string]::IsNullOrWhiteSpace($resolvedInstaller) -and [string]::IsNullOrWhiteSpace($resolvedAppImage)) {
     throw "Specify InstallerPath or AppImagePath so the packaged JVM is exercised."
 }
 
@@ -296,10 +312,14 @@ try {
     $script:ReleaseReportRoot = Join-Path $ReportRoot (Split-Path -Leaf $context.Session)
     [IO.Directory]::CreateDirectory($script:ReleaseReportRoot) | Out-Null
     Write-Host "Release E2E evidence: $script:ReleaseReportRoot"
-    Test-JavaArchive -Label "java-standard" -Archive $resolvedJavaZip `
-        -Destination (Join-Path $context.Session "java-standard")
-    Test-JavaArchive -Label "full-offline" -Archive $resolvedFullOfflineZip `
-        -Destination (Join-Path $context.Session "full-offline")
+    if ($resolvedJavaZip) {
+        Test-JavaArchive -Label "java-standard" -Archive $resolvedJavaZip `
+            -Destination (Join-Path $context.Session "java-standard")
+    }
+    if ($resolvedFullOfflineZip) {
+        Test-JavaArchive -Label "full-offline" -Archive $resolvedFullOfflineZip `
+            -Destination (Join-Path $context.Session "full-offline")
+    }
 
     if (-not [string]::IsNullOrWhiteSpace($resolvedAppImage)) {
         $isolatedImage = Join-Path $context.Session 'app-image'


### PR DESCRIPTION
## 变更内容

Nightly 和 Release 原先依次发布插件、构建应用、组装 Java 包、构建安装器，再串行验收三种发行物。现在同一源码的完整质量门禁通过后，应用构建与插件发布并行；Java 包与安装器消费同一核心 JAR、验签工具和已验证插件输入并行组装。

- Quality Gate 将 SDK 验证从 Java 测试任务中拆出，与 Java 测试和 ProGuard 产物验证并行，稳定的 java-tests 检查仍等待三者全部成功。
- Java 标准包、full-offline 包和 Windows 安装器使用三个独立 Windows runner 验收，保留完整场景，关闭矩阵 fail-fast，按发行物上传独立证据；发布仍要求全部验收成功。
- Nightly / Force 全量插件发布改为一次 Maven reactor 构建，普通正式插件发布保留按需构建和已有不可变附件的跳过行为。
- 安装器复用应用构建产出的验签工具；独立安装器验收从自己的应用 JAR 初始化探针，Release 验收按实际文件名处理版本前缀。

## 验证

- [x] 完整 Maven verify 构建，启用 official-surveys；本地使用开发凭据。
- [x] JavaScript 逻辑测试 298 项通过；最终工作流结构测试 15 项通过。
- [x] 产物边界测试 19 项及发布脚本测试 49 项通过，均无跳过。
- [x] SDK 从隔离源码构建，模板、Javadoc、整合 ZIP、精确 SDK 字节离线消费以及第三方插件签名 / 未签名运行期验收通过。
- [x] Java 标准包与 full-offline 包完成签名及布局校验，两个包的 headless、默认 Compose 和显式 Swing 共六个真实运行场景通过。
- [x] PowerShell 5.1 / 7 编排测试、真实运行期守卫、actionlint、i18n 和 Gate parity 通过。
- [x] 当前 PR 测试合并对象的完整 Quality Gate 及六项 App required checks 全部通过（run 34311023303，attempt 1）。
- [ ] 合入后通过实际 Nightly 验证新任务调度、安装器和公开发行物，并测量总耗时。
- [x] CHANGELOG 已评估：本次为内部 CI 编排优化，无产品版本和用户功能变化。

本地已有安装版，未运行真实安装器安装 / 卸载验收；安装器编排与探针输入已由执行式测试覆盖，完整安装器运行期验收保留在干净 CI runner。此次验证未进行优化前后发行物的逐字节一致性比较。
