### PR TITLE
fix(release): 区分桌面就绪等待与稳定期响应超时

### DIFF
--- a/scripts/release-e2e/ReleaseProbeAgent.java
+++ b/scripts/release-e2e/ReleaseProbeAgent.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.imageio.ImageIO;
 
@@ -60,7 +60,9 @@ public final class ReleaseProbeAgent {
                         String result = execute(lines.get(1), lines.size() > 2 ? lines.get(2) : "");
                         respond(nonce, "\"ok\":true," + result);
                     } catch (Throwable failure) {
-                        respond(nonce, "\"ok\":false,\"error\":" + quote(stack(failure)));
+                        String status = failure instanceof EdtTimeoutException timeout
+                                ? ",\"code\":\"EDT_TIMEOUT\",\"taskStarted\":" + timeout.taskStarted : "";
+                        respond(nonce, "\"ok\":false,\"error\":" + quote(stack(failure)) + status);
                     }
                 }
                 Thread.sleep(50);
@@ -252,19 +254,32 @@ public final class ReleaseProbeAgent {
     }
 
     private static <T> T onEventThread(java.util.concurrent.Callable<T> action) throws Exception {
-        AtomicBoolean started = new AtomicBoolean();
+        // 开始与取消竞争同一个状态，避免超时响应把刚开始的检查误报为仍在排队。
+        AtomicInteger state = new AtomicInteger(); // 0：排队；1：开始；2：取消
         FutureTask<T> task = new FutureTask<>(() -> {
-            started.set(true);
+            if (!state.compareAndSet(0, 1)) return null;
             return action.call();
         });
         EventQueue.invokeLater(task);
         try {
             return task.get(5, TimeUnit.SECONDS);
-        } catch (TimeoutException failure) {
+        } catch (TimeoutException cause) {
+            boolean started = !state.compareAndSet(0, 2);
             task.cancel(false);
+            EdtTimeoutException failure = new EdtTimeoutException(started, cause);
             // 不依赖已阻塞的 EDT 保存现场，也不让诊断失败覆盖原始超时。
-            try { saveThreads(started.get()); } catch (Exception diagnostic) { failure.addSuppressed(diagnostic); }
+            try { saveThreads(started); } catch (Exception diagnostic) { failure.addSuppressed(diagnostic); }
             throw failure;
+        }
+    }
+
+    private static final class EdtTimeoutException extends TimeoutException {
+        private final boolean taskStarted;
+
+        private EdtTimeoutException(boolean taskStarted, TimeoutException cause) {
+            super("EDT task started: " + taskStarted);
+            this.taskStarted = taskStarted;
+            initCause(cause);
         }
     }
 

--- a/scripts/release-e2e/fixtures/DelayedLauncher.java
+++ b/scripts/release-e2e/fixtures/DelayedLauncher.java
@@ -2,7 +2,11 @@ package top.sywyar.pixivdownload.gui;
 
 import java.awt.Dialog;
 import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Font;
 import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Label;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.nio.file.Files;
