### PR TITLE
fix(ci): 保留 Windows 构建参数的完整传递

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           node-version: '24'
       - name: Build release artifacts with ProGuard
-        run: mvn -B -ntp verify -Pofficial-surveys -DskipTests -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
+        run: mvn -B -ntp verify -Pofficial-surveys -DskipTests '-Dmaven.javadoc.skip=true' '-Dmaven.source.skip=true'
       - name: Run Windows Compose tests using the compiled plugin
         working-directory: pixivdownload-plugin-gui-compose
         shell: pwsh

--- a/scripts/ci/test/workflow-orchestration.test.ps1
+++ b/scripts/ci/test/workflow-orchestration.test.ps1
@@ -39,6 +39,16 @@ $fixture = Join-Path $tempBase ('pixiv-workflow-test-' + [Guid]::NewGuid().ToStr
 [IO.Directory]::CreateDirectory($fixture) | Out-Null
 try {
     & {
+        $commands = @(Get-Content (Join-Path $repo '.github/workflows/quality-gate.yml') |
+            Where-Object { $_ -match '^\s+run: mvn\b.*\bverify\b.*-Pofficial-surveys' })
+        Assert-Equal $commands.Count 1
+        function mvn { $script:mavenArguments = @($args) }
+        & ([scriptblock]::Create(($commands[0] -replace '^\s+run: ', '')))
+        foreach ($property in @('maven.javadoc.skip', 'maven.source.skip')) {
+            Assert-Equal (@($script:mavenArguments | Where-Object { $_ -ceq "-D$property=true" }).Count) 1
+        }
+    }
+    & {
         $program = Read-Program (Join-Path $repo 'scripts/test-release-artifacts.ps1')
         foreach ($definition in $program.Functions) { . ([scriptblock]::Create($definition.Extent.Text)) }
         $script:observed = [Collections.Generic.List[string]]::new()


### PR DESCRIPTION
## 变更内容

Windows Quality Gate 调用 Maven 时，未加引号的点号属性被 PowerShell 拆分，触发 `Unknown lifecycle phase ".javadoc.skip=true"`。给两个属性参数加引号，并在 PowerShell 编排测试中执行实际工作流命令、检查收到的完整参数；构建目标和所有验收步骤保持不变。

## 验证

- [x] 新回归在原命令下失败，修复后通过 PowerShell 5.1 和 7。
- [x] 真实 Maven 接收修复后的参数并完成 validate；工作流回归 16 项、actionlint、i18n、trusted contract / parity 通过。
- [x] 完整 JavaScript 299 项通过。本机显式选用 Git Bash；此前 WSL bash 解析错误和临时目录清理失败未计作通过。
- [ ] 当前 PR 的 required checks 全部通过。

当前受保护 master 的 reusable Quality Gate 仍包含原错误命令。PR 按现行可信契约调用该版本，因此修复候选本身不能替换这次执行中的命令；这会阻断正常合并，不能将本地通过当作远端门禁成功。

仅修正 CI 参数传递，无用户使用方式、外部网络访问或运行期行为变化，沿用现有 CHANGELOG 与中英文网络说明。

## 一次性恢复

受保护 base 的错误命令使 PR 自动 QG 在构建前失败。候选 head `2261f26892ababc499cd241ee6e0cf432eaf217b` 已通过直接执行修复后 workflow 的完整 QG：[34332369018](https://github.com/Sywyar/PixivDownloader/actions/runs/34332369018)，9 个 job 全部成功；这不等于 PR 的 App required checks 已通过。

维护者已批准：只给 master Ruleset 临时加入管理员的 pull_request bypass，保留全部 required contexts、App 绑定、strict 与其它规则，对本 PR 执行一次锁定 head 的 Merge commit，并在合并请求成功或失败后立即恢复原配置、逐项核对及运行 doctor。随后对内容树和双亲均匹配的实际 master 合并提交执行完整 QG，通过原生 protected-master 恢复验证后再推进可信 anchor。该例外不作为日常合并方式。
恢复执行状态：候选完整 QG 已通过；管理员合并命令被本地工作流执行守卫拒绝，未向 GitHub 发出合并请求。临时 Ruleset 例外已在 finally 中立即撤销，恢复后的逐字段比较和 GitHub gate doctor 均通过。GitHub Ruleset 历史版本 49119105 / 49119108 记录了约 4.45 秒的变更窗口。PR 仍开放，master 未更新，后续主线完整 QG 和 Nightly 尚未执行。