### PR TITLE
fix(ci): 保留 GUI 观测超时现场并取消过期任务

### DIFF
--- a/scripts/release-e2e/ReleaseProbeAgent.java
+++ b/scripts/release-e2e/ReleaseProbeAgent.java
@@ -13,6 +13,7 @@ import java.awt.image.BufferedImage;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.instrument.Instrumentation;
+import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
@@ -26,6 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.imageio.ImageIO;
 
@@ -249,9 +252,34 @@ public final class ReleaseProbeAgent {
     }
 
     private static <T> T onEventThread(java.util.concurrent.Callable<T> action) throws Exception {
-        FutureTask<T> task = new FutureTask<>(action);
+        AtomicBoolean started = new AtomicBoolean();
+        FutureTask<T> task = new FutureTask<>(() -> {
+            started.set(true);
+            return action.call();
+        });
         EventQueue.invokeLater(task);
-        return task.get(5, TimeUnit.SECONDS);
+        try {
+            return task.get(5, TimeUnit.SECONDS);
+        } catch (TimeoutException failure) {
+            task.cancel(false);
+            // 不依赖已阻塞的 EDT 保存现场，也不让诊断失败覆盖原始超时。
+            try { saveThreads(started.get()); } catch (Exception diagnostic) { failure.addSuppressed(diagnostic); }
+            throw failure;
+        }
+    }
+
+    private static void saveThreads(boolean started) throws Exception {
+        var threads = ManagementFactory.getThreadMXBean().dumpAllThreads(true, true, 128);
+        try (var output = Files.newBufferedWriter(directory.resolve("edt-timeout.txt"), StandardCharsets.UTF_8)) {
+            output.write("EDT task started: " + started + "\n");
+            for (int i = 0; i < Math.min(threads.length, 256); i++) {
+                var thread = threads[i];
+                output.write("\n" + thread.getThreadName() + " #" + thread.getThreadId() + " "
+                        + thread.getThreadState() + " lock=" + thread.getLockName()
+                        + " owner=" + thread.getLockOwnerName() + " #" + thread.getLockOwnerId() + "\n");
+                for (var frame : thread.getStackTrace()) output.write("\tat " + frame + "\n");
+            }
+        }
     }
 
     private static Object field(Class<?> type, Object object, String name) throws Exception {

--- a/scripts/release-e2e/fixtures/DelayedLauncher.java
+++ b/scripts/release-e2e/fixtures/DelayedLauncher.java
@@ -1,5 +1,10 @@
 package top.sywyar.pixivdownload.gui;
 
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicReference;
@@ -10,7 +15,28 @@ public final class DelayedLauncher {
         Path directory = Path.of(args[0]);
         while (!Files.exists(directory.resolve("load"))) Thread.sleep(20);
         Class.forName("top.sywyar.pixivdownload.gui.GuiLauncher");
-        while (!Files.exists(directory.resolve("exit"))) Thread.sleep(20);
+        while (!Files.exists(directory.resolve("exit"))) {
+            if (Files.deleteIfExists(directory.resolve("block"))) {
+                EventQueue.invokeLater(() -> blockEventThread(directory));
+            }
+            Thread.sleep(20);
+        }
+        System.exit(0);
+    }
+
+    private static void blockEventThread(Path directory) {
+        try {
+            Dialog dialog = new Dialog((Frame) null, "Queued dismissal sentinel");
+            dialog.addWindowListener(new WindowAdapter() {
+                @Override public void windowClosing(WindowEvent event) { dialog.dispose(); }
+            });
+            dialog.setSize(240, 120);
+            dialog.setVisible(true);
+            Files.createFile(directory.resolve("blocked"));
+            while (!Files.exists(directory.resolve("release"))) Thread.sleep(20);
+        } catch (Exception failure) {
+            throw new IllegalStateException(failure);
+        }
     }
 }
 

--- a/scripts/release-e2e/runtime.test.ps1
+++ b/scripts/release-e2e/runtime.test.ps1
@@ -81,6 +81,33 @@ try {
     } while ($true)
     if (Test-ReleaseDesktopReady $desktop '' -BootstrapPrompt) { throw 'Loaded entry without a window was accepted.' }
     Assert-Rejected { Invoke-ReleaseProbe $child $startupProbe 'unknown-command' } 'Unknown probe command'