@@ -11,6 +15,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /** 用文件握手控制入口类加载，让真实观测器稳定遇到启动中的应用。 */
 public final class DelayedLauncher {
+    private static Dialog dialog;
+
     public static void main(String[] args) throws Exception {
         Path directory = Path.of(args[0]);
         while (!Files.exists(directory.resolve("load"))) Thread.sleep(20);
@@ -19,6 +25,10 @@ public final class DelayedLauncher {
             if (Files.deleteIfExists(directory.resolve("block"))) {
                 EventQueue.invokeLater(() -> blockEventThread(directory));
             }
+            if (Files.isRegularFile(directory.resolve("edt-timeout.txt"))
+                    && Files.deleteIfExists(directory.resolve("release-after-timeout"))) {
+                Files.writeString(directory.resolve("release"), "");
+            }
             Thread.sleep(20);
         }
         System.exit(0);
@@ -26,17 +36,44 @@ public final class DelayedLauncher {
 
     private static void blockEventThread(Path directory) {
         try {
-            Dialog dialog = new Dialog((Frame) null, "Queued dismissal sentinel");
-            dialog.addWindowListener(new WindowAdapter() {
-                @Override public void windowClosing(WindowEvent event) { dialog.dispose(); }
-            });
-            dialog.setSize(240, 120);
-            dialog.setVisible(true);
+            if (dialog == null) {
+                dialog = new Dialog((Frame) null, "Queued dismissal sentinel");
+                dialog.addWindowListener(new WindowAdapter() {
+                    @Override public void windowClosing(WindowEvent event) { dialog.dispose(); }
+                });
+                dialog.setLayout(new FlowLayout());
+                dialog.setFont(new Font(Font.DIALOG, Font.PLAIN, 14));
+                for (String text : new String[]{"Release observer fixture", "Ready"}) {
+                    dialog.add(new Label(text) {
+                        // 原生 Label 的离屏 paint 不绘制文字；夹具显式绘制以接受同一可读性检查。
+                        @Override public void paint(Graphics graphics) {
+                            graphics.drawString(getText(), 0, getFontMetrics(getFont()).getAscent());
+                        }
+                        @Override public javax.accessibility.AccessibleContext getAccessibleContext() {
+                            try {
+                                if (Files.deleteIfExists(directory.resolve("block-inspection"))) {
+                                    Files.createFile(directory.resolve("inspection-started"));
+                                    awaitRelease(directory);
+                                }
+                            } catch (Exception failure) {
+                                throw new IllegalStateException(failure);
+                            }
+                            return super.getAccessibleContext();
+                        }
+                    });
+                }
+                dialog.setSize(300, 160);
+                dialog.setVisible(true);
+            }
             Files.createFile(directory.resolve("blocked"));
-            while (!Files.exists(directory.resolve("release"))) Thread.sleep(20);
+            awaitRelease(directory);
         } catch (Exception failure) {
             throw new IllegalStateException(failure);
         }
+    }
+
+    private static void awaitRelease(Path directory) throws Exception {
+        while (!Files.exists(directory.resolve("release"))) Thread.sleep(20);
     }
 }
 

--- a/scripts/release-e2e/runtime.ps1
+++ b/scripts/release-e2e/runtime.ps1
@@ -66,7 +66,10 @@ function Assert-ArtifactAlive {
 }
 
 function Invoke-ReleaseProbe {
-    param($Process, [string]$ProbeRoot, [string]$Command, [string]$Target = '', [int]$TimeoutSeconds = 15)
+    param($Process, [string]$ProbeRoot, [string]$Command, [string]$Target = '', [int]$TimeoutSeconds = 15,
+        [switch]$AllowPendingDesktop, [DateTime]$Deadline = [DateTime]::MaxValue)
+    $responseDeadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    if ($Deadline -lt $responseDeadline) { $responseDeadline = $Deadline }
     Assert-ArtifactAlive $Process $Command
     $nonce = [Guid]::NewGuid().ToString('N')
     $responsePath = Join-Path $ProbeRoot 'response.json'
@@ -76,12 +79,19 @@ function Invoke-ReleaseProbe {
     $request = Join-Path $ProbeRoot 'request.txt'
     [IO.File]::WriteAllText($temporary, "$nonce`n$Command`n$Target`n", [Text.UTF8Encoding]::new($false))
     [IO.File]::Move($temporary, $request)
-    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
-    do {
+    while ([DateTime]::UtcNow -lt $responseDeadline) {
         if (Test-Path -LiteralPath $responsePath) {
             $response = Get-Content -LiteralPath $responsePath -Raw -Encoding UTF8 | ConvertFrom-Json
             if ($response.nonce -eq $nonce) {
-                if (-not $response.ok) { throw "Release observer failed: $($response.error)" }
+                if (-not $response.ok) {
+                    if ($AllowPendingDesktop -and $Command -eq 'desktop' -and
+                        $response.PSObject.Properties['code'] -and $response.code -eq 'EDT_TIMEOUT' -and
+                        $response.PSObject.Properties['taskStarted'] -and
+                        $response.taskStarted -is [bool] -and -not $response.taskStarted) {
+                        return $response
+                    }
+                    throw "Release observer failed: $($response.error)"
+                }
                 if ($Command -eq 'desktop') {
                     $response | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $ProbeRoot 'desktop.json') -Encoding UTF8
                 }
@@ -89,9 +99,10 @@ function Invoke-ReleaseProbe {
             }
         }
         Assert-ArtifactAlive $Process $Command
-        Start-Sleep -Milliseconds 100
-    } while ([DateTime]::UtcNow -lt $deadline)
-    throw "Release observer did not answer $Command within $TimeoutSeconds seconds"
+        $remaining = ($responseDeadline - [DateTime]::UtcNow).TotalMilliseconds
+        if ($remaining -gt 0) { Start-Sleep -Milliseconds ([int][Math]::Ceiling([Math]::Min(100, $remaining))) }
+    }
+    throw "Release observer did not answer $Command before its deadline (up to $TimeoutSeconds seconds)"
 }
 
 function Connect-ReleaseProbe {
@@ -152,10 +163,13 @@ function Assert-ReleaseStatus {
 function Wait-ReleaseDesktop {
     param($Process, [string]$ProbeRoot, [string]$Provider, [switch]$BootstrapPrompt, [int]$TimeoutSeconds = 180)
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    $desktop = $null
     do {
-        $desktop = Invoke-ReleaseProbe $Process $ProbeRoot 'desktop'
-        if (Test-ReleaseDesktopReady $desktop $Provider -BootstrapPrompt:$BootstrapPrompt) { return $desktop }
-        Start-Sleep -Milliseconds 500
+        $desktop = Invoke-ReleaseProbe $Process $ProbeRoot 'desktop' -AllowPendingDesktop -Deadline $deadline
+        if ([DateTime]::UtcNow -ge $deadline) { break }
+        if ($desktop.ok -and (Test-ReleaseDesktopReady $desktop $Provider -BootstrapPrompt:$BootstrapPrompt)) { return $desktop }
+        $remaining = ($deadline - [DateTime]::UtcNow).TotalMilliseconds
+        if ($remaining -gt 0) { Start-Sleep -Milliseconds ([int][Math]::Ceiling([Math]::Min(500, $remaining))) }
     } while ([DateTime]::UtcNow -lt $deadline)
     throw "Desktop did not render the expected provider/prompt: $($desktop | ConvertTo-Json -Compress -Depth 4)"
 }

--- a/scripts/release-e2e/runtime.test.ps1
+++ b/scripts/release-e2e/runtime.test.ps1
@@ -229,6 +229,15 @@ try {
     Assert-Rejected { Wait-ArtifactProcessExit $child 'stuck child' 1 } 'did not exit'
     if (-not $child.HasExited) { throw 'Timed out child was not cleaned up.' }
     Write-Host 'PASS: release E2E retries queued desktop startup within one deadline; rejects active/stable EDT stalls, early/late exit, dead JVM, stale probes, broken GUI, unexpected recovery and failed shutdown.'
+} catch {
+    Write-Host $_.ScriptStackTrace
+    Get-ChildItem -LiteralPath $context.Session -Recurse -File |
+        Where-Object { $_.Name -in @('edt-timeout.txt', 'probe-error.txt', 'stderr.log') } |
+        ForEach-Object {
+            Write-Host "Fixture diagnostic: $($_.FullName)"
+            Get-Content -LiteralPath $_.FullName -Tail 200 -Encoding UTF8 | ForEach-Object { Write-Host $_ }
+        }
+    throw
 } finally {
     foreach ($child in $children) { Stop-ArtifactProcess $child }
     Remove-TestSessionRoot $context

--- a/scripts/release-e2e/runtime.test.ps1
+++ b/scripts/release-e2e/runtime.test.ps1
@@ -19,6 +19,20 @@ function Assert-Rejected {
     throw "False success: expected $Message"
 }
 
+function Start-BlockedDesktop {
+    foreach ($name in @('blocked', 'release', 'edt-timeout.txt')) {
+        $path = Join-Path $startupProbe $name
+        if (Test-Path -LiteralPath $path) { Remove-Item -LiteralPath $path }
+    }
+    New-Item -ItemType File -Path (Join-Path $startupProbe 'block') | Out-Null
+    $deadline = [DateTime]::UtcNow.AddSeconds(15)
+    while (-not (Test-Path -LiteralPath (Join-Path $startupProbe 'blocked'))) {
+        Assert-ArtifactAlive $child 'Blocked EDT fixture'
+        if ([DateTime]::UtcNow -ge $deadline) { throw 'EDT fixture did not block.' }
+        Start-Sleep -Milliseconds 50
+    }
+}
+
 $WorkRoot = [IO.Path]::GetTempPath()
 $context = New-TestSessionRoot
 $children = @()
@@ -81,14 +95,8 @@ try {
     } while ($true)
     if (Test-ReleaseDesktopReady $desktop '' -BootstrapPrompt) { throw 'Loaded entry without a window was accepted.' }
     Assert-Rejected { Invoke-ReleaseProbe $child $startupProbe 'unknown-command' } 'Unknown probe command'
-    New-Item -ItemType File -Path (Join-Path $startupProbe 'block') | Out-Null
-    $deadline = [DateTime]::UtcNow.AddSeconds(15)
-    while (-not (Test-Path -LiteralPath (Join-Path $startupProbe 'blocked'))) {
-        Assert-ArtifactAlive $child 'Blocked EDT fixture'
-        if ([DateTime]::UtcNow -ge $deadline) { throw 'EDT fixture did not block.' }
-        Start-Sleep -Milliseconds 50
-    }
-    Assert-Rejected { Invoke-ReleaseProbe $child $startupProbe 'dismiss' } 'TimeoutException'
+    Start-BlockedDesktop
+    Assert-Rejected { Invoke-ReleaseProbe $child $startupProbe 'dismiss' -AllowPendingDesktop } 'TimeoutException'
     $threads = Get-Content -LiteralPath (Join-Path $startupProbe 'edt-timeout.txt') -Raw -Encoding UTF8
     if (-not $threads.Contains('EDT task started: false') -or
         -not $threads.Contains('AWT-EventQueue') -or -not $threads.Contains('blockEventThread')) {
@@ -102,9 +110,44 @@ try {
     if (-not $errorResponse.error.Contains('Suppressed:')) {
         throw 'Thread evidence write failure replaced or hid the original timeout.'
     }
-    New-Item -ItemType File -Path (Join-Path $startupProbe 'release') | Out-Null
-    $desktop = Invoke-ReleaseProbe $child $startupProbe 'desktop'
+    if ($errorResponse.code -ne 'EDT_TIMEOUT' -or $errorResponse.taskStarted -cne $false) {
+        throw 'Queued EDT timeout did not carry structured state.'
+    }
+    Remove-Item -LiteralPath $threadPath
+    New-Item -ItemType File -Path (Join-Path $startupProbe 'release-after-timeout') | Out-Null
+    $elapsed = [Diagnostics.Stopwatch]::StartNew()
+    $desktop = Wait-ReleaseDesktop $child $startupProbe '' -BootstrapPrompt -TimeoutSeconds 15
+    if ($elapsed.Elapsed.TotalSeconds -lt 5) { throw 'Recovery did not exercise a queued EDT timeout.' }
     if ($desktop.bootstrapPrompts -ne 1) { throw 'Expired dismissal ran after EDT recovery.' }
+
+    Start-BlockedDesktop
+    $elapsed.Restart()
+    Assert-Rejected { Wait-ReleaseDesktop $child $startupProbe '' -BootstrapPrompt -TimeoutSeconds 7 } 'did not answer desktop'
+    if ($elapsed.Elapsed.TotalSeconds -lt 7 -or $elapsed.Elapsed.TotalSeconds -gt 9) {
+        throw 'Desktop retries reset or overran the shared deadline.'
+    }
+    New-Item -ItemType File -Path (Join-Path $startupProbe 'release') | Out-Null
+    Wait-ReleaseDesktop $child $startupProbe '' -BootstrapPrompt -TimeoutSeconds 15 | Out-Null
+
+    Start-BlockedDesktop
+    $elapsed.Restart()
+    Assert-Rejected { Assert-ReleaseStable -Process $child -ProbeRoot $startupProbe -BootstrapPrompt -Seconds 15 } 'TimeoutException'
+    if ($elapsed.Elapsed.TotalSeconds -gt 8) { throw 'Stable observation retried an unresponsive EDT.' }
+    New-Item -ItemType File -Path (Join-Path $startupProbe 'release') | Out-Null
+    Wait-ReleaseDesktop $child $startupProbe '' -BootstrapPrompt -TimeoutSeconds 15 | Out-Null
+
+    Remove-Item -LiteralPath (Join-Path $startupProbe 'release')
+    New-Item -ItemType File -Path (Join-Path $startupProbe 'block-inspection') | Out-Null
+    $elapsed.Restart()
+    Assert-Rejected { Wait-ReleaseDesktop $child $startupProbe '' -BootstrapPrompt -TimeoutSeconds 15 } 'TimeoutException'
+    $errorResponse = Get-Content -LiteralPath (Join-Path $startupProbe 'response.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+    $threads = Get-Content -LiteralPath $threadPath -Raw -Encoding UTF8
+    if ($errorResponse.taskStarted -cne $true -or -not $threads.Contains('EDT task started: true') -or
+        -not (Test-Path -LiteralPath (Join-Path $startupProbe 'inspection-started')) -or $elapsed.Elapsed.TotalSeconds -gt 8) {
+        throw 'An already running desktop inspection was retried or lost its evidence.'
+    }
+    New-Item -ItemType File -Path (Join-Path $startupProbe 'release') | Out-Null
+    Wait-ReleaseDesktop $child $startupProbe '' -BootstrapPrompt -TimeoutSeconds 15 | Out-Null
     Invoke-ReleaseProbe $child $startupProbe 'dismiss' | Out-Null
     $desktop = Invoke-ReleaseProbe $child $startupProbe 'desktop'
     if ($desktop.bootstrapPrompts -ne 0) { throw 'Fresh dismissal did not close the fixture window.' }
@@ -113,13 +156,13 @@ try {
     if ($child.ExitCode -ne 0) { throw "Delayed entry fixture failed with code $($child.ExitCode)." }
     Assert-Rejected { Wait-ReleaseDesktop $child $startupProbe '' -BootstrapPrompt -TimeoutSeconds 1 } 'exited'
 
-    $good = [pscustomobject]@{applicationLoaded=$true; provider='gui-compose'; bootstrapPrompts=0; contentColors=30; windows=@('window')}
+    $good = [pscustomobject]@{ok=$true; applicationLoaded=$true; provider='gui-compose'; bootstrapPrompts=0; contentColors=30; windows=@('window')}
     if (-not (Test-ReleaseDesktopReady $good 'gui-compose')) { throw 'Rendered GUI rejected.' }
     foreach ($bad in @(
         [pscustomobject]@{applicationLoaded=$true; provider='gui-swing'; bootstrapPrompts=0; contentColors=30; windows=@('window')},
         [pscustomobject]@{applicationLoaded=$true; provider='gui-compose'; bootstrapPrompts=0; contentColors=1; windows=@('window')},
         [pscustomobject]@{applicationLoaded=$true; provider='gui-compose'; bootstrapPrompts=0; contentColors=30; windows=@()},
-        [pscustomobject]@{applicationLoaded=$true; provider=''; bootstrapPrompts=1; contentColors=30; windows=@('dialog'); bootstrapTextRendered=$true}
+        [pscustomobject]@{ok=$true; applicationLoaded=$true; provider=''; bootstrapPrompts=1; contentColors=30; windows=@('dialog'); bootstrapTextRendered=$true}
     )) {
         if (Test-ReleaseDesktopReady $bad 'gui-compose') { throw 'Wrong, blank or absent GUI accepted.' }
     }
@@ -141,7 +184,7 @@ try {
         $bad.bootstrapPrompts = 1
         $script:desktopReads = 0
         function Invoke-ReleaseProbe {
-            if (++$script:desktopReads -eq 1) { return [pscustomobject]@{applicationLoaded=$false} }
+            if (++$script:desktopReads -eq 1) { return [pscustomobject]@{ok=$true; applicationLoaded=$false} }
             return $ready
         }
         $observed = Wait-ReleaseDesktop $parent $probe $ready.provider -BootstrapPrompt:$bootstrap -TimeoutSeconds 3
@@ -185,7 +228,7 @@ try {
     $children += $child
     Assert-Rejected { Wait-ArtifactProcessExit $child 'stuck child' 1 } 'did not exit'
     if (-not $child.HasExited) { throw 'Timed out child was not cleaned up.' }
-    Write-Host 'PASS: release E2E rejects early/late exit, dead JVM, stale probes, broken GUI, unexpected recovery and failed shutdown.'
+    Write-Host 'PASS: release E2E retries queued desktop startup within one deadline; rejects active/stable EDT stalls, early/late exit, dead JVM, stale probes, broken GUI, unexpected recovery and failed shutdown.'
 } finally {
     foreach ($child in $children) { Stop-ArtifactProcess $child }
     Remove-TestSessionRoot $context


### PR DESCRIPTION
## 变更内容

桌面启动或故障回退期间，发行物观测器的检查可能在 EDT 上排队超过 5 秒，导致桌面尚未就绪时提前终止验收。探针现在区分排队超时与已经开始的检查超时；仅桌面就绪等待可在原 180 秒总期限内重试排队超时。稳定运行仍执行 5 秒响应要求，并保留线程快照和陈旧任务取消。回归测试失败时输出调用栈及测试进程诊断。

## 验证

- [x] PowerShell 5.1 / 7 真实 Java agent 回归，覆盖暂时阻塞恢复、总期限、稳定期阻塞和已开始的检查超时
- [x] JavaScript 311 项通过（Windows 下使用 Git Bash）
- [x] i18n 严格检查及 Gate parity 通过
- [x] 当前 PR 的完整 Quality Gate 和六项绑定 App 的 required checks 通过：[运行 34681020122](https://github.com/Sywyar/PixivDownloader/actions/runs/34681020122)

首次 CI 曾出现已开始的 EDT 检查超时，后续本地与 CI 未复现；保留失败现场输出用于追踪偶发阻塞。本地已有注册安装，未运行安装器 E2E；真实发行物结果仍需 Nightly 验证。此次仅调整内部验收逻辑，不涉及用户功能或发行产物变化，CHANGELOG 不适用。
