### PR TITLE
ci(release): 复用 SDK 门禁产物并完善发布恢复

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -89,6 +89,9 @@ jobs:
             echo "release_id=$release_id"
             echo "prerelease=$prerelease"
           } >> "$GITHUB_OUTPUT"
+          if [ "$publish" = false ]; then
+            echo "SDK $release_id unchanged: publication was not attempted; previous failures are not recovered by this run." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   quality-gate:
     needs: release-plan
@@ -96,6 +99,7 @@ jobs:
     uses: ./.github/workflows/quality-gate.yml
     with:
       trusted_base_sha: ${{ needs.release-plan.outputs.trusted_base_sha }}
+      export_sdk_candidates: ${{ needs.release-plan.outputs.mode == 'publish' }}
 
   publish:
     needs: [release-plan, quality-gate]
@@ -159,7 +163,7 @@ jobs:
             esac
           done
           if [ "$central_count" -ne 0 ] && [ "$central_count" -ne "${#artifacts[@]}" ]; then
-            echo "Maven Central contains only part of SDK $SDK_VERSION; refusing to mutate publication history" >&2
+            echo "Maven Central exposes only part of SDK $SDK_VERSION; inspect the original Central deployment and wait for all coordinates before recovery. No upload will be attempted." >&2
             exit 1
           fi
 
@@ -183,31 +187,50 @@ jobs:
             published="$(node -pe '!JSON.parse(process.argv[1])[0].draft' "$releases")"
           fi
 
-          if [ "$PUBLICATION_MODE" = "publish" ]; then
-            if [ "$central_count" -ne 0 ] || [ "$published" = true ] || { [ "$tag_exists" = true ] && [ "$reuse_release" = false ]; }; then
-              echo "SDK $RELEASE_ID already has public artifacts; use exact recovery or a new SDK version" >&2
-              exit 1
-            fi
-          elif [ "$PUBLICATION_MODE" = "recover-release" ]; then
-            if [ "$central_count" -ne "${#artifacts[@]}" ] || [ "$reuse_release" = false ]; then
-              echo "release recovery requires complete Central artifacts and the original frozen SDK Release" >&2
-              exit 1
-            fi
-          else
+          if [ "$PUBLICATION_MODE" != publish ] && [ "$PUBLICATION_MODE" != recover-release ]; then
             echo "unsupported publication mode: $PUBLICATION_MODE" >&2
             exit 1
           fi
+          publish_central=false
+          if [ "$central_count" -eq "${#artifacts[@]}" ]; then
+            if [ "$reuse_release" = false ]; then
+              echo "release recovery requires the original frozen SDK Release" >&2
+              exit 1
+            fi
+            echo "Central is complete; restore and verify the original signed SDK assets without redeploying."
+          elif [ "$reuse_release" = true ]; then
+            echo "SDK $RELEASE_ID already has frozen assets but Central is not publicly readable. A previous upload may still be processing; inspect its deployment ID before retrying. No upload will be attempted." >&2
+            exit 1
+          elif [ "$PUBLICATION_MODE" = recover-release ] || [ "$tag_exists" = true ]; then
+            echo "SDK publication state is incomplete: recovery requires complete Central artifacts and the original frozen SDK Release" >&2
+            exit 1
+          else
+            publish_central=true
+          fi
           echo "reuse_release=$reuse_release" >> "$GITHUB_OUTPUT"
           echo "published=$published" >> "$GITHUB_OUTPUT"
+          echo "publish_central=$publish_central" >> "$GITHUB_OUTPUT"
 
       - name: Install Node.js dependencies
         run: npm ci
 
-      - name: Verify release SDK artifacts
+      - name: Require SDK candidate from this quality gate
         if: ${{ steps.state.outputs.reuse_release == 'false' }}