+    New-Item -ItemType File -Path (Join-Path $startupProbe 'block') | Out-Null
+    $deadline = [DateTime]::UtcNow.AddSeconds(15)
+    while (-not (Test-Path -LiteralPath (Join-Path $startupProbe 'blocked'))) {
+        Assert-ArtifactAlive $child 'Blocked EDT fixture'
+        if ([DateTime]::UtcNow -ge $deadline) { throw 'EDT fixture did not block.' }
+        Start-Sleep -Milliseconds 50
+    }
+    Assert-Rejected { Invoke-ReleaseProbe $child $startupProbe 'dismiss' } 'TimeoutException'
+    $threads = Get-Content -LiteralPath (Join-Path $startupProbe 'edt-timeout.txt') -Raw -Encoding UTF8
+    if (-not $threads.Contains('EDT task started: false') -or
+        -not $threads.Contains('AWT-EventQueue') -or -not $threads.Contains('blockEventThread')) {
+        throw 'EDT timeout evidence omitted the queued task or blocking thread.'
+    }
+    $threadPath = Join-Path $startupProbe 'edt-timeout.txt'
+    Remove-Item -LiteralPath $threadPath
+    New-Item -ItemType Directory -Path $threadPath | Out-Null
+    Assert-Rejected { Invoke-ReleaseProbe $child $startupProbe 'desktop' } 'TimeoutException'
+    $errorResponse = Get-Content -LiteralPath (Join-Path $startupProbe 'response.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+    if (-not $errorResponse.error.Contains('Suppressed:')) {
+        throw 'Thread evidence write failure replaced or hid the original timeout.'
+    }
+    New-Item -ItemType File -Path (Join-Path $startupProbe 'release') | Out-Null
+    $desktop = Invoke-ReleaseProbe $child $startupProbe 'desktop'
+    if ($desktop.bootstrapPrompts -ne 1) { throw 'Expired dismissal ran after EDT recovery.' }
+    Invoke-ReleaseProbe $child $startupProbe 'dismiss' | Out-Null
+    $desktop = Invoke-ReleaseProbe $child $startupProbe 'desktop'
+    if ($desktop.bootstrapPrompts -ne 0) { throw 'Fresh dismissal did not close the fixture window.' }
     New-Item -ItemType File -Path (Join-Path $startupProbe 'exit') | Out-Null
     Wait-ArtifactProcessExit $child 'Delayed entry fixture' 15
     if ($child.ExitCode -ne 0) { throw "Delayed entry fixture failed with code $($child.ExitCode)." }


### PR DESCRIPTION
## 变更内容

发行物 GUI 观测在 EDT 响应超过 5 秒时只留下超时异常，且排队的命令可能在 EDT 恢复后继续执行。现在会取消过期任务，并保存线程状态、锁信息和调用栈；记录失败作为附加异常保留，原始超时继续使验收失败。

回归使用真实 Java agent 和阻塞 EDT 的夹具，验证线程现场、记录写入失败，以及恢复后过期命令不执行、新命令正常执行。保留既有 5 秒 EDT 和 15 秒 IPC 超时。

原始 [Nightly #131](https://github.com/Sywyar/PixivDownloader/actions/runs/34348827524) 的 GUI 回退超时尚未在本机复现。本次修复观测器的错误处理，并为再次发生的超时提供诊断证据。

## 验证

- [x] PowerShell 5.1 和 7 执行观测器回归通过。
- [x] 原始 Nightly #131 的 packaged JRE 执行观测器回归通过；删除取消逻辑的反例会使过期命令断言失败。
- [x] 从 #131 原始安装包提取的隔离副本，通过首次运行、GUI 初始化故障、GUI 连续回退和插件运行期故障场景。使用原始 packaged JRE，未覆盖 EXE 提权及实际安装、卸载。
- [x] `npm run i18n:check` 和 `npm run gate:parity` 通过。
- [x] 当前 PR 的完整 Quality Gate 和六项 App required checks 全部通过（run 34362794433，attempt 1）。
- [x] 已判断 CHANGELOG 适用性：仅内部测试工具变化，无用户产物或行为变化，不新增条目。