-        uses: ./.github/actions/verify-sdk
+        env:
+          SDK_CANDIDATE_ID: ${{ needs.quality-gate.outputs.sdk_candidate_id }}
+        run: |
+          if ! [[ "$SDK_CANDIDATE_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Missing verified SDK candidate; rerun the full workflow for this source commit." >&2
+            exit 1
+          fi
+
+      - name: Restore SDK candidate verified by this run
+        if: ${{ steps.state.outputs.reuse_release == 'false' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          source_sha: ${{ github.sha }}
+          artifact-ids: ${{ needs.quality-gate.outputs.sdk_candidate_id }}
+          path: target/sdk-release
+          merge-multiple: true
 
       - name: Restore original frozen SDK Release
         if: ${{ steps.state.outputs.reuse_release == 'true' }}
@@ -222,8 +245,9 @@ jobs:
           done
           cd "$GITHUB_WORKSPACE"
           node scripts/ci/sdk-release.mjs --verify-directory target/sdk-release --source-sha "$GITHUB_SHA"
-          # 消费者仍从同一源码构建；恢复时复用原始宿主、工具和 SDK ZIP。
-          mvn -B -ntp -pl pixivdownload-plugin-signature package -DskipTests -Dexec.skip=true
+
+      - name: Build signature verifier for frozen consumers
+        run: mvn -B -ntp -pl pixivdownload-plugin-signature package -DskipTests -Dexec.skip=true
 
       - name: Freeze signed SDK assets before Central publication
         if: ${{ steps.state.outputs.reuse_release == 'false' }}
@@ -267,7 +291,7 @@ jobs:
           node scripts/ci/sdk-release.mjs --verify-directory target/sdk-frozen-download --source-sha "$GITHUB_SHA"
 
       - name: Publish SDK artifacts to Maven Central
-        if: ${{ needs.release-plan.outputs.mode == 'publish' }}
+        if: ${{ steps.state.outputs.publish_central == 'true' }}
         run: |
           set -euo pipefail
           sdk_modules="$(node scripts/ci/sdk-version.mjs --modules)"

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -9,6 +9,10 @@ on:
         type: string
   workflow_call:
     inputs:
+      export_sdk_candidates:
+        required: false
+        type: boolean
+        default: false
       export_release_candidates:
         required: false
         type: boolean
@@ -16,6 +20,10 @@ on:
       trusted_base_sha:
         required: false
         type: string
+    outputs:
+      sdk_candidate_id:
+        description: SDK candidate artifact verified in this workflow run
+        value: ${{ jobs.sdk-tests.outputs.candidate_id }}
 
 permissions:
   contents: read
@@ -56,6 +64,8 @@ jobs:
   sdk-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    outputs:
+      candidate_id: ${{ steps.sdk-candidate.outputs.artifact-id }}
     steps:
       - name: Checkout tested commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -99,6 +109,17 @@ jobs:
           node scripts/ci/sdk-api-surface.mjs --module sdk-info=pixivdownload-sdk-info/target --module plugin-api=pixivdownload-plugin-api/target --module core-api=pixivdownload-core-api/target --output "$RUNNER_TEMP/sdk-candidate-surface.txt"
           node scripts/ci/sdk-contract.mjs --repo-root . --base-ref "$SDK_BASE_SHA" --candidate-ref "$GITHUB_SHA" --base-surface "$RUNNER_TEMP/sdk-base-surface.txt" --candidate-surface "$RUNNER_TEMP/sdk-candidate-surface.txt" --base-sdk-root "$BASE_DIR" --candidate-sdk-root . --report "$RUNNER_TEMP/sdk-contract-report.json"
           cat "$RUNNER_TEMP/sdk-contract-report.json"
+
+      - name: Upload verified SDK candidate
+        id: sdk-candidate
+        if: inputs.export_sdk_candidates == true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: sdk-candidate-${{ github.sha }}-${{ github.run_attempt }}
+          path: target/sdk-release/
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
 
   release-artifacts:
     runs-on: windows-latest

--- a/pom.xml
+++ b/pom.xml
@@ -331,6 +331,7 @@ obfuscate=false
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
                             <waitUntil>PUBLISHED</waitUntil>
+                            <waitMaxTime>3600</waitMaxTime>
                             <checksums>all</checksums>
                             <deploymentName>PixivDownloader Plugin SDK ${pixivdownload.sdk.version}</deploymentName>
                             <excludeArtifacts>

--- a/scripts/ci/sdk-runtime-input.json
+++ b/scripts/ci/sdk-runtime-input.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "assetUrl": "https://api.github.com/repos/Sywyar/PixivDownloader/releases/assets/553050767",
-  "size": 150696018,
-  "sha256": "5d73f16d48e9e434cdbc9ecdd67150b0dab63cc2fc3483f04f31d43ec088ed1a"
+  "assetUrl": "https://api.github.com/repos/Sywyar/PixivDownloader-Plugin-SDK/releases/assets/557298186",
+  "size": 150708972,
+  "sha256": "841a7f9c513dfbc6d4d5c3adf7bc91df30259c2a8a31895c37fbf26ed0b3ceca"
 }

--- a/scripts/ci/sdk-runtime-inputs.ps1
+++ b/scripts/ci/sdk-runtime-inputs.ps1
@@ -12,7 +12,7 @@ $inputFile = Get-Item -LiteralPath $InputManifest
 if ($inputFile.Length -gt 1MB) { throw 'SDK input metadata is too large.' }
 $inputLock = [IO.File]::ReadAllText($inputFile.FullName, [Text.Encoding]::UTF8) | ConvertFrom-Json
 if ($inputLock.schemaVersion -ne 1 -or
-    $inputLock.assetUrl -cnotmatch '^https://api\.github\.com/repos/Sywyar/PixivDownloader/releases/assets/[1-9][0-9]*$' -or
+    $inputLock.assetUrl -cnotmatch '^https://api\.github\.com/repos/Sywyar/PixivDownloader(?:-Plugin-SDK)?/releases/assets/[1-9][0-9]*$' -or
     $inputLock.sha256 -cnotmatch '^[0-9a-f]{64}$' -or
     $inputLock.size -le 0 -or $inputLock.size -gt 512MB) { throw 'Invalid fixed SDK plugin input.' }
 $OutputDirectory = [IO.Path]::GetFullPath($OutputDirectory)

--- a/scripts/ci/test/quality-gate-workflow.test.mjs
+++ b/scripts/ci/test/quality-gate-workflow.test.mjs
@@ -268,17 +268,39 @@ test('QG 覆盖 Compose、SDK 消费者和两种 PowerShell，并顺序复用构
     const scripts = Object.values(jobs).flatMap(executionSteps)
         .filter(step => /check-powershell\.ps1/u.test(step.run || ''));
     assert.deepEqual(scripts.map(step => step.shell).sort(), ['powershell', 'pwsh']);
-    for (const [file, action] of [
-        ['.github/workflows/publish-sdk.yml', './.github/actions/verify-sdk'],
-        ['.github/actions/build-release-java/action.yml', './.github/actions/verify-release-boundaries'],
-    ]) {
-        const doc = load(file);
-        const steps = doc.runs?.steps || Object.values(doc.jobs).flatMap(job => job.steps || []);
-        assert.ok(steps.some(step => step.uses === action), file);
-    }
     const release = load('.github/actions/build-release-java/action.yml').runs.steps
         .find(step => step.uses === './.github/actions/verify-release-boundaries');
+    assert.ok(release);
     assert.equal(release.with.require_production_credential_key, 'true');
+});
+
+test('SDK 发布串行消费本次完整 QG 验证的候选，恢复继续使用原始冻结附件', () => {
+    const qg = load('.github/workflows/quality-gate.yml');
+    const sdk = load('.github/workflows/publish-sdk.yml');
+    const producer = qg.jobs['sdk-tests'];
+    const upload = producer.steps.find(step => step.id === 'sdk-candidate');
+    assert.equal(qg.on.workflow_call.inputs.export_sdk_candidates.default, false);
+    assert.equal(sdk.jobs['quality-gate'].with.export_sdk_candidates,
+        "${{ needs.release-plan.outputs.mode == 'publish' }}");
+    assert.match(upload.uses, /^actions\/upload-artifact@[a-f0-9]{40}$/u);
+    assert.equal(upload.if.replace(/^\$\{\{\s*|\s*\}\}$/gu, ''), 'inputs.export_sdk_candidates == true');
+    assert.equal(upload.with.path, 'target/sdk-release/');
+    assert.equal(upload.with['if-no-files-found'], 'error');
+    assert.equal(producer.outputs.candidate_id, '${{ steps.sdk-candidate.outputs.artifact-id }}');
+    assert.equal(qg.on.workflow_call.outputs.sdk_candidate_id.value,
+        '${{ jobs.sdk-tests.outputs.candidate_id }}');
+    const steps = sdk.jobs.publish.steps;
+    const download = steps.find(step => step.uses?.startsWith('actions/download-artifact@'));
+    assert.deepEqual(download.with, {
+        'artifact-ids': '${{ needs.quality-gate.outputs.sdk_candidate_id }}',
+        path: 'target/sdk-release', 'merge-multiple': true,
+    });
+    assert.equal(download.if, "${{ steps.state.outputs.reuse_release == 'false' }}");
+    assert.ok(!steps.some(step => step.uses === './.github/actions/verify-sdk'));
+    const freeze = steps.findIndex(step => step.name === 'Freeze signed SDK assets before Central publication');
+    assert.ok(steps.indexOf(download) < freeze);
+    assert.match(steps[freeze].run, /--verify-directory target\/sdk-release --source-sha/u);
+    assert.ok(steps.findIndex(step => /pixivdownload-plugin-signature package/u.test(step.run || '')) < freeze);
 });
 
 test('发布链：所有凭据与写权限只在 release Environment 的门禁后使用', () => {
@@ -442,7 +464,7 @@ test('SDK 发布链只在身份变化或显式恢复时通过同 SHA 门禁写�
     const restore = sdk.jobs.publish.steps.find(step => step.name === 'Restore original frozen SDK Release');
     assert.match(restore.run, /gpg --batch --verify/u);
     assert.match(restore.run, /--verify-directory/u);
-    assert.equal(central.if, "${{ needs.release-plan.outputs.mode == 'publish' }}");
+    assert.equal(central.if, "${{ steps.state.outputs.publish_central == 'true' }}");
     assert.match(remote.run, /gh release download/u);
     assert.match(remote.run, /sdk-consumer\.mjs/u);
     assert.doesNotMatch(serialized, /PixivDownloader-Plugin-SDK-Javadocs/u);

--- a/scripts/ci/test/sdk-publication.test.mjs
+++ b/scripts/ci/test/sdk-publication.test.mjs
@@ -13,7 +13,7 @@ const IDENTITY = inspectSdkVersion(ROOT);
 const workflow = YAML.parse(fs.readFileSync(path.join(ROOT, '.github/workflows/publish-sdk.yml'), 'utf8'));
 const script = workflow.jobs.publish.steps.find(step => step.name === 'Check immutable publication state').run;
 
-test('SDK 发布状态实际拒绝部分 Central、冲突公开身份和缺少冻结附件的恢复', () => {
+test('SDK 发布仅在全新身份上传，完整 Central 复用冻结附件，不确定状态拒绝重复上传', () => {
     const work = fs.mkdtempSync(path.join(os.tmpdir(), 'sdk-publication-'));
     try {
         const entry = path.join(work, 'check.sh');
@@ -38,19 +38,25 @@ test('SDK 发布状态实际拒绝部分 Central、冲突公开身份和缺少�
         ].join('\n'), 'utf8');
         for (const [mode, central, release, tag, accept, published] of [
             ['publish', 'empty', 'absent', false, true, false],
-            ['publish', 'empty', 'draft', false, true, false],
-            ['publish', 'empty', 'draft', true, true, false],
+            ['publish', 'empty', 'draft', false, false],
+            ['publish', 'empty', 'draft', true, false],
             ['publish', 'empty', 'published', true, false],
-            ['publish', 'complete', 'draft', true, false],
+            ['publish', 'complete', 'draft', false, true, false],
+            ['publish', 'complete', 'draft', true, true, false],
+            ['publish', 'complete', 'published', true, true, true],
+            ['publish', 'complete', 'absent', false, false],
+            ['publish', 'complete', 'duplicate', true, false],
             ['publish', 'partial', 'draft', true, false],
             ['publish', 'unavailable', 'absent', false, false],
             ['publish', 'empty', 'absent', true, false],
             ['recover-release', 'complete', 'draft', true, true, false],
             ['recover-release', 'complete', 'published', true, true, true],
             ['recover-release', 'complete', 'absent', false, false],
+            ['recover-release', 'empty', 'absent', false, false],
             ['recover-release', 'empty', 'draft', false, false],
             ['recover-release', 'partial', 'draft', true, false],
             ['recover-release', 'complete', 'duplicate', true, false],
+            ['invalid-mode', 'empty', 'absent', false, false],
         ]) {
             const output = path.join(work, 'output.txt');
             fs.writeFileSync(output, '', 'utf8');
@@ -68,7 +74,8 @@ test('SDK 发布状态实际拒绝部分 Central、冲突公开身份和缺少�
             const label = [mode, central, release, tag].join('/');
             assert.equal(result.status === 0, accept, label + ': ' + (result.error ?? result.stderr));
             const outputs = fs.readFileSync(output, 'utf8');
-            const expected = 'reuse_release=' + (release !== 'absent') + '\npublished=' + published + '\n';
+            const expected = 'reuse_release=' + (release !== 'absent') + '\npublished=' + published
+                + '\npublish_central=' + (central === 'empty') + '\n';
             assert.equal(outputs, accept ? expected : '', label);
         }
     } finally {

--- a/scripts/ci/test/sdk-runtime-input.test.ps1
+++ b/scripts/ci/test/sdk-runtime-input.test.ps1
@@ -8,9 +8,9 @@ $TestDirectory = [IO.Path]::GetFullPath($TestDirectory)
 if (Test-Path -LiteralPath $TestDirectory) { throw 'Test directory must be new.' }
 [IO.Directory]::CreateDirectory($TestDirectory) | Out-Null
 $script = Join-Path $PSScriptRoot '../sdk-runtime-inputs.ps1'
-$inputLock = Get-Content -LiteralPath (Join-Path $PSScriptRoot '../sdk-runtime-input.json') -Raw -Encoding UTF8 | ConvertFrom-Json
-
-function Test-Input([string]$Name, [string[]]$Entries, [string]$Mutation, [bool]$Accept) {
+function Test-Input([string]$Name, [string[]]$Entries, [string]$Mutation, [bool]$Accept, [string]$AssetUrl) {
+    $inputLock = Get-Content -LiteralPath (Join-Path $PSScriptRoot '../sdk-runtime-input.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+    if ($AssetUrl) { $inputLock.assetUrl = $AssetUrl }
     $archive = Join-Path $TestDirectory "$Name.zip"
     $zip = [IO.Compression.ZipFile]::Open($archive, [IO.Compression.ZipArchiveMode]::Create)
     try {
@@ -43,6 +43,11 @@ function Test-Input([string]$Name, [string[]]$Entries, [string]$Mutation, [bool]
     } elseif (-not $failure) { throw "Invalid SDK input accepted: $Name" }
 }
 Test-Input 'valid' @('plugins/example.jar', 'plugins/provenance/example.jar.pixiv-plugin-provenance', 'ignored.txt') '' $true
+Test-Input 'main-release' @('plugins/example.jar') '' $true 'https://api.github.com/repos/Sywyar/PixivDownloader/releases/assets/1'
+Test-Input 'sdk-release' @('plugins/example.jar') '' $true 'https://api.github.com/repos/Sywyar/PixivDownloader-Plugin-SDK/releases/assets/1'
+Test-Input 'foreign-repository' @('plugins/example.jar') '' $false 'https://api.github.com/repos/other/PixivDownloader-Plugin-SDK/releases/assets/1'
+Test-Input 'moving-tag' @('plugins/example.jar') '' $false 'https://api.github.com/repos/Sywyar/PixivDownloader-Plugin-SDK/releases/tags/latest'
+Test-Input 'http' @('plugins/example.jar') '' $false 'http://api.github.com/repos/Sywyar/PixivDownloader-Plugin-SDK/releases/assets/1'
 Test-Input 'digest' @('plugins/example.jar') 'digest' $false
 Test-Input 'truncated' @('plugins/example.jar') 'truncated' $false
 Test-Input 'traversal' @('plugins/../escape.jar') '' $false


### PR DESCRIPTION
## 变更内容

SDK 发布任务在完整 Quality Gate 成功后，通过同次运行输出的不可变 artifact ID 接收已验证的 SDK，省去第二次完整构建。签名前继续核对源码 SHA、大小与摘要；公开 Maven 坐标和最终 Release 的消费者验收保持执行。

全部 Central 坐标公开且原始 Release 存在时，普通发布重试也恢复冻结附件，不再次上传 Central。已有 Draft 而 Central 尚未公开、部分坐标公开或冻结附件缺失时停止。Central 插件等待 PUBLISHED 的上限显式配置为 3600 秒；SDK 身份未变时说明本次未执行发布。

SDK 构建的固定插件输入改用已发布 SDK 版本保留的运行包，避免 Nightly 替换附件后锁定资产返回 404。下载只允许主仓库或 SDK 仓库的 asset API，继续核对固定大小与 SHA-256，并由共享组装器复验官方插件集合、原签名和 provenance。

## 验证

- [x] 全量 JavaScript 回归通过；同步最新主线后重新通过 SDK 发布、归档与 workflow 聚焦回归
- [x] 五个 SDK 模块实际构建并部署至本地文件仓库；签名工具独立构建通过
- [x] Maven effective POM 确认 PUBLISHED 与 3600 秒等待配置
- [x] i18n 检查与当前候选 trusted gate parity 通过
- [x] PowerShell 5.1 / 7 的真实输入回归通过；锁定运行包经共享组装器验证 13 个官方插件及原签名
- [x] GitHub runner 完成固定输入下载、SDK 隔离消费者与两种插件模式的完整宿主验收
- [x] 当前提交 `98049dcc9565dcd2f14e6e0360ac23bc70b52a52` 的[完整 Quality Gate](https://github.com/Sywyar/PixivDownloader/actions/runs/34684491097)与六项绑定 App 的 required checks 全部通过

GitHub Artifact 交接与 Central 端到端发布尚未实跑。SDK 身份保持不变，合并本次流程修改不会触发新的 SDK 发行。中英文网络访问说明由 gh-pages 分支单独交付；本次仅修改 CI 编排，README 与 CHANGELOG 无需更新。
