### PR TITLE
refactor(ci): 建立受保护的通用 Gate 升级协议

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -232,19 +232,31 @@ jobs:
       - name: Materialize protected verifier
         run: |
           GATE_DIR="$RUNNER_TEMP/trusted-gate"
-          mkdir -p "$GATE_DIR"
-          git show "$BASE_SHA:scripts/ci/release-gate-policy.json" > "$RUNNER_TEMP/gate-policy.json"
-          GATE_EPOCH=$(node -e 'console.log(require(process.argv[1]).gateEpoch)' "$RUNNER_TEMP/gate-policy.json")
-          node -e 'const p=require(process.argv[1]); console.log(p.protectedCore.join("\n"))' "$RUNNER_TEMP/gate-policy.json" > "$RUNNER_TEMP/gate-files.txt"
-          while IFS= read -r rel; do
-            mkdir -p "$GATE_DIR/$(dirname "$rel")"
-            git show "$BASE_SHA:$rel" > "$GATE_DIR/$rel"
-          done < "$RUNNER_TEMP/gate-files.txt"
-          if [ "$GATE_EPOCH" = "5" ] && [ "$(git show "$CANDIDATE_SHA:scripts/ci/release-gate-policy.json" | node -e 'let s=""; process.stdin.on("data",c=>s+=c).on("end",()=>console.log(JSON.parse(s).gateEpoch))')" = "8" ]; then
-            for rel in release-gate-trust.mjs release-gate-verifier.mjs resolve-trusted-base.mjs; do
-              git show "$BASE_SHA:scripts/ci/gate-admission/$rel" > "$GATE_DIR/scripts/ci/$rel"
+          git merge-base --is-ancestor "$BASE_SHA" refs/remotes/origin/master
+          git merge-base --is-ancestor "$BASE_SHA" "$CANDIDATE_SHA"
+          test "$BASE_SHA" != "$CANDIDATE_SHA"
+          if git cat-file -e "$BASE_SHA:scripts/ci/gate-upgrade.mjs" 2>/dev/null; then
+            git show "$BASE_SHA:scripts/ci/gate-upgrade.mjs" > "$RUNNER_TEMP/gate-upgrade.mjs"
+            node "$RUNNER_TEMP/gate-upgrade.mjs" --repo-root "$GITHUB_WORKSPACE" --trusted-ref "$BASE_SHA" --candidate-ref "$CANDIDATE_SHA" --directory "$GATE_DIR"
+            GATE_EPOCH=$(node -e 'console.log(require(process.argv[1]).gateEpoch)' "$GATE_DIR/scripts/ci/release-gate-policy.json")
+          else
+            mkdir -p "$GATE_DIR"
+            git show "$BASE_SHA:scripts/ci/release-gate-policy.json" > "$RUNNER_TEMP/gate-policy.json"
+            GATE_EPOCH=$(node -e 'console.log(require(process.argv[1]).gateEpoch)' "$RUNNER_TEMP/gate-policy.json")
+            node -e 'const p=require(process.argv[1]); console.log(p.protectedCore.join("\n"))' "$RUNNER_TEMP/gate-policy.json" > "$RUNNER_TEMP/gate-files.txt"
+            while IFS= read -r rel; do
+              mkdir -p "$GATE_DIR/$(dirname "$rel")"
+              git show "$BASE_SHA:$rel" > "$GATE_DIR/$rel"
+            done < "$RUNNER_TEMP/gate-files.txt"
+            if [ "$GATE_EPOCH" = "5" ] && [ "$(git show "$CANDIDATE_SHA:scripts/ci/release-gate-policy.json" | node -e 'let s=""; process.stdin.on("data",c=>s+=c).on("end",()=>console.log(JSON.parse(s).gateEpoch))')" = "8" ]; then
+              for rel in release-gate-trust.mjs release-gate-verifier.mjs resolve-trusted-base.mjs; do
+                git show "$BASE_SHA:scripts/ci/gate-admission/$rel" > "$GATE_DIR/scripts/ci/$rel"
+              done
+              GATE_EPOCH=8
+            fi
+            for rel in package.json package-lock.json; do
+              git show "$BASE_SHA:$rel" > "$GATE_DIR/$rel"
             done
-            GATE_EPOCH=8
           fi
           echo "GATE_EPOCH=$GATE_EPOCH" >> "$GITHUB_ENV"
           echo "GATE_DIR=$GATE_DIR" >> "$GITHUB_ENV"
@@ -297,27 +309,36 @@ jobs:
       - name: Materialize protected verifier
         run: |
           GATE_DIR="$RUNNER_TEMP/trusted-gate"
-          mkdir -p "$GATE_DIR"
-          git show "$BASE_SHA:scripts/ci/release-gate-policy.json" > "$RUNNER_TEMP/gate-policy.json"
-          GATE_EPOCH=$(node -e 'console.log(require(process.argv[1]).gateEpoch)' "$RUNNER_TEMP/gate-policy.json")
-          node -e 'const p=require(process.argv[1]); console.log(p.protectedCore.join("\n"))' "$RUNNER_TEMP/gate-policy.json" > "$RUNNER_TEMP/gate-files.txt"
-          while IFS= read -r rel; do
-            mkdir -p "$GATE_DIR/$(dirname "$rel")"
-            git show "$BASE_SHA:$rel" > "$GATE_DIR/$rel"
-          done < "$RUNNER_TEMP/gate-files.txt"
-          if [ "$GATE_EPOCH" = "5" ] && [ "$(git show "$CANDIDATE_SHA:scripts/ci/release-gate-policy.json" | node -e 'let s=""; process.stdin.on("data",c=>s+=c).on("end",()=>console.log(JSON.parse(s).gateEpoch))')" = "8" ]; then
-            for rel in release-gate-trust.mjs release-gate-verifier.mjs resolve-trusted-base.mjs; do
-              git show "$BASE_SHA:scripts/ci/gate-admission/$rel" > "$GATE_DIR/scripts/ci/$rel"
+          git merge-base --is-ancestor "$BASE_SHA" refs/remotes/origin/master
+          git merge-base --is-ancestor "$BASE_SHA" "$CANDIDATE_SHA"
+          test "$BASE_SHA" != "$CANDIDATE_SHA"
+          if git cat-file -e "$BASE_SHA:scripts/ci/gate-upgrade.mjs" 2>/dev/null; then
+            git show "$BASE_SHA:scripts/ci/gate-upgrade.mjs" > "$RUNNER_TEMP/gate-upgrade.mjs"
+            node "$RUNNER_TEMP/gate-upgrade.mjs" --repo-root "$GITHUB_WORKSPACE" --trusted-ref "$BASE_SHA" --candidate-ref "$CANDIDATE_SHA" --directory "$GATE_DIR"
+            GATE_EPOCH=$(node -e 'console.log(require(process.argv[1]).gateEpoch)' "$GATE_DIR/scripts/ci/release-gate-policy.json")
+          else
+            mkdir -p "$GATE_DIR"
+            git show "$BASE_SHA:scripts/ci/release-gate-policy.json" > "$RUNNER_TEMP/gate-policy.json"
+            GATE_EPOCH=$(node -e 'console.log(require(process.argv[1]).gateEpoch)' "$RUNNER_TEMP/gate-policy.json")
+            node -e 'const p=require(process.argv[1]); console.log(p.protectedCore.join("\n"))' "$RUNNER_TEMP/gate-policy.json" > "$RUNNER_TEMP/gate-files.txt"
+            while IFS= read -r rel; do
+              mkdir -p "$GATE_DIR/$(dirname "$rel")"
+              git show "$BASE_SHA:$rel" > "$GATE_DIR/$rel"
+            done < "$RUNNER_TEMP/gate-files.txt"
+            if [ "$GATE_EPOCH" = "5" ] && [ "$(git show "$CANDIDATE_SHA:scripts/ci/release-gate-policy.json" | node -e 'let s=""; process.stdin.on("data",c=>s+=c).on("end",()=>console.log(JSON.parse(s).gateEpoch))')" = "8" ]; then
+              for rel in release-gate-trust.mjs release-gate-verifier.mjs resolve-trusted-base.mjs; do
+                git show "$BASE_SHA:scripts/ci/gate-admission/$rel" > "$GATE_DIR/scripts/ci/$rel"
+              done
+              GATE_EPOCH=8
+            fi
+            for rel in package.json package-lock.json; do
+              git show "$BASE_SHA:$rel" > "$GATE_DIR/$rel"
             done
-            GATE_EPOCH=8
           fi
           echo "GATE_EPOCH=$GATE_EPOCH" >> "$GITHUB_ENV"
           echo "GATE_DIR=$GATE_DIR" >> "$GITHUB_ENV"
       - name: Install protected parser
         run: |
-          for rel in package.json package-lock.json; do
-            git show "$BASE_SHA:$rel" > "$GATE_DIR/$rel"
-          done
           (cd "$GATE_DIR" && npm ci --ignore-scripts --no-audit --no-fund)
           echo "TRUSTED_GATE_PACKAGE_JSON=$GATE_DIR/package.json" >> "$GITHUB_ENV"
       - name: Verify trusted release contract

--- a/scripts/ci/doctor-github-ruleset.mjs
+++ b/scripts/ci/doctor-github-ruleset.mjs
@@ -101,7 +101,10 @@ function isBranchRulesetFor(rs, ref) {
 function isTagRulesetFor(rs, ref) {
     return rs && rs.target === 'tag' && (rs.conditions || {}).ref_name
         && Array.isArray((rs.conditions.ref_name || {}).include)
-        && rs.conditions.ref_name.include.includes(ref);
+        && !(rs.conditions.ref_name.exclude || []).length
+        && rs.conditions.ref_name.include.some((pattern) => pattern === ref
+            || (pattern === 'refs/tags/release-gate-epoch-*-root'
+                && /^refs\/tags\/release-gate-epoch-[1-9][0-9]*-root$/u.test(ref)));
 }
 
 function active(details, label, problems, report) {

--- a/scripts/ci/gate-checks.mjs
+++ b/scripts/ci/gate-checks.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import YAML from 'yaml';
+import { verifyProtectedCandidate } from './trusted-gate-runner.mjs';
 
 const REPO = 'Sywyar/PixivDownloader';
 const REPO_ID = 1089943605;
@@ -342,8 +343,9 @@ async function main() {
     if (process.argv.slice(2).some((arg) => arg !== '--publish')) fail('usage: gate-checks.mjs [--publish]');
     const repo = process.cwd();
     const policy = JSON.parse(fs.readFileSync(path.join(repo, 'scripts/ci/release-gate-policy.json'), 'utf8'));
-    const core = await import(policy.gateEpoch === 5
+    const installedCore = await import(policy.gateEpoch === 5
         ? './gate-admission/release-gate-verifier.mjs' : './release-gate-verifier.mjs');
+    const core = { ...installedCore, verifyCandidate: verifyProtectedCandidate };
     const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
     const evidence = await checkEvent({ repo, event, eventName: process.env.GITHUB_EVENT_NAME, core });
     if (process.env.GITHUB_OUTPUT && !process.argv.includes('--publish')) {

--- a/scripts/ci/gate-contract.mjs
+++ b/scripts/ci/gate-contract.mjs
@@ -15,8 +15,8 @@ const dispatchRoot = path.resolve(repoIndex >= 0 ? cliArgs[repoIndex + 1] : proc
 if (process.argv.length === 3 && process.argv[2] === '--version') {
     const policy = JSON.parse(fs.readFileSync(new URL('./release-gate-policy.json', import.meta.url), 'utf8'));
     console.log(`gate-contract ${policy.contractVersion}`);
-} else if (!['5', '8'].includes(configuredEpoch(dispatchRoot))) {
-    throw new Error('configured release Gate epoch 5 or 8 is required');
+} else if (!/^[1-9][0-9]*$/u.test(configuredEpoch(dispatchRoot))) {
+    throw new Error('configured release Gate epoch is required');
 } else {
     const args = cliArgs;
     const value = (name) => {
@@ -48,23 +48,23 @@ if (process.argv.length === 3 && process.argv[2] === '--version') {
     let candidateSha = git(repo, ['rev-parse', '--verify', `${candidate}^{commit}`]);
     const trustedSha = git(repo, ['rev-parse', '--verify', `${trusted}^{commit}`]);
     const policy = JSON.parse(git(repo, ['show', `${candidateSha}:scripts/ci/release-gate-policy.json`]));
-    if (!snapshot && process.env.CI !== 'true' && policy.gateEpoch === 8 && configuredEpoch(repo) === '5') {
+    if (!snapshot && process.env.CI !== 'true' && String(policy.gateEpoch) !== configuredEpoch(repo)) {
         // 推送前按精确 tip 的树核对拟合并对象，保留首次准入的核心、根与双亲校验。
         const tip = candidateSha;
         candidateSha = git(repo, ['commit-tree', `${tip}^{tree}`, '-p', trustedSha, '-p', tip], {}, 'local proposed merge\n');
         console.log(`LOCAL MERGE CANDIDATE ${candidateSha} (tip ${tip})`);
     }
-    withTrustedGate(repo, trustedSha, policy.gateEpoch, (directory, env) => {
+    withTrustedGate(repo, trustedSha, candidateSha, (directory, env) => {
         const verifyArgs = [path.join(directory, 'scripts/ci/release-gate-verifier.mjs'),
             '--repo-root', repo, '--candidate-ref', candidateSha];
         if (candidateSha === trustedSha) verifyArgs.push('--invariants');
         else verifyArgs.push('--trusted-ref', trustedSha);
-        if (policy.gateEpoch === 8 && snapshot) verifyArgs.push('--local-feedback');
+        if (snapshot && String(policy.gateEpoch) !== configuredEpoch(repo)) verifyArgs.push('--local-feedback');
         if (args.includes('--signature')) verifyArgs.push('--signature');
         const result = spawnSync(process.execPath, verifyArgs,
             { cwd: repo, env, stdio: 'inherit', windowsHide: true });
         if (result.status !== 0) throw new Error('protected predecessor rejected the candidate');
-    });
+    }, { localFeedback: Boolean(snapshot) && String(policy.gateEpoch) !== configuredEpoch(repo) });
     console.log(`GATE CONTRACT OK (candidate ${candidateSha})`);
 }
 

--- a/scripts/ci/gate-credentials.mjs
+++ b/scripts/ci/gate-credentials.mjs
@@ -1,0 +1,127 @@
+// 只解释 Actions 表达式中的凭据来源；不把变量名或任意 shell 源码当成权限证明。
+function expressions(text) {
+    const result = [];
+    for (let start = text.indexOf('${{'); start >= 0; start = text.indexOf('${{', start)) {
+        let end = start + 3, quoted = false;
+        for (; end < text.length; end += 1) {
+            if (text[end] === "'") {
+                if (quoted && text[end + 1] === "'") end += 1;
+                else quoted = !quoted;
+            }
+            if (!quoted && text.slice(end, end + 2) === '}}') break;
+        }
+        if (end === text.length) throw new Error('unterminated Actions expression');
+        result.push(text.slice(start + 3, end));
+        start = end + 2;
+    }
+    return result;
+}
+
+function references(expression) {
+    const tokens = expression.match(/'(?:[^']|'')*'|[a-zA-Z_][a-zA-Z0-9_-]*|[^\s]/gu) || [];
+    const result = [];
+    for (let i = 0; i < tokens.length; i += 1) {
+        if (!/^[a-zA-Z_]/u.test(tokens[i]) || ['.', '['].includes(tokens[i - 1])) continue;
+        const parts = [tokens[i].toLowerCase()];
+        while (i + 1 < tokens.length) {
+            if (tokens[i + 1] === '.' && /^[a-zA-Z_]/u.test(tokens[i + 2] || '')) {
+                parts.push(tokens[i + 2].toLowerCase()); i += 2;
+            } else if (tokens[i + 1] === '[' && /^'(?:[^']|'')*'$/u.test(tokens[i + 2] || '')
+                && tokens[i + 3] === ']') {
+                parts.push(tokens[i + 2].slice(1, -1).replaceAll("''", "'").toLowerCase()); i += 3;
+            } else break;
+        }
+        result.push(parts);
+    }
+    return result;
+}
+
+export function credentialSources(value, bindings = new Map()) {
+    const sources = new Set();
+    const visit = (item) => {
+        if (typeof item === 'string') {
+            for (const expression of expressions(item)) {
+                for (const parts of references(expression)) {
+                    const [context, key] = parts;
+                    if (context === 'secrets') sources.add(key === 'github_token' ? 'github' : 'secret');
+                    if (context === 'github' && (!key || key === 'token')) sources.add('github');
+                    if (context === 'env' && key === 'actions_runtime_token') sources.add('runtime');
+                    if (context === 'env' && /^actions_id_token_request_(?:token|url)$/u.test(key || '')) sources.add('oidc');
+                    const reference = parts.join('.');
+                    for (const [name, values] of bindings) {
+                        if (name === reference || name.startsWith(reference + '.')) values.forEach((source) => sources.add(source));
+                    }
+                }
+            }
+        } else if (Array.isArray(item)) item.forEach(visit);
+        else if (item && typeof item === 'object') {
+            if (/^actions\/create-github-app-token@[0-9a-f]{40}$/u.test(item.uses || '')) sources.add('app');
+            Object.values(item).forEach(visit);
+        }
+    };
+    visit(value);
+    return sources;
+}
+
+// 显式 job map 替换 workflow map；未列出的权限为 none。调用方上限只能缩小权限。
+export function effectivePermissions(workflow, job, caller) {
+    const selected = job === undefined ? workflow : job;
+    const level = (permissions, name) => typeof permissions === 'string'
+        ? permissions === 'write-all' ? 'write' : permissions === 'read-all' ? (name === 'id-token' ? 'none' : 'read') : 'none'
+        : permissions?.[name] || 'none';
+    const names = new Set(['contents', 'id-token', ...Object.keys(typeof selected === 'object' && selected || {}),
+        ...Object.keys(typeof caller === 'object' && caller || {})]);
+    const rank = ['none', 'read', 'write'];
+    return Object.fromEntries([...names].map((name) => [name, caller === undefined ? level(selected, name)
+        : rank[Math.min(rank.indexOf(level(selected, name)), rank.indexOf(level(caller, name)))]]));
+}
+
+export function privilegedCredentials(value, workflowPermissions, jobPermissions, bindings) {
+    const sources = credentialSources(value, bindings);
+    const permissions = effectivePermissions(workflowPermissions, jobPermissions);
+    return sources.has('secret') || sources.has('app') || sources.has('oidc') || sources.has('runtime')
+        || Object.values(permissions).includes('write');
+}
+
+// 追踪 YAML 明确引用的输出；不猜测脚本打印的 token，也不把未知输出仅凭名字判成凭据。
+export function workflowCredentialBindings(doc) {
+    const jobs = new Map(Object.keys(doc.jobs).map((id) => [id, new Map()]));
+    const shared = new Map();
+    let changed = true;
+    const add = (map, name, sources) => {
+        const current = map.get(name) || new Set();
+        for (const source of sources) if (!current.has(source)) { current.add(source); changed = true; }
+        map.set(name, current);
+    };
+    const outputs = (steps, inherited) => {
+        const bindings = new Map(inherited);
+        for (const step of steps || []) {
+            if (!step.id) continue;
+            const prefix = `steps.${step.id.toLowerCase()}.outputs.`;
+            if (/^actions\/create-github-app-token@[0-9a-f]{40}$/u.test(step.uses || '')) {
+                bindings.set(prefix + 'token', new Set(['app']));
+            }
+            if (step.gateLocalAction) {
+                const inputs = new Map(Object.entries(step.with || {}).map(([name, value]) =>
+                    ['inputs.' + name.toLowerCase(), credentialSources(value, bindings)]));
+                const internal = outputs(step.gateLocalAction.runs.steps, inputs);
+                for (const [name, spec] of Object.entries(step.gateLocalAction.outputs || {})) {
+                    bindings.set(prefix + name.toLowerCase(), credentialSources(spec.value, internal));
+                }
+            }
+        }
+        return bindings;
+    };
+    while (changed) {
+        changed = false;
+        for (const [id, job] of Object.entries(doc.jobs)) {
+            const bindings = jobs.get(id);
+            for (const [name, values] of shared) add(bindings, name, values);
+            for (const [name, values] of outputs(job.steps, shared)) add(bindings, name, values);
+            for (const [name, value] of Object.entries(job.outputs || {})) {
+                add(shared, `needs.${id.toLowerCase()}.outputs.${name.toLowerCase()}`, credentialSources(value, bindings));
+            }
+        }
+    }
+    return jobs;
+}

--- a/scripts/ci/gate-upgrade.mjs
+++ b/scripts/ci/gate-upgrade.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+export const POLICY_PATH = 'scripts/ci/release-gate-policy.json';
+export const APPROVAL_PATH = 'scripts/ci/gate-upgrade/approval.json';
+export const UPGRADE_DIRECTORY = 'scripts/ci/gate-upgrade/core/';
+const DEPENDENCIES = ['package.json', 'package-lock.json'];
+const MAX_GIT_BYTES = 32 * 1024 * 1024;
+const MAX_APPROVAL_BYTES = 64 * 1024;
+const SHA = /^[0-9a-f]{40}$/u;
+const FILE = /^(?:scripts\/ci\/[a-z0-9-]+\.mjs|scripts\/ci\/release-gate-policy\.json|package(?:-lock)?\.json)$/u;
+
+function fail(message) { throw new Error(`gate upgrade: ${message}`); }
+export function readGit(repo, args, options = {}) {
+    return execFileSync('git', ['--no-replace-objects', '-C', repo, ...args], {
+        encoding: 'utf8', windowsHide: true, stdio: ['pipe', 'pipe', 'pipe'],
+        maxBuffer: MAX_GIT_BYTES, ...options,
+    });
+}
+function commit(repo, ref) {
+    const value = readGit(repo, ['rev-parse', '--verify', '--end-of-options', `${ref}^{commit}`]).trim();
+    if (!SHA.test(value)) fail('invalid commit identity');
+    return value;
+}
+function ancestor(repo, older, newer) {
+    try { readGit(repo, ['merge-base', '--is-ancestor', older, newer]); return true; }
+    catch { return false; }
+}
+function read(repo, ref, file) { return readGit(repo, ['show', `${ref}:${file}`], { encoding: null }); }
+export function readPolicy(repo, ref) { return JSON.parse(read(repo, ref, POLICY_PATH).toString('utf8')); }
+function equal(left, right) { return JSON.stringify(left) === JSON.stringify(right); }
+function exactKeys(value, keys, label) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)
+        || !equal(Object.keys(value).sort(), [...keys].sort())) fail(`invalid ${label} fields`);
+}
+function epoch(value) { return Number.isSafeInteger(value) && value > 0; }
+function rootName(value) { return `refs/tags/release-gate-epoch-${value}-root`; }
+function entry(repo, ref, file) {
+    const rows = readGit(repo, ['ls-tree', '-z', ref, '--', `:(literal)${file}`]).split('\0').filter(Boolean);
+    const match = rows.length === 1 && /^(100644|100755) blob ([0-9a-f]{40})\t(.+)$/u.exec(rows[0]);
+    if (!match || match[3] !== file) fail(`missing regular file: ${file}`);
+    return { mode: match[1], blob: match[2] };
+}
+function containsAll(before, after, label) {
+    if (!Array.isArray(before) || !Array.isArray(after)
+        || before.some((value) => !after.includes(value))) fail(`upgrade removed ${label}`);
+}
+
+// 升级授权不豁免现有质量职责、发布环境、检查签发者及历史根保护。
+export function verifyUpgradePolicy(before, after) {
+    for (const key of ['schemaVersion', 'protectedBranch', 'releaseEnvironment']) {
+        if (!equal(before[key], after[key])) fail(`upgrade changed ${key}`);
+    }
+    for (const key of ['workflow', 'workflowName']) {
+        if (!equal(before.qualityGate?.[key], after.qualityGate?.[key])) fail(`upgrade changed quality ${key}`);
+    }
+    containsAll(before.qualityGate?.requiredJobs, after.qualityGate?.requiredJobs, 'quality roles');
+    containsAll(before.qualityGate?.requiredTriggers, after.qualityGate?.requiredTriggers, 'quality triggers');
+    for (const [file, spec] of Object.entries(before.workflows || {})) {
+        const next = after.workflows?.[file];
+        if (next?.workflowName !== spec.workflowName) fail(`upgrade changed workflow ${file}`);
+        containsAll(spec.requiredJobs, next.requiredJobs, `${file} roles`);
+        containsAll(spec.requiredTriggers, next.requiredTriggers, `${file} triggers`);
+    }
+    const oldRules = before.ruleset, nextRules = after.ruleset;
+    containsAll(oldRules?.requiredChecks, nextRules?.requiredChecks, 'required checks');
+    for (const name of oldRules.requiredChecks) {
+        if (oldRules.requiredCheckSources?.[name] !== nextRules.requiredCheckSources?.[name]) {
+            fail(`upgrade changed check authority: ${name}`);
+        }
+    }
+    for (const key of ['requireStrict', 'requirePullRequest', 'allowBypass', 'allowDeletion', 'allowNonFastForward']) {
+        if (oldRules[key] !== nextRules[key]) fail(`upgrade changed ruleset ${key}`);
+    }
+    if (!Number.isSafeInteger(nextRules.minimumApprovals) || nextRules.minimumApprovals < oldRules.minimumApprovals) {
+        fail('upgrade lowered required reviews');
+    }
+    for (const [root, rules] of Object.entries(oldRules.roots)) {
+        if (!equal(rules, nextRules.roots?.[root])) fail(`upgrade changed historical root ${root}`);
+    }
+    if (!equal(nextRules.roots?.[after.rootTag],
+        { allowDeletion: false, allowNonFastForward: false, allowBypass: false })) fail('target root is unprotected');
+}
+
+function approval(repo, base) {
+    const bytes = read(repo, base, APPROVAL_PATH);
+    if (bytes.length > MAX_APPROVAL_BYTES) fail('approval exceeds 64 KiB');
+    const value = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes));
+    exactKeys(value, ['schemaVersion', 'from', 'to', 'files', 'changes'], 'approval');
+    exactKeys(value.from, ['epoch', 'root', 'rootCommit'], 'source identity');
+    exactKeys(value.to, ['epoch', 'root'], 'target identity');
+    if (value.schemaVersion !== 1 || !epoch(value.from.epoch) || !epoch(value.to.epoch)
+        || value.to.epoch <= value.from.epoch || !SHA.test(value.from.rootCommit)
+        || value.from.root !== rootName(value.from.epoch) || value.to.root !== rootName(value.to.epoch)
+        || !Array.isArray(value.files) || !value.files.length || !Array.isArray(value.changes)
+        || !value.changes.length || value.changes.some((change) => typeof change !== 'string' || !change.trim())) {
+        fail('invalid approval identity or declared changes');
+    }
+    const names = new Set();
+    for (const file of value.files) {
+        exactKeys(file, ['path', 'source', 'mode', 'blob'], 'approved file');
+        if (!FILE.test(file.path) || names.has(file.path)
+            || ![file.path, UPGRADE_DIRECTORY + path.posix.basename(file.path)].includes(file.source)
+            || !['100644', '100755'].includes(file.mode) || !SHA.test(file.blob)) fail('invalid approved file');
+        names.add(file.path);
+        if (!equal(entry(repo, base, file.source), { mode: file.mode, blob: file.blob })) {
+            fail(`approved source changed: ${file.source}`);
+        }
+    }
+    return value;
+}
+
+export function verifyUpgrade({ repo, trusted, candidate, localFeedback = false }) {
+    if (localFeedback && process.env.CI === 'true') fail('local feedback is forbidden in CI');
+    const base = commit(repo, trusted), next = commit(repo, candidate);
+    const before = readPolicy(repo, base), after = readPolicy(repo, next);
+    if (base === next || !ancestor(repo, base, 'refs/remotes/origin/master') || !ancestor(repo, base, next)) {
+        fail('approval must come from a strict protected predecessor');
+    }
+    const permit = approval(repo, base);
+    if (permit.from.epoch !== before.gateEpoch || permit.from.root !== before.rootTag
+        || permit.to.epoch !== after.gateEpoch || permit.to.root !== after.rootTag
+        || after.upgradeProtocol !== 1 || commit(repo, permit.from.root) !== permit.from.rootCommit
+        || !ancestor(repo, permit.from.rootCommit, base)) fail('approval does not match the active trust chain');
+    const expected = [...after.protectedCore, POLICY_PATH, ...DEPENDENCIES].sort();
+    if (new Set(expected).size !== expected.length
+        || !equal(permit.files.map((file) => file.path).sort(), expected)) fail('approval does not cover the execution closure');
+    for (const file of permit.files) {
+        if (!equal(entry(repo, next, file.path), { mode: file.mode, blob: file.blob })) {
+            fail(`candidate differs from approved bytes: ${file.path}`);
+        }
+    }
+    verifyUpgradePolicy(before, after);
+    if (localFeedback) return permit;
+    const root = commit(repo, permit.to.root);
+    if (readGit(repo, ['cat-file', '-t', permit.to.root]).trim() !== 'tag') fail('root must be an annotated tag');
+    const parents = (ref) => readGit(repo, ['rev-list', '--parents', '-n', '1', ref]).trim().split(/\s+/u).slice(1);
+    const rootParents = parents(root);
+    if (rootParents.length !== 1 || !ancestor(repo, rootParents[0], base)
+        || !equal(entry(repo, rootParents[0], APPROVAL_PATH), entry(repo, base, APPROVAL_PATH))) {
+        fail('root must descend from the same protected approval');
+    }
+    for (const file of permit.files) {
+        if (!equal(entry(repo, root, file.path), { mode: file.mode, blob: file.blob })) fail(`root bytes differ: ${file.path}`);
+    }
+    const nextParents = parents(next);
+    if (next !== root && (nextParents.length !== 2 || nextParents[0] !== base
+        || !ancestor(repo, root, nextParents[1]))) fail('activation must preserve the approved root and exact merge parents');
+    return permit;
+}
+
+export function selectGateFiles({ repo, trusted, candidate, localFeedback = false }) {
+    const base = commit(repo, trusted), next = commit(repo, candidate);
+    const before = readPolicy(repo, base), after = readPolicy(repo, next);
+    if (!epoch(before.gateEpoch) || before.rootTag !== rootName(before.gateEpoch)
+        || !ancestor(repo, before.rootTag, base) || !ancestor(repo, base, 'refs/remotes/origin/master')
+        || !ancestor(repo, base, next)) fail('loader requires a protected predecessor');
+    if (before.gateEpoch !== after.gateEpoch) {
+        return verifyUpgrade({ repo, trusted: base, candidate: next, localFeedback }).files;
+    }
+    if (!epoch(before.gateEpoch) || !Array.isArray(before.protectedCore)) fail('invalid protected policy');
+    return [...before.protectedCore, POLICY_PATH, ...DEPENDENCIES].map((file) => {
+        if (!FILE.test(file)) fail('invalid protected core path');
+        return { path: file, source: file, ...entry(repo, base, file) };
+    });
+}
+
+export function materializeGate({ repo, trusted, candidate, directory, localFeedback = false }) {
+    const base = commit(repo, trusted);
+    const files = selectGateFiles({ repo, trusted: base, candidate, localFeedback });
+    if (!path.isAbsolute(directory) || fs.existsSync(directory)) fail('materialization requires a new absolute directory');
+    fs.mkdirSync(directory);
+    for (const file of files) {
+        const target = path.join(directory, file.path);
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.writeFileSync(target, read(repo, base, file.source), { flag: 'wx', mode: file.mode === '100755' ? 0o755 : 0o644 });
+    }
+    return files;
+}
+
+// 只生成待审数据；文件存在不代表已经获得受保护主线授权。
+export function createApproval({ repo, trusted, changes }) {
+    const before = readPolicy(repo, trusted);
+    const after = JSON.parse(fs.readFileSync(path.join(repo, UPGRADE_DIRECTORY, 'release-gate-policy.json'), 'utf8'));
+    verifyUpgradePolicy(before, after);
+    const files = [...after.protectedCore, POLICY_PATH, ...DEPENDENCIES].map((file) => {
+        if (!FILE.test(file)) fail('invalid proposed core path');
+        const staged = UPGRADE_DIRECTORY + path.posix.basename(file);
+        const source = fs.existsSync(path.join(repo, staged)) ? staged : file;
+        const actual = path.join(repo, source);
+        if (!fs.lstatSync(actual).isFile()) fail('proposal source must be a regular file');
+        const blob = readGit(repo, ['hash-object', '--path', source, '--stdin'], { input: fs.readFileSync(actual) }).trim();
+        const tracked = readGit(repo, ['ls-files', '--stage', '--', source]).trim();
+        const mode = /^(100644|100755) /u.exec(tracked)?.[1] || '100644';
+        return { path: file, source, mode, blob };
+    });
+    return { schemaVersion: 1, from: { epoch: before.gateEpoch, root: before.rootTag,
+        rootCommit: commit(repo, before.rootTag) }, to: { epoch: after.gateEpoch, root: after.rootTag }, files, changes };
+}
+
+function main() {
+    const args = process.argv.slice(2), values = {};
+    const operation = ['--prepare', '--activate'].includes(args[0]) ? args.shift() : null;
+    for (let i = 0; i < args.length; i += 2) {
+        if (!['--repo-root', '--trusted-ref', '--candidate-ref', '--directory', '--changes'].includes(args[i])
+            || !args[i + 1] || Object.hasOwn(values, args[i])) {
+            fail('invalid or duplicated upgrade argument');
+        }
+        values[args[i]] = args[i + 1];
+    }
+    const repo = path.resolve(values['--repo-root'] || '.');
+    if (operation === '--prepare') {
+        const changes = JSON.parse(values['--changes'] || 'null');
+        if (!Array.isArray(changes) || !changes.length || changes.some((item) => typeof item !== 'string' || !item.trim())) {
+            fail('--changes must be a nonempty JSON string array');
+        }
+        const record = createApproval({ repo, trusted: values['--trusted-ref'], changes });
+        fs.writeFileSync(path.join(repo, APPROVAL_PATH), JSON.stringify(record, null, 2) + '\n', 'utf8');
+        return;
+    }
+    if (operation === '--activate') {
+        if (readGit(repo, ['status', '--porcelain']).trim()) fail('activation requires a clean worktree');
+        const base = commit(repo, values['--trusted-ref']);
+        if (commit(repo, 'HEAD') !== base || !ancestor(repo, base, 'refs/remotes/origin/master')) {
+            fail('activation must start at the protected approval commit');
+        }
+        const record = approval(repo, base), current = readPolicy(repo, base);
+        if (current.gateEpoch !== record.from.epoch || current.rootTag !== record.from.root
+            || commit(repo, current.rootTag) !== record.from.rootCommit) fail('stale upgrade approval');
+        for (const file of record.files) {
+            const target = path.join(repo, file.path);
+            fs.mkdirSync(path.dirname(target), { recursive: true });
+            if (fs.existsSync(target) && !fs.lstatSync(target).isFile()) fail('activation cannot replace a nonregular file');
+            fs.writeFileSync(target, read(repo, base, file.source));
+            fs.chmodSync(target, file.mode === '100755' ? 0o755 : 0o644);
+        }
+        console.log('Approved files copied; commit, protected root creation and integration remain separate operations.');
+        return;
+    }
+    materializeGate({ repo: values['--repo-root'] || '.', trusted: values['--trusted-ref'],
+        candidate: values['--candidate-ref'], directory: values['--directory'] });
+}
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    try { main(); } catch (error) { console.error(error.message); process.exitCode = 1; }
+}

--- a/scripts/ci/gate-upgrade/approval.json
+++ b/scripts/ci/gate-upgrade/approval.json
@@ -1,0 +1,66 @@
+{
+  "schemaVersion": 1,
+  "from": {
+    "epoch": 8,
+    "root": "refs/tags/release-gate-epoch-8-root",
+    "rootCommit": "2b6513c3c0ff278a27eb221346a2637e25e456fa"
+  },
+  "to": {
+    "epoch": 9,
+    "root": "refs/tags/release-gate-epoch-9-root"
+  },
+  "files": [
+    {
+      "path": "scripts/ci/release-gate-trust.mjs",
+      "source": "scripts/ci/gate-upgrade/core/release-gate-trust.mjs",
+      "mode": "100644",
+      "blob": "951926b1ca690f9f5dd23328d7c666eee569d3e6"
+    },
+    {
+      "path": "scripts/ci/release-gate-verifier.mjs",
+      "source": "scripts/ci/gate-upgrade/core/release-gate-verifier.mjs",
+      "mode": "100644",
+      "blob": "bae6a95c44ed400aa19e95e13ff5e27c58c93001"
+    },
+    {
+      "path": "scripts/ci/resolve-trusted-base.mjs",
+      "source": "scripts/ci/gate-upgrade/core/resolve-trusted-base.mjs",
+      "mode": "100644",
+      "blob": "c020a77c7afba3cd49c43c0f563dfe2a9336bd63"
+    },
+    {
+      "path": "scripts/ci/gate-upgrade.mjs",
+      "source": "scripts/ci/gate-upgrade.mjs",
+      "mode": "100644",
+      "blob": "4de61edbfbdcc608d35750f1b132e92aea550e9b"
+    },
+    {
+      "path": "scripts/ci/gate-credentials.mjs",
+      "source": "scripts/ci/gate-credentials.mjs",
+      "mode": "100644",
+      "blob": "c910a0c67c7beae12733e1a3be505eabbe5561bf"
+    },
+    {
+      "path": "scripts/ci/release-gate-policy.json",
+      "source": "scripts/ci/gate-upgrade/core/release-gate-policy.json",
+      "mode": "100644",
+      "blob": "944f4f67a3fb1d05009eca31f576d4ff836914b0"
+    },
+    {
+      "path": "package.json",
+      "source": "package.json",
+      "mode": "100644",
+      "blob": "bf6c317450549986509172480717de12336d9b70"
+    },
+    {
+      "path": "package-lock.json",
+      "source": "package-lock.json",
+      "mode": "100644",
+      "blob": "dd931ffe2065fb21e8da5451b977da5facaf2ae5"
+    }
+  ],
+  "changes": [
+    "Classify workflow credentials by source and effective permissions",
+    "Admit exact protected predecessor approvals with a reusable upgrade protocol"
+  ]
+}

--- a/scripts/ci/gate-upgrade/core/release-gate-policy.json
+++ b/scripts/ci/gate-upgrade/core/release-gate-policy.json
@@ -1,0 +1,186 @@
+{
+  "schemaVersion": 1,
+  "gateEpoch": 9,
+  "contractVersion": 10,
+  "rootTag": "refs/tags/release-gate-epoch-9-root",
+  "protectedBranch": "refs/heads/master",
+  "protectedCore": [
+    "scripts/ci/release-gate-trust.mjs",
+    "scripts/ci/release-gate-verifier.mjs",
+    "scripts/ci/resolve-trusted-base.mjs",
+    "scripts/ci/gate-upgrade.mjs",
+    "scripts/ci/gate-credentials.mjs"
+  ],
+  "qualityGate": {
+    "workflow": ".github/workflows/quality-gate.yml",
+    "workflowName": "Quality Gate",
+    "requiredJobs": [
+      "java-tests",
+      "javascript-tests",
+      "signature-guard",
+      "trusted-gate-contract",
+      "i18n-check",
+      "check-shared-snippets"
+    ],
+    "requiredTriggers": [
+      "workflow_call",
+      "workflow_dispatch"
+    ]
+  },
+  "workflows": {
+    ".github/workflows/release.yml": {
+      "workflowName": "Release",
+      "requiredJobs": [
+        "validate-release-tag",
+        "draft-quality-gate",
+        "publish-plugins",
+        "publish-plugin-artifacts",
+        "build-jar",
+        "build-windows-installer",
+        "release",
+        "create-draft-release"
+      ],
+      "requiredTriggers": [
+        "push",
+        "workflow_dispatch"
+      ]
+    },
+    ".github/workflows/nightly.yml": {
+      "workflowName": "Nightly Build",
+      "requiredJobs": [
+        "resolve-version",
+        "publish-plugins",
+        "publish-plugin-artifacts",
+        "build-jar",
+        "build-windows-installer",
+        "release-nightly"
+      ],
+      "requiredTriggers": [
+        "schedule",
+        "workflow_dispatch"
+      ]
+    },
+    ".github/workflows/publish-plugins.yml": {
+      "workflowName": "Publish plugins",
+      "requiredJobs": [
+        "quality-gate",
+        "publish"
+      ],
+      "requiredTriggers": [
+        "workflow_call",
+        "workflow_dispatch"
+      ]
+    },
+    ".github/workflows/build-stable-ffmpeg.yml": {
+      "workflowName": "Build stable FFmpeg",
+      "requiredJobs": [
+        "trusted-base",
+        "quality-gate",
+        "resolve-source",
+        "build",
+        "publish"
+      ],
+      "requiredTriggers": [
+        "workflow_dispatch"
+      ]
+    },
+    ".github/workflows/publish-sdk.yml": {
+      "workflowName": "Publish plugin SDK",
+      "requiredJobs": [
+        "release-plan",
+        "quality-gate",
+        "publish"
+      ],
+      "requiredTriggers": [
+        "push",
+        "workflow_dispatch"
+      ]
+    },
+    ".github/workflows/sdk-repository-ci.yml": {
+      "workflowName": "SDK repository CI",
+      "requiredJobs": [
+        "verify"
+      ],
+      "requiredTriggers": [
+        "workflow_call"
+      ]
+    },
+    ".github/workflows/sdk-pages.yml": {
+      "workflowName": "Build SDK Pages",
+      "requiredJobs": [
+        "build"
+      ],
+      "requiredTriggers": [
+        "workflow_call"
+      ]
+    }
+  },
+  "releaseEnvironment": "release",
+  "ruleset": {
+    "requiredChecks": [
+      "java-tests",
+      "javascript-tests",
+      "signature-guard",
+      "trusted-gate-contract",
+      "i18n-check",
+      "check-shared-snippets"
+    ],
+    "requireStrict": true,
+    "requirePullRequest": true,
+    "minimumApprovals": 0,
+    "allowBypass": false,
+    "allowDeletion": false,
+    "allowNonFastForward": false,
+    "roots": {
+      "refs/tags/i18n-gate-epoch-2-root": {
+        "allowDeletion": false,
+        "allowNonFastForward": false,
+        "allowBypass": false
+      },
+      "refs/tags/i18n-gate-epoch-3-root": {
+        "allowDeletion": false,
+        "allowNonFastForward": false,
+        "allowBypass": false
+      },
+      "refs/tags/i18n-gate-epoch-4-root": {
+        "allowDeletion": false,
+        "allowNonFastForward": false,
+        "allowBypass": false
+      },
+      "refs/tags/release-gate-epoch-5-root": {
+        "allowDeletion": false,
+        "allowNonFastForward": false,
+        "allowBypass": false
+      },
+      "refs/tags/release-gate-epoch-6-root": {
+        "allowDeletion": false,
+        "allowNonFastForward": false,
+        "allowBypass": false
+      },
+      "refs/tags/release-gate-epoch-7-root": {
+        "allowDeletion": false,
+        "allowNonFastForward": false,
+        "allowBypass": false
+      },
+      "refs/tags/release-gate-epoch-8-root": {
+        "allowDeletion": false,
+        "allowNonFastForward": false,
+        "allowBypass": false
+      },
+      "refs/tags/release-gate-epoch-9-root": {
+        "allowDeletion": false,
+        "allowNonFastForward": false,
+        "allowBypass": false
+      }
+    },
+    "requiredCheckSources": {
+      "java-tests": 4837005,
+      "javascript-tests": 4837005,
+      "signature-guard": 4837005,
+      "trusted-gate-contract": 4837005,
+      "i18n-check": 4837005,
+      "check-shared-snippets": 4837005
+    }
+  },
+  "upgradeProtocol": 1
+}

--- a/scripts/ci/gate-upgrade/core/release-gate-trust.mjs
+++ b/scripts/ci/gate-upgrade/core/release-gate-trust.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { readGit, readPolicy } from './gate-upgrade.mjs';
+import { verifyCandidate } from './release-gate-verifier.mjs';
+
+const REF_KEY = 'pixiv.release.trustedGateRef';
+const EPOCH_KEY = 'pixiv.release.trustedGateEpoch';
+function fail(message) { throw new Error(message); }
+function main() {
+    const repo = readGit(process.cwd(), ['rev-parse', '--show-toplevel']).trim();
+    const config = (key) => readGit(repo, ['config', '--local', '--get', key]).trim();
+    const commit = (ref) => readGit(repo, ['rev-parse', '--verify', '--end-of-options', ref + '^{commit}']).trim();
+    const args = process.argv.slice(2);
+    if (args.length !== 3 || !['--advance', '--adopt-root'].includes(args[0]) || args[1] !== '--ref') {
+        fail('usage: release-gate-trust.mjs --advance|--adopt-root --ref <commit>');
+    }
+    if (process.env.CI === 'true') fail('anchor changes are forbidden in CI');
+    if (readGit(repo, ['status', '--porcelain']).trim()) fail('trust commands require a clean worktree');
+    const trusted = commit(config(REF_KEY)), candidate = commit(args[2]);
+    const before = readPolicy(repo, trusted), after = readPolicy(repo, candidate);
+    if (config(EPOCH_KEY) !== String(before.gateEpoch)
+        || readGit(repo, ['symbolic-ref', '--quiet', 'HEAD']).trim() !== 'refs/heads/master'
+        || candidate !== commit('HEAD') || candidate !== commit('refs/remotes/origin/master')) {
+        fail('anchor changes require the configured predecessor and protected master tip');
+    }
+    if ((args[0] === '--adopt-root') !== (before.gateEpoch !== after.gateEpoch)) {
+        fail('use --adopt-root for an approved epoch transition, otherwise --advance');
+    }
+    verifyCandidate({ repo, trusted, candidate });
+    const common = readGit(repo, ['rev-parse', '--path-format=absolute', '--git-common-dir']).trim();
+    const file = path.join(common, 'config'), lock = file + '.lock';
+    const fd = fs.openSync(lock, 'wx');
+    try {
+        try { fs.writeFileSync(fd, fs.readFileSync(file)); } finally { fs.closeSync(fd); }
+        // 锁内再次核对原锚点，验证期间的并发推进不能被覆盖。
+        for (const [key, expected] of [[REF_KEY, trusted], [EPOCH_KEY, String(before.gateEpoch)]]) {
+            if (readGit(repo, ['config', '--file', lock, '--get', key]).trim() !== expected) fail('anchor changed during verification');
+        }
+        readGit(repo, ['config', '--file', lock, EPOCH_KEY, String(after.gateEpoch)]);
+        readGit(repo, ['config', '--file', lock, REF_KEY, candidate]);
+        fs.renameSync(lock, file);
+    } finally {
+        if (fs.existsSync(lock)) fs.unlinkSync(lock);
+    }
+    if (config(REF_KEY) !== candidate || config(EPOCH_KEY) !== String(after.gateEpoch)) fail('anchor update did not persist');
+    console.log('release-gate-trust: trusted anchor advanced to ' + candidate + ' (epoch ' + after.gateEpoch + ')');
+}
+try { main(); } catch (error) { console.error('release-gate-trust: ' + error.message); process.exitCode = 1; }

--- a/scripts/ci/gate-upgrade/core/release-gate-verifier.mjs
+++ b/scripts/ci/gate-upgrade/core/release-gate-verifier.mjs
@@ -1,0 +1,612 @@
+#!/usr/bin/env node
+'use strict';
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+import { verifyUpgrade } from './gate-upgrade.mjs';
+import { credentialSources, privilegedCredentials, workflowCredentialBindings } from './gate-credentials.mjs';
+
+const POLICY = 'scripts/ci/release-gate-policy.json';
+const REPOSITORY = 'Sywyar/PixivDownloader';
+const REPOSITORY_ID = 1089943605;
+const APP_ID = 4837005;
+const PR_WORKFLOW = '.github/workflows/pr-quality-gate.yml';
+const CHECK_WORKFLOW = '.github/workflows/gate-checks.yml';
+const QUALITY_USE = `${REPOSITORY}/.github/workflows/quality-gate.yml@master`;
+const BRANCH = 'refs/heads/master';
+const CORE = [
+    'scripts/ci/release-gate-trust.mjs',
+    'scripts/ci/release-gate-verifier.mjs',
+    'scripts/ci/resolve-trusted-base.mjs',
+    'scripts/ci/gate-upgrade.mjs',
+    'scripts/ci/gate-credentials.mjs',
+];
+const FLOOR = {
+    checks: ['java-tests', 'javascript-tests', 'signature-guard', 'trusted-gate-contract',
+        'i18n-check', 'check-shared-snippets'],
+    roots: ['refs/tags/i18n-gate-epoch-2-root', 'refs/tags/i18n-gate-epoch-3-root',
+        'refs/tags/i18n-gate-epoch-4-root', 'refs/tags/release-gate-epoch-5-root',
+        'refs/tags/release-gate-epoch-6-root', 'refs/tags/release-gate-epoch-7-root', 'refs/tags/release-gate-epoch-8-root'],
+    workflows: {
+        '.github/workflows/release.yml': ['validate-release-tag', 'draft-quality-gate',
+            'publish-plugins', 'publish-plugin-artifacts', 'build-jar',
+            'build-windows-installer', 'release', 'create-draft-release'],
+        '.github/workflows/nightly.yml': ['resolve-version', 'publish-plugins',
+            'publish-plugin-artifacts', 'build-jar', 'build-windows-installer', 'release-nightly'],
+        '.github/workflows/publish-plugins.yml': ['quality-gate', 'publish'],
+    },
+};
+const SHA = /^[0-9a-f]{40}$/;
+
+function fail(message) {
+    throw new Error(message);
+}
+
+function git(repo, args, encoding = 'utf8') {
+    return execFileSync('git', ['-C', repo, ...args], {
+        encoding, windowsHide: true, stdio: ['ignore', 'pipe', 'pipe'],
+    });
+}
+
+function resolveCommit(repo, ref, label) {
+    const sha = git(repo, ['rev-parse', '--verify', `${ref}^{commit}`]).trim();
+    if (!SHA.test(sha)) fail(`${label} is not a commit: ${ref}`);
+    return sha;
+}
+
+function show(repo, ref, rel, encoding = 'utf8') {
+    try {
+        return git(repo, ['show', `${ref}:${rel}`], encoding);
+    } catch {
+        fail(`missing ${rel} at ${ref}`);
+    }
+}
+
+function json(repo, ref, rel) {
+    try {
+        return JSON.parse(show(repo, ref, rel));
+    } catch (error) {
+        if (error instanceof SyntaxError) fail(`invalid JSON in ${rel} at ${ref}: ${error.message}`);
+        throw error;
+    }
+}
+
+function same(a, b) {
+    return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function list(value) {
+    if (value === undefined || value === null) return [];
+    return Array.isArray(value) ? value.map(String) : [String(value)];
+}
+
+function requireSubset(less, more, label) {
+    const actual = new Set(more);
+    for (const item of less) if (!actual.has(item)) fail(`${label} removed ${item}`);
+}
+
+function exactIdentity(trusted, candidate, label) {
+    if (!same(trusted, candidate)) fail(`${label} changed and requires a new Gate Epoch`);
+}
+
+function validateRootPolicy(policy) {
+    if (policy.schemaVersion !== 1 || !Number.isSafeInteger(policy.gateEpoch) || policy.gateEpoch <= 8
+        || !Number.isSafeInteger(policy.contractVersion) || policy.contractVersion < 10 || policy.upgradeProtocol !== 1) {
+        fail('upgradable Gate policy identity is invalid');
+    }
+    if (policy.rootTag !== `refs/tags/release-gate-epoch-${policy.gateEpoch}-root` || policy.protectedBranch !== BRANCH) {
+        fail('protected root or branch identity changed');
+    }
+    if (!same(policy.protectedCore, CORE)) fail('immutable core declaration differs from verifier');
+    if (policy.qualityGate?.workflow !== '.github/workflows/quality-gate.yml'
+        || policy.qualityGate?.workflowName !== 'Quality Gate') {
+        fail('Quality Gate identity is invalid');
+    }
+    requireSubset(FLOOR.checks,
+        policy.qualityGate.requiredJobs, 'Quality Gate jobs');
+    requireSubset(['workflow_dispatch', 'workflow_call'],
+        policy.qualityGate.requiredTriggers, 'Quality Gate triggers');
+    for (const [rel, jobs] of Object.entries(FLOOR.workflows)) {
+        if (!policy.workflows?.[rel]) fail(`policy removed required workflow ${rel}`);
+        requireSubset(jobs, policy.workflows[rel].requiredJobs, `${rel} jobs`);
+    }
+    const rules = policy.ruleset || {};
+    const contexts = rules.requiredChecks || [];
+    if (!Array.isArray(contexts) || contexts.some((context) => typeof context !== 'string' || !context)
+        || new Set(contexts).size !== contexts.length) {
+        fail('Ruleset required check declarations are invalid or duplicated');
+    }
+    requireSubset(FLOOR.checks, contexts, 'Ruleset checks');
+    requireSubset(contexts, policy.qualityGate.requiredJobs, 'required check execution roles');
+    for (const context of contexts) {
+        if (rules.requiredCheckSources?.[context] !== APP_ID) {
+            fail(`required check ${context} must be bound to the Gate App`);
+        }
+    }
+    for (const root of [...FLOOR.roots, policy.rootTag]) {
+        if (!rules.roots?.[root]) fail(`Ruleset policy removed historical root ${root}`);
+    }
+    if (rules.requireStrict !== true || rules.requirePullRequest !== true
+        || !Number.isInteger(rules.minimumApprovals) || rules.minimumApprovals < 0
+        || rules.allowBypass !== false || rules.allowDeletion !== false
+        || rules.allowNonFastForward !== false) {
+        fail('master Ruleset policy is weakened or invalid');
+    }
+    for (const [root, expected] of Object.entries(rules.roots || {})) {
+        if (!root.startsWith('refs/tags/') || expected.allowDeletion !== false
+            || expected.allowNonFastForward !== false || expected.allowBypass !== false) {
+            fail(`root Ruleset policy is weakened or invalid: ${root}`);
+        }
+    }
+    if (policy.releaseEnvironment !== 'release') fail('release Environment identity changed');
+}
+
+function validateMonotonic(trusted, candidate) {
+    validateRootPolicy(trusted);
+    validateRootPolicy(candidate);
+    for (const key of ['schemaVersion', 'gateEpoch', 'contractVersion', 'rootTag',
+        'protectedBranch', 'protectedCore', 'releaseEnvironment', 'upgradeProtocol']) {
+        exactIdentity(trusted[key], candidate[key], `policy.${key}`);
+    }
+    for (const key of ['workflow', 'workflowName']) {
+        exactIdentity(trusted.qualityGate[key], candidate.qualityGate[key], `qualityGate.${key}`);
+    }
+    requireSubset(trusted.qualityGate.requiredJobs, candidate.qualityGate.requiredJobs,
+        'Quality Gate jobs');
+    requireSubset(trusted.qualityGate.requiredTriggers, candidate.qualityGate.requiredTriggers,
+        'Quality Gate triggers');
+    for (const [rel, spec] of Object.entries(trusted.workflows)) {
+        const next = candidate.workflows?.[rel];
+        if (!next) fail(`policy removed workflow ${rel}`);
+        exactIdentity(spec.workflowName, next.workflowName, `${rel} workflow name`);
+        requireSubset(spec.requiredJobs, next.requiredJobs, `${rel} jobs`);
+        requireSubset(spec.requiredTriggers, next.requiredTriggers, `${rel} triggers`);
+    }
+    const oldRules = trusted.ruleset;
+    const newRules = candidate.ruleset;
+    requireSubset(oldRules.requiredChecks, newRules.requiredChecks, 'Ruleset checks');
+    if (newRules.minimumApprovals < oldRules.minimumApprovals) {
+        fail('Ruleset minimum approvals decreased');
+    }
+    for (const key of ['requireStrict', 'requirePullRequest']) {
+        if (oldRules[key] === true && newRules[key] !== true) fail(`Ruleset ${key} was disabled`);
+    }
+    for (const key of ['allowBypass', 'allowDeletion', 'allowNonFastForward']) {
+        if (oldRules[key] === false && newRules[key] !== false) fail(`Ruleset ${key} was enabled`);
+    }
+    for (const [root, expected] of Object.entries(oldRules.roots)) {
+        if (!same(expected, newRules.roots?.[root])) fail(`historical root policy changed: ${root}`);
+    }
+}
+
+function parseWorkflow(YAML, repo, ref, rel) {
+    try {
+        const doc = YAML.parse(show(repo, ref, rel));
+        if (!doc || typeof doc !== 'object' || !doc.jobs || typeof doc.jobs !== 'object') {
+            fail(`${rel} is not a workflow document`);
+        }
+        return doc;
+    } catch (error) {
+        if (error.message?.startsWith(rel)) throw error;
+        fail(`invalid workflow ${rel}: ${error.message}`);
+    }
+}
+
+function triggers(doc) {
+    const value = doc.on ?? doc.true;
+    if (typeof value === 'string') return [value];
+    if (Array.isArray(value)) return value.map(String);
+    return value && typeof value === 'object' ? Object.keys(value) : [];
+}
+
+function permissionsWrite(permissions) {
+    if (permissions === 'write-all') return true;
+    return permissions && typeof permissions === 'object'
+        && Object.values(permissions).some((value) => value === 'write');
+}
+
+function environmentName(job) {
+    return typeof job.environment === 'string' ? job.environment : job.environment?.name;
+}
+
+function needs(job) {
+    return list(job.needs);
+}
+
+function dependsOn(jobs, id, roots, seen = new Set()) {
+    if (roots.has(id)) return true;
+    if (seen.has(id)) return false;
+    seen.add(id);
+    const job = jobs[id] || {};
+    if (/\b(?:always|failure|cancelled)\s*\(/iu.test(String(job.if || ''))
+        || [job, ...(job.steps || [])].some((step) => step['continue-on-error'] !== undefined
+            && step['continue-on-error'] !== false)) return false;
+    return needs(jobs[id] || {}).some((dep) => dependsOn(jobs, dep, roots, seen));
+}
+
+function containsSecret(job) {
+    return credentialSources(job).has('secret');
+}
+
+function localWorkflow(uses) {
+    return typeof uses === 'string' && uses.startsWith('./.github/workflows/') ? uses.slice(2) : null;
+}
+
+function validateActionPins(rel, doc) {
+    const uses = [];
+    for (const job of Object.values(doc.jobs)) {
+        if (job.uses) uses.push(job.uses);
+        for (const step of job.steps || []) if (step.uses) uses.push(step.uses);
+    }
+    for (const value of uses) {
+        if (rel === PR_WORKFLOW && value === QUALITY_USE) continue;
+        if (typeof value !== 'string') fail(`${rel} has a nonliteral action reference`);
+        if (value.startsWith('./')) continue;
+        if (/^docker:\/\/.+@sha256:[0-9a-f]{64}$/u.test(value)) continue;
+        if (!/@[0-9a-f]{40}$/u.test(value)) fail(`${rel} uses an external action without a full SHA: ${value}`);
+    }
+}
+
+function validateQualityJobs(policy, doc) {
+    for (const id of policy.qualityGate.requiredJobs) {
+        const job = doc.jobs[id];
+        if (!job || job.uses || job.if !== undefined || job.strategy !== undefined
+            || (job.name !== undefined && job.name !== id)) {
+            fail(`Quality Gate role ${id} must be unconditional and have a stable check identity`);
+        }
+    }
+}
+
+export function validatePullRequestCaller(doc) {
+    if (!doc || doc.name !== 'Pull Request Quality Gate'
+        || !same(triggers(doc), ['pull_request'])) fail('PR caller must use pull_request');
+    const event = doc.on.pull_request || {};
+    requireSubset(['opened', 'reopened', 'synchronize', 'edited'], event.types || [], 'PR events');
+    if (!same(Object.keys(doc.jobs), ['quality-gate'])) fail('PR caller must only invoke Quality Gate');
+    const call = doc.jobs['quality-gate'];
+    if (call.uses !== QUALITY_USE || Object.keys(call).some((key) => !['uses', 'if'].includes(key))) {
+        fail('PR caller must invoke the protected Quality Gate without candidate inputs or steps');
+    }
+    if (!same(doc.permissions, { contents: 'read' }) || containsSecret(doc)) {
+        fail('PR caller may only read contents');
+    }
+}
+
+function validateCheckPublisher(doc) {
+    if (!doc || doc.name !== 'Gate Checks') fail('missing protected check publisher');
+    if (triggers(doc).some((event) => !['workflow_run', 'push'].includes(event))
+        || !same([...(doc.on.workflow_run?.workflows || [])].sort(), ['Pull Request Quality Gate', 'Quality Gate'])
+        || !same([...(doc.on.workflow_run?.types || [])].sort(), ['completed', 'in_progress'])
+        || !same(doc.on.push?.branches, ['master'])) {
+        fail('check credentials are restricted to protected workflow completion and master push');
+    }
+    // 此例外仅允许 App 写检查；产品凭据和 GITHUB_TOKEN 写权限仍须经过完整发布门禁。
+    const publicDocument = structuredClone(doc);
+    for (const job of Object.values(publicDocument.jobs)) {
+        if (permissionsWrite(job.permissions === undefined ? doc.permissions : job.permissions)) {
+            fail('check publisher cannot grant GITHUB_TOKEN write permissions');
+        }
+        for (const step of job.steps || []) {
+            if (!step.uses?.startsWith('actions/create-github-app-token@')) continue;
+            const inputs = step.with || {};
+            if (inputs['client-id'] !== 'Iv23lixorUs94dx1xEvB' || inputs['permission-checks'] !== 'write'
+                || Object.keys(inputs).some((key) => !['client-id', 'private-key', 'permission-checks'].includes(key))) {
+                fail('check publisher may only mint the configured checks-only App token');
+            }
+            delete inputs['private-key'];
+        }
+    }
+    if (containsSecret(publicDocument)) {
+        fail('check publisher cannot consume other release credentials');
+    }
+}
+
+function workflowSecurityProblems(rel, doc, policy, providerPaths) {
+    const problems = [];
+    if (!Object.prototype.hasOwnProperty.call(doc, 'permissions') || doc.permissions === null) {
+        problems.push(`${rel} must declare top-level permissions`);
+    }
+    if (triggers(doc).includes('pull_request_target')) {
+        problems.push(`${rel} cannot give PR execution the protected branch cache scope`);
+    }
+    for (const permissions of [doc.permissions, ...Object.values(doc.jobs).map((job) => job.permissions)]) {
+        if (permissions === undefined) continue;
+        if (permissions === 'read-all' || permissions === 'write-all') continue;
+        if (!permissions || typeof permissions !== 'object' || Array.isArray(permissions)
+            || Object.values(permissions).some((value) => !['read', 'write', 'none'].includes(value))) {
+            problems.push(`${rel} permissions must be explicit literal access levels`);
+        }
+    }
+    const jobs = doc.jobs;
+    const credentialBindings = workflowCredentialBindings(doc);
+    const roots = new Set(Object.entries(jobs)
+        .filter(([, job]) => providerPaths.has(localWorkflow(job.uses)))
+        .map(([id]) => id));
+    for (const [id, job] of Object.entries(jobs)) {
+        if (job.secrets === 'inherit') problems.push(`${rel} job ${id} uses secrets: inherit`);
+        const condition = String(job.if || '');
+        const provider = roots.has(id);
+        const sensitive = privilegedCredentials([doc.env, job], doc.permissions, job.permissions, credentialBindings.get(id))
+            || environmentName(job) !== undefined;
+        const required = provider || (rel === policy.qualityGate.workflow
+            && policy.qualityGate.requiredJobs.some((role) => dependsOn(jobs, role, new Set([id]))));
+        if ((required || sensitive) && (/\b(?:always|failure|cancelled)\s*\(/iu.test(condition)
+            || [job, ...(job.steps || [])].some((step) => step['continue-on-error'] !== undefined
+                && step['continue-on-error'] !== false))) {
+            problems.push(`${rel} job ${id} can bypass a failed dependency or suppress a failure`);
+        }
+        if (provider && privilegedCredentials([doc.env, job], doc.permissions, job.permissions, credentialBindings.get(id))) {
+            problems.push(`${rel} job ${id} cannot forward credentials into the quality provider`);
+        }
+        if (!sensitive || provider) continue;
+        if (environmentName(job) !== policy.releaseEnvironment) {
+            problems.push(`${rel} job ${id} uses privileged capabilities outside the release Environment`);
+        }
+        if (rel !== CHECK_WORKFLOW && !dependsOn(jobs, id, roots)) {
+            problems.push(`${rel} job ${id} can use privileged capabilities before Quality Gate success`);
+        }
+    }
+    return problems;
+}
+
+function validateWorkflows(repo, ref, policy) {
+    const require = createRequire(import.meta.url);
+    let YAML;
+    try {
+        YAML = require('yaml');
+    } catch {
+        fail('the installed yaml dependency is required to inspect workflows');
+    }
+    const names = git(repo, ['ls-tree', '-r', '--name-only', ref, '--', '.github/workflows'])
+        .split(/\r?\n/u).filter((name) => /\.ya?ml$/u.test(name));
+    const expand = (steps, seen = new Set()) => {
+        for (const step of steps || []) {
+            if (!step.uses?.startsWith('./')) continue;
+            const action = step.uses.slice(2);
+            if (!action || path.posix.isAbsolute(action) || path.posix.normalize(action) !== action
+                || action.startsWith('../') || action.includes('\\') || seen.has(action)) {
+                fail('invalid or recursive local action: ' + action);
+            }
+            const files = git(repo, ['ls-tree', '--name-only', ref, '--', action + '/action.yml', action + '/action.yaml'])
+                .trim().split(/\r?\n/u).filter(Boolean);
+            if (files.length !== 1) fail('missing or ambiguous local action: ' + action);
+            if (!/^100(?:644|755) blob /u.test(git(repo, ['ls-tree', ref, '--', files[0]]))) {
+                fail('local action descriptor must be a regular file: ' + action);
+            }
+            const definition = YAML.parse(show(repo, ref, files[0]));
+            if (definition?.runs?.using !== 'composite') continue;
+            const steps = definition.runs.steps;
+            validateActionPins(files[0], { jobs: { action: { steps } } });
+            expand(steps, new Set([...seen, action]));
+            step.gateLocalAction = definition;
+        }
+    };
+    const docs = new Map(names.map((rel) => {
+        const doc = parseWorkflow(YAML, repo, ref, rel);
+        for (const job of Object.values(doc.jobs)) expand(job.steps);
+        return [rel, doc];
+    }));
+    const required = new Map([[policy.qualityGate.workflow, policy.qualityGate],
+        ...Object.entries(policy.workflows)]);
+    for (const [rel, spec] of required) {
+        const doc = docs.get(rel);
+        if (!doc) fail(`missing required workflow ${rel}`);
+        if (doc.name !== spec.workflowName) fail(`${rel} workflow name changed`);
+        requireSubset(spec.requiredTriggers, triggers(doc), `${rel} triggers`);
+        requireSubset(spec.requiredJobs, Object.keys(doc.jobs), `${rel} jobs`);
+    }
+    const quality = docs.get(policy.qualityGate.workflow);
+    if (triggers(quality).some((event) => !['workflow_call', 'workflow_dispatch'].includes(event))) {
+        fail('full Quality Gate must run through the PR caller or an explicit reusable/manual call');
+    }
+    validateQualityJobs(policy, quality);
+    validatePullRequestCaller(docs.get(PR_WORKFLOW));
+    validateCheckPublisher(docs.get(CHECK_WORKFLOW));
+    const providerPaths = new Set([policy.qualityGate.workflow]);
+    let changed = true;
+    while (changed) {
+        changed = false;
+        for (const [rel, doc] of docs) {
+            if (providerPaths.has(rel) || !triggers(doc).includes('workflow_call')) continue;
+            // 可复用 workflow 整体成功必须意味着 QG 已执行成功；仅包含一个可跳过的调用不够。
+            const unconditional = (id, seen = new Set()) => {
+                const job = doc.jobs[id];
+                if (!job || seen.has(id) || job.if !== undefined
+                    || (job.uses && !providerPaths.has(localWorkflow(job.uses)))) return false;
+                return needs(job).every((dep) => unconditional(dep, new Set([...seen, id])));
+            };
+            const hasProvider = Object.entries(doc.jobs)
+                .some(([id, job]) => providerPaths.has(localWorkflow(job.uses)) && unconditional(id));
+            if (hasProvider && workflowSecurityProblems(rel, doc, policy, providerPaths).length === 0) {
+                providerPaths.add(rel);
+                changed = true;
+            }
+        }
+    }
+    for (const [rel, doc] of docs) {
+        validateActionPins(rel, doc);
+        const problems = workflowSecurityProblems(rel, doc, policy, providerPaths);
+        if (problems.length > 0) fail(problems.join('\n'));
+    }
+}
+
+function validateCore(repo, trusted, candidate) {
+    for (const rel of CORE) {
+        const before = git(repo, ['ls-tree', trusted, '--', rel]).trim();
+        const after = git(repo, ['ls-tree', candidate, '--', rel]).trim();
+        if (!before || before !== after) fail(`immutable release gate core changed: ${rel}`);
+    }
+}
+
+function validateAncestry(repo, trusted, candidate) {
+    const root = resolveCommit(repo, json(repo, trusted, POLICY).rootTag, 'Gate root');
+    if (trusted === candidate) fail('trusted base must be a strict predecessor of the candidate');
+    for (const [ancestor, descendant, label] of [
+        [root, trusted, 'root to trusted base'],
+        [trusted, candidate, 'trusted base to candidate'],
+        [trusted, 'refs/remotes/origin/master', 'trusted base to protected branch'],
+    ]) {
+        const result = spawnSync('git', ['-C', repo, 'merge-base', '--is-ancestor', ancestor, descendant],
+            { windowsHide: true, stdio: 'ignore' });
+        if (result.status !== 0) fail(`invalid protected predecessor ancestry: ${label}`);
+    }
+}
+
+function validateSignatureBoundary(repo, candidate) {
+    const markers = ['DouyinX' + 'BogusSigner', 'DouyinA' + 'BogusSigner', 'Douyin' + 'Sm3',
+        'generateChrome' + 'Fingerprint', 'Dkdpgh4' + 'ZKs', 'Dkdpgh2' + 'Zms', 'ckdp1h4' + 'ZKs'];
+    const result = spawnSync('git', ['-C', repo, 'grep', '-nE', markers.join('|'), candidate, '--', '.',
+        ':(exclude)scripts/hooks/pre-push-guard.sh', ':(exclude)scripts/i18n/test/hooks.test.mjs'],
+    { encoding: 'utf8', windowsHide: true });
+    if (result.status === 0 && result.stdout.trim()) {
+        fail(`detected reverse-engineered Douyin signature code:\n${result.stdout.trim()}`);
+    }
+    if (result.status !== 0 && result.status !== 1) fail('cannot inspect signature boundary');
+}
+
+function parseArgs(argv) {
+    const out = { repo: '.', candidate: null, trusted: null, invariants: false,
+        signature: false, version: false, localFeedback: false };
+    for (let i = 0; i < argv.length; i += 1) {
+        const arg = argv[i];
+        if (arg === '--repo-root') out.repo = argv[++i];
+        else if (arg === '--candidate-ref') out.candidate = argv[++i];
+        else if (arg === '--trusted-ref') out.trusted = argv[++i];
+        else if (arg === '--invariants') out.invariants = true;
+        else if (arg === '--signature') out.signature = true;
+        else if (arg === '--version') out.version = true;
+        else if (arg === '--local-feedback') out.localFeedback = true;
+        else fail(`unknown argument: ${arg}`);
+    }
+    return out;
+}
+
+export function verifyCandidate({ repo, trusted, candidate, invariants = false,
+    signature = false, localFeedback = false }) {
+    const candidatePolicy = json(repo, candidate, POLICY);
+    validateRootPolicy(candidatePolicy);
+    if (!invariants) {
+        if (json(repo, trusted, POLICY).gateEpoch !== candidatePolicy.gateEpoch) {
+            verifyUpgrade({ repo, trusted, candidate, localFeedback });
+        } else {
+            validateMonotonic(json(repo, trusted, POLICY), candidatePolicy);
+            validateCore(repo, trusted, candidate);
+            validateAncestry(repo, trusted, candidate);
+        }
+    }
+    if (!signature) validateWorkflows(repo, candidate, candidatePolicy);
+    validateSignatureBoundary(repo, candidate);
+    return candidatePolicy;
+}
+
+export function parseExecutionProof(log) {
+    const records = String(log).split(/\r?\n/u).map((line) => line.replace(
+        /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z\s+/u, ''))
+        .filter((line) => line.startsWith('GATE_EXECUTION '));
+    if (records.length !== 1) fail('missing or ambiguous protected execution record');
+    const proof = JSON.parse(records[0].slice('GATE_EXECUTION '.length));
+    if (proof.schemaVersion !== 1 || proof.repository !== REPOSITORY
+        || proof.repositoryId !== String(REPOSITORY_ID) || proof.event !== 'pull_request'
+        || proof.baseRef !== 'master' || !SHA.test(proof.merge) || !SHA.test(proof.base)
+        || !SHA.test(proof.head) || !/^[1-9][0-9]*$/u.test(proof.pullRequest)
+        || !/^[1-9][0-9]*$/u.test(proof.runId) || !/^[1-9][0-9]*$/u.test(proof.attempt)) {
+        fail('execution record does not identify a master PR merge');
+    }
+    return proof;
+}
+
+export function verifyRunIdentity({ run, merge, caller, protectedBase, proof }) {
+    validatePullRequestCaller(caller);
+    if (run.repository?.id !== REPOSITORY_ID || run.repository?.full_name !== REPOSITORY
+        || run.event !== 'pull_request' || run.path?.split('@')[0] !== PR_WORKFLOW
+        || run.name !== caller.name || !Number.isSafeInteger(run.id) || run.id <= 0
+        || !Number.isSafeInteger(run.run_attempt) || run.run_attempt <= 0) {
+        fail('run is not a pull request execution from the expected repository and workflow');
+    }
+    if (!SHA.test(run.head_sha) || proof.merge !== merge.sha || proof.head !== run.head_sha
+        || proof.base !== protectedBase
+        || !SHA.test(merge.tree?.sha) || merge.parents?.length !== 2
+        || merge.parents[1]?.sha !== run.head_sha || merge.parents[0]?.sha !== protectedBase) {
+        fail('run head, tested merge and protected base do not agree');
+    }
+    const use = caller.jobs['quality-gate'].uses;
+    const sources = run.referenced_workflows;
+    const qualitySources = (sources || []).filter((source) => source.path === use);
+    if (!Array.isArray(sources) || qualitySources.length !== 1
+        || qualitySources[0].sha !== protectedBase || qualitySources[0].ref !== 'refs/heads/master'
+        || proof.runId !== String(run.id) || Number(proof.attempt) > run.run_attempt) {
+        fail('Quality Gate execution did not use the tested protected base');
+    }
+    return { head: run.head_sha, base: protectedBase, merge: merge.sha, tree: merge.tree.sha,
+        runId: run.id, attempt: run.run_attempt };
+}
+
+export function verifyRunResults({ run, jobs, requiredJobs = FLOOR.checks, expectedJobs = requiredJobs,
+    jobPrefix = 'quality-gate / ' }) {
+    if (run.status !== 'completed' || run.conclusion !== 'success') {
+        fail('Quality Gate run has not completed successfully');
+    }
+    if (!Array.isArray(jobs)) {
+        fail('missing effective jobs');
+    }
+    const ids = new Set();
+    for (const job of jobs) {
+        if (!Number.isSafeInteger(job.id) || job.id <= 0 || ids.has(job.id)
+            || job.run_id !== run.id || job.head_sha !== run.head_sha
+            || job.status !== 'completed' || !job.name?.startsWith(jobPrefix)) {
+            fail('job results are duplicated, foreign or incomplete');
+        }
+        ids.add(job.id);
+    }
+    requireSubset(requiredJobs, expectedJobs, 'protected Quality Gate roles');
+    for (const role of requiredJobs) {
+        const matches = jobs.filter((job) => job.name === `${jobPrefix}${role}`);
+        if (matches.length !== 1) fail(`missing or ambiguous effective result for ${role}`);
+        if (matches[0].conclusion !== 'success') fail(`required role ${role} is skipped or unsuccessful`);
+    }
+}
+
+export function verifyIntegratedTree(evidence, integrated) {
+    if (!SHA.test(integrated.sha) || integrated.parents?.length !== 2
+        || integrated.parents[0]?.sha !== evidence.base || integrated.parents[1]?.sha !== evidence.head
+        || integrated.tree?.sha !== evidence.tree) {
+        fail('protected merge commit does not preserve the tested parents and tree');
+    }
+    return integrated.sha;
+}
+
+export function verifyAppChecks({ checks, evidence, requiredChecks = FLOOR.checks }) {
+    const details = `https://github.com/${REPOSITORY}/actions/runs/${evidence.runId}/attempts/${evidence.attempt}`;
+    for (const name of requiredChecks) {
+        const matching = checks.filter((check) => check.name === name && check.app?.id === APP_ID);
+        if (matching.length !== 1 || matching[0].head_sha !== evidence.merge
+            || matching[0].status !== 'completed' || matching[0].conclusion !== 'success'
+            || matching[0].details_url !== details) fail(`missing current App evidence for ${name}`);
+    }
+}
+
+function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.version) {
+        console.log('release-gate-verifier upgrade-protocol=1 schema=1');
+        return;
+    }
+    const repo = path.resolve(args.repo);
+    const candidate = resolveCommit(repo, args.candidate || 'HEAD', 'candidate');
+    const trusted = args.invariants ? null : resolveCommit(repo, args.trusted, 'trusted base');
+    verifyCandidate({ ...args, repo, trusted, candidate });
+    console.log(`TRUSTED RELEASE GATE ${json(repo, candidate, POLICY).gateEpoch} OK (${candidate})`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    try {
+        main();
+    } catch (error) {
+        console.error(`release-gate-verifier: ${error.message}`);
+        process.exitCode = 1;
+    }
+}

--- a/scripts/ci/gate-upgrade/core/resolve-trusted-base.mjs
+++ b/scripts/ci/gate-upgrade/core/resolve-trusted-base.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+'use strict';
+
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function git(repo, args) {
+    return execFileSync('git', ['-C', repo, ...args], {
+        encoding: 'utf8', windowsHide: true, stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+}
+
+export function resolveTrustedBase({ repo = '.', candidate, event, before, ref,
+    prBase, prHead, mergeGroupBase, inputBase }) {
+    const commit = (value) => {
+        if (!value) throw new Error('missing commit');
+        const sha = git(repo, ['rev-parse', '--verify', value + '^{commit}']);
+        if (!/^[0-9a-f]{40}$/u.test(sha)) throw new Error('invalid commit');
+        return sha;
+    };
+    const tested = commit(candidate);
+    const master = commit('refs/remotes/origin/master');
+    const onMaster = git(repo, ['merge-base', tested, master]) === tested;
+    let protectedPredecessor = onMaster ? commit(tested + '^1') : git(repo, ['merge-base', tested, master]);
+    let proposed = inputBase;
+    if (event === 'pull_request') {
+        const parents = git(repo, ['rev-list', '--parents', '-n', '1', tested]).split(/\s+/u).slice(1);
+        if (parents.length !== 2 || parents[0] !== commit(prBase) || parents[1] !== commit(prHead)) {
+            throw new Error('PR candidate must have the event base and head as its two parents');
+        }
+        // 开发分支是合并候选的父提交；只有它与 master 的共同历史能提供可信核心。
+        protectedPredecessor = git(repo, ['merge-base', commit(prBase), master]);
+        proposed = protectedPredecessor;
+    } else if (!proposed && event === 'push' && ref === 'refs/heads/master') {
+        proposed = before;
+    } else if (!proposed && event === 'merge_group') {
+        proposed = mergeGroupBase;
+    } else if (!proposed) {
+        proposed = protectedPredecessor;
+    }
+    const base = commit(proposed);
+    if (base !== protectedPredecessor || (inputBase && commit(inputBase) !== base) || base === tested) {
+        throw new Error('trusted base must be the exact protected predecessor');
+    }
+    git(repo, ['merge-base', '--is-ancestor', base, tested]);
+    git(repo, ['merge-base', '--is-ancestor', base, master]);
+    const policy = JSON.parse(git(repo, ['show', base + ':scripts/ci/release-gate-policy.json']));
+    if (!Number.isSafeInteger(policy.gateEpoch) || policy.gateEpoch < 5
+        || policy.rootTag !== 'refs/tags/release-gate-epoch-' + policy.gateEpoch + '-root') {
+        throw new Error('invalid predecessor epoch');
+    }
+    const root = commit('refs/tags/release-gate-epoch-' + policy.gateEpoch + '-root');
+    git(repo, ['merge-base', '--is-ancestor', root, base]);
+    return { mode: 'NORMAL', base, root };
+}
+
+function main() {
+    const values = {};
+    let mode = false;
+    const names = new Set(['repo-root', 'candidate', 'event-name', 'before', 'ref',
+        'pr-base', 'pr-head', 'merge-group-base', 'input-base', 'default-branch',
+        'root-admission', 'root-candidate-sha']);
+    for (let i = 2; i < process.argv.length; i += 1) {
+        const key = process.argv[i].replace(/^--/u, '');
+        if (key === 'mode') mode = true;
+        else if (names.has(key) && process.argv[i + 1] !== undefined) values[key] = process.argv[++i];
+        else throw new Error('unknown or incomplete argument: ' + process.argv[i]);
+    }
+    if (values['default-branch'] && values['default-branch'] !== 'master') {
+        throw new Error('protected branch must be master');
+    }
+    if ((values['root-admission'] && values['root-admission'] !== 'false') || values['root-candidate-sha']) {
+        throw new Error('candidate self-admission is not supported');
+    }
+    const result = resolveTrustedBase({ repo: values['repo-root'], candidate: values.candidate,
+        event: values['event-name'], before: values.before, ref: values.ref,
+        prBase: values['pr-base'], prHead: values['pr-head'], mergeGroupBase: values['merge-group-base'],
+        inputBase: values['input-base'] });
+    console.log(mode ? JSON.stringify(result) : result.base);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    try { main(); } catch (error) {
+        console.error('resolve-trusted-base: ' + error.message);
+        process.exitCode = 2;
+    }
+}

--- a/scripts/ci/test/doctor-github-ruleset.test.mjs
+++ b/scripts/ci/test/doctor-github-ruleset.test.mjs
@@ -161,6 +161,25 @@ test('doctor：master + root tag detail 完全正确 → success (exit 0)', asyn
     assert.equal(result.exitCode, 0, JSON.stringify(result.problems));
 });
 
+test('doctor：固定 root 通配保护覆盖新增 epoch，但排除项和 bypass 不能放行', async () => {
+    const expected = structuredClone(invariants);
+    expected.roots['refs/tags/release-gate-epoch-19-root'] = {
+        allowDeletion: false, allowNonFastForward: false, allowBypass: false,
+    };
+    const wildcard = validTagDetail('refs/tags/release-gate-epoch-*-root', 919);
+    const details = [validMasterDetail(), ...validTagDetails(), wildcard];
+    const inspect = () => {
+        const { fetchJson } = makeFetch(details.map(summaryOf), Object.fromEntries(details.map((detail) => [detail.id, detail])));
+        return runDoctor({ fetchJson, token: 't', repo: REPO, invariants: expected });
+    };
+    assert.equal((await inspect()).exitCode, 0);
+    wildcard.conditions.ref_name.exclude = ['refs/tags/release-gate-epoch-19-root'];
+    assert.equal((await inspect()).exitCode, 1);
+    wildcard.conditions.ref_name.exclude = [];
+    wildcard.bypass_actors = [{ actor_type: 'RepositoryRole', actor_id: 5, bypass_mode: 'always' }];
+    assert.equal((await inspect()).exitCode, 1);
+});
+
 test('doctor: Rulesets beyond the first page must be read and incomplete pagination cannot pass', async () => {
     const relevant = [validMasterDetail(), ...validTagDetails()];
     const filler = Array.from({ length: 100 }, (_, index) => ({ ...validMasterDetail(), id: 1000 + index,

--- a/scripts/ci/test/gate-upgrade.test.mjs
+++ b/scripts/ci/test/gate-upgrade.test.mjs
@@ -1,0 +1,178 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import YAML from 'yaml';
+import { historicalGateFile, historicalWorkflows } from './lib/historical-gate.mjs';
+import { createApproval, verifyUpgrade, materializeGate, selectGateFiles, POLICY_PATH, APPROVAL_PATH,
+    UPGRADE_DIRECTORY } from '../gate-upgrade.mjs';
+import { verifyProtectedCandidate } from '../trusted-gate-runner.mjs';
+import { credentialSources, effectivePermissions, privilegedCredentials, workflowCredentialBindings } from '../gate-credentials.mjs';
+
+const ROOT = fileURLToPath(new URL('../../../', import.meta.url));
+function fixture(t) {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv-upgrade-test-'));
+    t.after(() => fs.rmSync(repo, { recursive: true, force: true }));
+    const git = (...args) => execFileSync('git', ['-C', repo, ...args], {
+        encoding: 'utf8', windowsHide: true, stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const write = (file, value) => {
+        fs.mkdirSync(path.dirname(path.join(repo, file)), { recursive: true });
+        fs.writeFileSync(path.join(repo, file), typeof value === 'string' ? value : JSON.stringify(value, null, 2) + '\n');
+    };
+    const json = (file) => JSON.parse(fs.readFileSync(path.join(repo, file), 'utf8'));
+    const commit = (message) => { git('add', '.'); git('-c', 'commit.gpgsign=false', 'commit', '-qm', message); return git('rev-parse', 'HEAD'); };
+    git('init', '-q', '-b', 'master');
+    git('config', 'user.name', 'Gate test'); git('config', 'user.email', 'gate@example.invalid');
+    git('config', 'commit.gpgsign', 'false'); git('config', 'tag.gpgsign', 'false');
+    git('config', 'core.autocrlf', 'false'); git('config', 'core.hooksPath', path.join(repo, 'no-hooks'));
+    for (const file of ['.github', 'package.json', 'package-lock.json', 'scripts/ci']) {
+        fs.cpSync(path.join(ROOT, file), path.join(repo, file), { recursive: true });
+    }
+    const previous = JSON.parse(historicalGateFile(ROOT, POLICY_PATH, 8));
+    for (const file of [...previous.protectedCore, POLICY_PATH]) write(file, historicalGateFile(ROOT, file, 8).toString('utf8'));
+    fs.rmSync(path.join(repo, '.github/workflows'), { recursive: true });
+    for (const file of historicalWorkflows(ROOT, 8)) write(file, historicalGateFile(ROOT, file, 8).toString('utf8'));
+    // 固定的旧核心验证准备提交；新协议的 epoch 由测试数据选择。
+    const initial = commit('existing protected gate');
+    git('-c', 'tag.gpgsign=false', 'tag', '-a', 'release-gate-epoch-8-root', '-m', 'fixture root', initial);
+    git('update-ref', 'refs/remotes/origin/master', initial);
+    function prepare(nextEpoch) {
+        const before = json(POLICY_PATH), next = json(UPGRADE_DIRECTORY + 'release-gate-policy.json');
+        next.gateEpoch = nextEpoch; next.rootTag = `refs/tags/release-gate-epoch-${nextEpoch}-root`;
+        next.ruleset.roots = { ...before.ruleset.roots,
+            [next.rootTag]: { allowDeletion: false, allowNonFastForward: false, allowBypass: false } };
+        write(UPGRADE_DIRECTORY + 'release-gate-policy.json', next);
+        write(APPROVAL_PATH, createApproval({ repo, trusted: 'HEAD', changes: ['Reviewed credential semantics and upgrade contract'] }));
+        const base = commit('approve inactive core');
+        git('update-ref', 'refs/remotes/origin/master', base);
+        return base;
+    }
+    function activate(base) {
+        const record = json(APPROVAL_PATH);
+        execFileSync(process.execPath, [path.join(ROOT, 'scripts/ci/gate-upgrade.mjs'),
+            '--activate', '--repo-root', repo, '--trusted-ref', base], { cwd: repo, windowsHide: true });
+        fs.cpSync(path.join(ROOT, '.github/workflows'), path.join(repo, '.github/workflows'), { recursive: true });
+        const root = commit('activate approved core');
+        git('-c', 'tag.gpgsign=false', 'tag', '-a', record.to.root.slice('refs/tags/'.length), '-m', 'fixture sealed root', root);
+        const merge = git('commit-tree', `${root}^{tree}`, '-p', base, '-p', root, '-m', 'fixture integration');
+        return { root, merge };
+    }
+    return { repo, git, write, json, commit, initial, prepare, activate };
+}
+
+test('升级复用同一协议，旧核心批准准备提交，普通更新继续通过保护', (t) => {
+    const f = fixture(t), base = f.prepare(17);
+    assert.equal(verifyProtectedCandidate({ repo: f.repo, trusted: f.initial, candidate: base }).gateEpoch, 8);
+    const activated = f.activate(base);
+    assert.equal(verifyUpgrade({ repo: f.repo, trusted: base, candidate: activated.merge }).to.epoch, 17);
+    assert.equal(verifyProtectedCandidate({ repo: f.repo, trusted: base, candidate: activated.merge }).gateEpoch, 17);
+    const workflow = YAML.parse(fs.readFileSync(path.join(ROOT, '.github/workflows/quality-gate.yml'), 'utf8'));
+    const step = workflow.jobs['trusted-gate-contract'].steps.find((step) => step.name === 'Materialize protected verifier');
+    const runner = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv-upgrade-runner-'));
+    t.after(() => fs.rmSync(runner, { recursive: true, force: true }));
+    execFileSync('bash', ['-e', '-o', 'pipefail', '-c', step.run], { cwd: f.repo, windowsHide: true,
+        env: { ...process.env, BASE_SHA: base, CANDIDATE_SHA: activated.merge, GITHUB_WORKSPACE: f.repo,
+            RUNNER_TEMP: runner, GITHUB_ENV: path.join(runner, 'github-env') } });
+    assert.equal(JSON.parse(fs.readFileSync(path.join(runner, 'trusted-gate', POLICY_PATH), 'utf8')).gateEpoch, 17);
+    f.git('reset', '--hard', activated.merge);
+    f.git('update-ref', 'refs/remotes/origin/master', activated.merge);
+    f.git('config', 'pixiv.release.trustedGateEpoch', '8');
+    f.git('config', 'pixiv.release.trustedGateRef', base);
+    const local = { ...process.env }; delete local.CI;
+    execFileSync(process.execPath, [path.join(ROOT, 'scripts/ci/trust-gate.mjs'), '--adopt-root', '--ref', activated.merge],
+        { cwd: f.repo, env: local, windowsHide: true });
+    assert.equal(f.git('config', '--get', 'pixiv.release.trustedGateEpoch'), '17');
+    assert.equal(f.git('config', '--get', 'pixiv.release.trustedGateRef'), activated.merge);
+    const secondBase = f.prepare(18);
+    assert.equal(verifyProtectedCandidate({ repo: f.repo, trusted: activated.merge, candidate: secondBase }).gateEpoch, 17);
+    const second = f.activate(secondBase);
+    assert.equal(verifyProtectedCandidate({ repo: f.repo, trusted: secondBase, candidate: second.merge }).gateEpoch, 18);
+});
+
+test('候选声明、来源、核心字节、依赖、文件模式和 root 不能替代前驱授权', (t) => {
+    const f = fixture(t), base = f.prepare(17), { root, merge } = f.activate(base);
+    const options = { repo: f.repo, trusted: base, candidate: merge };
+    assert.doesNotThrow(() => verifyUpgrade(options));
+    assert.throws(() => selectGateFiles({ repo: f.repo, trusted: root, candidate: merge }), /protected predecessor/);
+    assert.throws(() => verifyUpgrade({ ...options, trusted: f.initial }), /approval|source|match/);
+    for (const file of ['scripts/ci/release-gate-verifier.mjs', 'scripts/ci/gate-credentials.mjs', 'package-lock.json']) {
+        f.git('reset', '--hard', root);
+        f.write(file, fs.readFileSync(path.join(f.repo, file), 'utf8') + '\n');
+        const tampered = f.commit('tampered candidate');
+        assert.throws(() => verifyUpgrade({ ...options, candidate: tampered }), /approved bytes/);
+    }
+    f.git('reset', '--hard', root);
+    f.git('update-index', '--chmod=+x', 'scripts/ci/release-gate-verifier.mjs');
+    f.git('-c', 'commit.gpgsign=false', 'commit', '-qm', 'tampered executable mode');
+    assert.throws(() => verifyUpgrade({ ...options, candidate: 'HEAD' }), /approved bytes/);
+    f.git('tag', '-d', 'release-gate-epoch-17-root');
+    f.git('-c', 'tag.gpgsign=false', 'tag', 'release-gate-epoch-17-root', root);
+    assert.throws(() => verifyUpgrade(options), /annotated/);
+});
+
+test('物化内容来自受保护前驱，启用前仅允许明确的本地反馈', (t) => {
+    const oldCI = process.env.CI;
+    t.after(() => { if (oldCI === undefined) delete process.env.CI; else process.env.CI = oldCI; });
+    delete process.env.CI;
+    const f = fixture(t), base = f.prepare(17);
+    for (const file of f.json(APPROVAL_PATH).files) f.write(file.path, fs.readFileSync(path.join(f.repo, file.source), 'utf8'));
+    const candidate = f.commit('unsealed activation'), opts = { repo: f.repo, trusted: base, candidate };
+    assert.throws(() => verifyUpgrade(opts));
+    assert.doesNotThrow(() => verifyUpgrade({ ...opts, localFeedback: true }));
+    process.env.CI = 'true';
+    assert.throws(() => verifyUpgrade({ ...opts, localFeedback: true }), /forbidden in CI/);
+    delete process.env.CI;
+    const directory = path.join(f.repo, 'materialized');
+    materializeGate({ ...opts, directory, localFeedback: true });
+    assert.equal(f.git('hash-object', path.join(directory, 'scripts/ci/release-gate-verifier.mjs')),
+        f.json(APPROVAL_PATH).files.find((file) => file.path === 'scripts/ci/release-gate-verifier.mjs').blob);
+});
+
+test('内置令牌别名、混合秘密、字面量、OIDC 与运行时令牌按来源分类', () => {
+    for (const value of ['${{ github.token }}', '${{ secrets.GITHUB_TOKEN }}', "${{ GiThUb['ToKeN'] }}", "${{ secrets['GITHUB_TOKEN'] }}"]) {
+        assert.deepEqual([...credentialSources(value)], ['github']);
+        assert.equal(privilegedCredentials(value, { contents: 'read' }), false);
+    }
+    for (const value of ["${{ github.token || secrets.PAT }}", "${{ secrets['PAT'] }}", '${{ toJSON(secrets) }}', '${{ secrets[inputs.name] }}']) {
+        assert.equal(privilegedCredentials(value, { contents: 'read' }), true);
+    }
+    assert.deepEqual([...credentialSources("${{ format('secrets github.token {0}', github.repository) }} GITHUB_TOKEN")], []);
+    assert.equal(privilegedCredentials('${{ github.token }}', 'read-all', { contents: 'write' }), true);
+    assert.equal(privilegedCredentials('${{ github.token }}', { contents: 'write' }, { contents: 'read' }), false);
+    assert.equal(privilegedCredentials({}, { 'id-token': 'write' }), true);
+    assert.equal(privilegedCredentials('${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}', {}), true);
+    assert.equal(privilegedCredentials('${{ env.ACTIONS_RUNTIME_TOKEN }}', {}), true);
+    assert.deepEqual(effectivePermissions({ contents: 'write' }, {}, { contents: 'read' }), { contents: 'none', 'id-token': 'none' });
+    assert.equal(effectivePermissions('write-all', undefined, { contents: 'read' }).contents, 'read');
+    const doc = { jobs: {
+        mint: { steps: [{ id: 'app', uses: 'actions/create-github-app-token@' + 'a'.repeat(40) }],
+            outputs: { credential: '${{ steps.app.outputs.token }}', ordinary: '${{ steps.app.outputs.app-slug }}' } },
+        consume: { env: { TOKEN: "${{ needs['mint'].outputs.credential }}" } },
+    } };
+    const bindings = workflowCredentialBindings(doc).get('consume');
+    assert.equal(privilegedCredentials(doc.jobs.consume, { contents: 'read' }, undefined, bindings), true);
+    assert.equal(privilegedCredentials('${{ needs.mint.outputs.ordinary }}', {}, undefined, bindings), false);
+    assert.equal(privilegedCredentials('${{ steps.unknown.outputs.token }}', {}), false);
+});
+
+test('真实 workflow 审查允许只读内置令牌，并拒绝 composite 隐藏秘密和未门控写权限', (t) => {
+    const f = fixture(t), base = f.prepare(17), { root, merge } = f.activate(base);
+    f.git('reset', '--hard', merge); f.git('update-ref', 'refs/remotes/origin/master', merge);
+    const action = '.github/actions/gate-credential-fixture/action.yml';
+    const workflow = '.github/workflows/gate-credential-fixture.yml';
+    f.write(action, "name: fixture\nruns:\n  using: composite\n  steps:\n    - shell: bash\n      run: echo ok\n      env:\n        GH_TOKEN: ${{ secrets['GITHUB_TOKEN'] }}\n");
+    f.write(workflow, "name: fixture\non: workflow_dispatch\npermissions:\n  contents: read\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/gate-credential-fixture\n");
+    const allowed = f.commit('read-only composite');
+    assert.equal(verifyProtectedCandidate({ repo: f.repo, trusted: merge, candidate: allowed }).gateEpoch, 17);
+    f.write(action, fs.readFileSync(path.join(f.repo, action), 'utf8').replace("secrets['GITHUB_TOKEN']", 'secrets.PAT'));
+    const denied = f.commit('secret composite');
+    assert.throws(() => verifyProtectedCandidate({ repo: f.repo, trusted: merge, candidate: denied }), /privileged capabilities/);
+    f.git('reset', '--hard', allowed);
+    f.write(workflow, fs.readFileSync(path.join(f.repo, workflow), 'utf8').replace('contents: read', 'contents: write'));
+    assert.throws(() => verifyProtectedCandidate({ repo: f.repo, trusted: merge, candidate: f.commit('write token') }), /privileged capabilities/);
+    assert.ok(root);
+});

--- a/scripts/ci/test/lib/historical-gate.mjs
+++ b/scripts/ci/test/lib/historical-gate.mjs
@@ -1,13 +1,16 @@
 import { execFileSync } from 'node:child_process';
 
-const ROOT = 'refs/tags/release-gate-epoch-5-root';
+function root(epoch) {
+    if (!Number.isSafeInteger(epoch) || epoch < 5) throw new Error('invalid historical epoch');
+    return `refs/tags/release-gate-epoch-${epoch}-root`;
+}
 
-export function historicalGateFile(repo, rel) {
-    return execFileSync('git', ['-C', repo, 'show', `${ROOT}:${rel}`],
+export function historicalGateFile(repo, rel, epoch = 5) {
+    return execFileSync('git', ['-C', repo, 'show', `${root(epoch)}:${rel}`],
         { windowsHide: true, stdio: ['ignore', 'pipe', 'pipe'] });
 }
 
-export function historicalWorkflows(repo) {
-    return execFileSync('git', ['-C', repo, 'ls-tree', '-r', '--name-only', ROOT, '--', '.github/workflows'],
+export function historicalWorkflows(repo, epoch = 5) {
+    return execFileSync('git', ['-C', repo, 'ls-tree', '-r', '--name-only', root(epoch), '--', '.github/workflows'],
         { encoding: 'utf8', windowsHide: true }).trim().split(/\r?\n/u).filter((rel) => /\.ya?ml$/u.test(rel));
 }

--- a/scripts/ci/test/pr-gate.test.mjs
+++ b/scripts/ci/test/pr-gate.test.mjs
@@ -1,23 +1,27 @@
-import { test } from 'node:test';
+import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { historicalGateFile, historicalWorkflows } from './lib/historical-gate.mjs';
 import childProcess, { execFileSync, spawnSync } from 'node:child_process';
 import { syncBuiltinESMExports } from 'node:module';
 import { prepare } from '../prepare-pr-gate.mjs';
 import { github, completePages, publishChecks, publishCurrentChecks, inspectRun, inspectFullRun, checkEvent, assertCurrentEvidence } from '../gate-checks.mjs';
 import YAML from 'yaml';
 const SOURCE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
-const SOURCE_POLICY = JSON.parse(fs.readFileSync(path.join(SOURCE_ROOT, 'scripts/ci/release-gate-policy.json'), 'utf8'));
-const CORE_DIRECTORY = SOURCE_POLICY.gateEpoch === 5 ? 'scripts/ci/gate-admission' : 'scripts/ci';
-const core = await import(new URL(SOURCE_POLICY.gateEpoch === 5
-    ? '../gate-admission/release-gate-verifier.mjs' : '../release-gate-verifier.mjs', import.meta.url));
+const SOURCE_POLICY = JSON.parse(historicalGateFile(SOURCE_ROOT, 'scripts/ci/release-gate-policy.json', 8));
+const CORE_DIRECTORY = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv historical pr gate '));
+for (const rel of SOURCE_POLICY.protectedCore) fs.writeFileSync(path.join(CORE_DIRECTORY, path.basename(rel)),
+    historicalGateFile(SOURCE_ROOT, rel, 8));
+fs.symlinkSync(path.join(SOURCE_ROOT, 'node_modules'), path.join(CORE_DIRECTORY, 'node_modules'),
+    process.platform === 'win32' ? 'junction' : 'dir');
+after(() => fs.rmSync(CORE_DIRECTORY, { recursive: true, force: true }));
+const core = await import(pathToFileURL(path.join(CORE_DIRECTORY, 'release-gate-verifier.mjs')).href);
 const { parseExecutionProof, verifyRunIdentity, verifyRunResults,
     verifyIntegratedTree, verifyAppChecks, verifyCandidate } = core;
-const { resolveTrustedBase } = await import(new URL(SOURCE_POLICY.gateEpoch === 5
-    ? '../gate-admission/resolve-trusted-base.mjs' : '../resolve-trusted-base.mjs', import.meta.url));
+const { resolveTrustedBase } = await import(pathToFileURL(path.join(CORE_DIRECTORY, 'resolve-trusted-base.mjs')).href);
 
 const B = 'b'.repeat(40), H = 'a'.repeat(40), M = 'c'.repeat(40), T = 'd'.repeat(40);
 const roles = ['java-tests', 'javascript-tests', 'signature-guard', 'trusted-gate-contract',
@@ -359,14 +363,16 @@ test('protected predecessor admits only its approved core, permits ordinary root
         git(['init', '-q']);
         git(['config', 'user.name', 'Gate test']);
         git(['config', 'user.email', 'gate@example.test']);
-        fs.cpSync(path.join(source, '.github/workflows'), path.join(repo, '.github/workflows'), { recursive: true });
-        const policy = JSON.parse(fs.readFileSync(path.join(source, 'scripts/ci/release-gate-policy.json'), 'utf8'));
+        fs.mkdirSync(path.join(repo, '.github/workflows'), { recursive: true });
+        for (const rel of historicalWorkflows(source, 8)) fs.writeFileSync(path.join(repo, rel), historicalGateFile(source, rel, 8));
+        const policy = structuredClone(SOURCE_POLICY);
         for (const rel of [...policy.protectedCore, 'scripts/ci/release-gate-policy.json', 'package.json', 'package-lock.json']) {
             fs.mkdirSync(path.dirname(path.join(repo, rel)), { recursive: true });
-            fs.copyFileSync(path.join(source, rel), path.join(repo, rel));
+            fs.writeFileSync(path.join(repo, rel), rel.startsWith('scripts/ci/')
+                ? historicalGateFile(source, rel, 8) : fs.readFileSync(path.join(source, rel)));
         }
         fs.mkdirSync(path.join(repo, 'scripts/ci/gate-admission'), { recursive: true });
-        for (const rel of policy.protectedCore) fs.copyFileSync(path.join(source, CORE_DIRECTORY, path.basename(rel)),
+        for (const rel of policy.protectedCore) fs.copyFileSync(path.join(CORE_DIRECTORY, path.basename(rel)),
             path.join(repo, 'scripts/ci/gate-admission', path.basename(rel)));
         policy.gateEpoch = 5;
         policy.contractVersion = 6;
@@ -396,7 +402,7 @@ test('protected predecessor admits only its approved core, permits ordinary root
         prepare(repo);
         assert.deepEqual(workflowFiles.map(actionComments), comments, '生成器保留既有 Action 版本注释');
         const preparedPolicy = JSON.parse(fs.readFileSync(path.join(repo, 'scripts/ci/release-gate-policy.json'), 'utf8'));
-        assert.equal(execFileSync(process.execPath, [path.join(source, CORE_DIRECTORY, 'release-gate-verifier.mjs'), '--version'],
+        assert.equal(execFileSync(process.execPath, [path.join(CORE_DIRECTORY, 'release-gate-verifier.mjs'), '--version'],
             { encoding: 'utf8' }).trim(), `release-gate-verifier epoch=${preparedPolicy.gateEpoch} contract=${preparedPolicy.contractVersion} schema=${preparedPolicy.schemaVersion}`);
         const root = commit('approved root');
         git(['tag', 'release-gate-epoch-8-root', root]);
@@ -418,7 +424,7 @@ test('protected predecessor admits only its approved core, permits ordinary root
                 assert.match(fs.readFileSync(path.join(runner, 'env'), 'utf8'), new RegExp(`^GATE_EPOCH=${preparedPolicy.gateEpoch}$`, 'm'));
                 for (const rel of policy.protectedCore) assert.equal(
                     fs.readFileSync(path.join(runner, 'trusted-gate', rel), 'utf8'),
-                    fs.readFileSync(path.join(source, CORE_DIRECTORY, path.basename(rel)), 'utf8'));
+                    fs.readFileSync(path.join(CORE_DIRECTORY, path.basename(rel)), 'utf8'));
             } finally {
                 fs.rmSync(runner, { recursive: true, force: true });
             }
@@ -456,7 +462,7 @@ test('protected predecessor admits only its approved core, permits ordinary root
         git(['config', '--local', 'pixiv.release.trustedGateRef', advancedBase]);
         const adoptionEnv = { ...process.env }; delete adoptionEnv.CI;
         const repairedAdoption = spawnSync(process.execPath,
-            [path.join(source, CORE_DIRECTORY, 'release-gate-trust.mjs'), '--adopt-root', '--ref', repairMerge],
+            [path.join(CORE_DIRECTORY, 'release-gate-trust.mjs'), '--adopt-root', '--ref', repairMerge],
             { cwd: repo, env: adoptionEnv, encoding: 'utf8' });
         assert.equal(repairedAdoption.status, 0, repairedAdoption.stderr || repairedAdoption.stdout);
         assert.equal(git(['config', '--get', 'pixiv.release.trustedGateRef']), repairMerge);
@@ -595,7 +601,7 @@ test('protected predecessor admits only its approved core, permits ordinary root
         const env = { ...process.env };
         delete env.CI;
         const adopted = spawnSync(process.execPath,
-            [path.join(source, CORE_DIRECTORY, 'release-gate-trust.mjs'), '--adopt-root', '--ref', merge],
+            [path.join(CORE_DIRECTORY, 'release-gate-trust.mjs'), '--adopt-root', '--ref', merge],
             { cwd: repo, env, encoding: 'utf8' });
         assert.equal(adopted.status, 0, adopted.stderr || adopted.stdout);
         assert.equal(git(['config', '--get', 'pixiv.release.trustedGateEpoch']), '8');
@@ -636,13 +642,13 @@ test('protected predecessor admits only its approved core, permits ordinary root
         assert.throws(() => verifyCandidate({ repo, trusted: base, candidate: unapproved }), /unapproved admission core/u);
         git(['update-ref', 'refs/remotes/origin/master', unapproved]);
         const rejected = spawnSync(process.execPath,
-            [path.join(source, CORE_DIRECTORY, 'release-gate-trust.mjs'), '--advance', '--ref', unapproved],
+            [path.join(CORE_DIRECTORY, 'release-gate-trust.mjs'), '--advance', '--ref', unapproved],
             { cwd: repo, env, encoding: 'utf8' });
         assert.notEqual(rejected.status, 0);
         assert.equal(git(['config', '--get', 'pixiv.release.trustedGateEpoch']), '8');
         assert.equal(git(['config', '--get', 'pixiv.release.trustedGateRef']), merge);
         fs.writeFileSync(path.join(repo, 'scripts/ci/release-gate-verifier.mjs'),
-            fs.readFileSync(path.join(source, CORE_DIRECTORY, 'release-gate-verifier.mjs')));
+            fs.readFileSync(path.join(CORE_DIRECTORY, 'release-gate-verifier.mjs')));
         git(['update-ref', 'refs/remotes/origin/master', merge]);
         const branch = git(['symbolic-ref', 'HEAD']);
         git(['update-ref', branch, merge]);

--- a/scripts/ci/test/quality-gate-workflow.test.mjs
+++ b/scripts/ci/test/quality-gate-workflow.test.mjs
@@ -78,7 +78,7 @@ test('Action 引用按 YAML step 校验完整 SHA 与版本注释，reusable 调
 test('PR concurrency cancels only earlier validation of the same PR and workflow', () => {
     const evaluate = (text, github) => text.replace(/\$\{\{(.*?)\}\}/g,
         (_, expression) => String(vm.runInNewContext(expression, { github })));
-    if (POLICY.gateEpoch === 8) {
+    if (POLICY.gateEpoch >= 8) {
         const caller = load('.github/workflows/pr-quality-gate.yml');
         assert.deepEqual(triggers(caller), ['pull_request']);
         assert.equal(caller.concurrency['cancel-in-progress'], true);
@@ -344,7 +344,7 @@ test('发布链：所有凭据与写权限只在 release Environment 的门禁�
     assert.deepEqual(publish.permissions, { contents: 'read' });
     assert.deepEqual(release.permissions, { contents: 'read' });
     assert.deepEqual(nightly.permissions, { contents: 'read' });
-    const sharedProvider = load(POLICY.gateEpoch === 8
+    const sharedProvider = load(POLICY.gateEpoch >= 8
         ? '.github/workflows/quality-gate.yml' : '.github/workflows/shared-snippets-check.yml');
     assert.deepEqual(sharedProvider.permissions, { contents: 'read' });
     assert.equal(release.jobs['publish-plugins'].uses, './.github/workflows/publish-plugins.yml');

--- a/scripts/ci/trust-gate.mjs
+++ b/scripts/ci/trust-gate.mjs
@@ -12,7 +12,7 @@ if (process.argv.length === 3 && process.argv[2] === '--version') {
 } else if (process.argv.includes('--version')) {
     console.error('Usage: trust-gate.mjs --version');
     process.exitCode = 2;
-} else if (['5', '8'].includes(configuredEpoch())) {
+} else if (/^[1-9][0-9]*$/u.test(configuredEpoch())) {
     const repo = git(['rev-parse', '--show-toplevel']);
     const args = process.argv.slice(2);
     const epoch = configuredEpoch();
@@ -26,8 +26,7 @@ if (process.argv.length === 3 && process.argv[2] === '--version') {
             throw new Error('usage: trust-gate.mjs --show | --advance --ref <commit> | --adopt-root --ref <commit>');
         }
         const candidate = git(['rev-parse', '--verify', `${args[2]}^{commit}`]);
-        const policy = JSON.parse(git(['show', `${candidate}:scripts/ci/release-gate-policy.json`]));
-        withTrustedGate(repo, base, policy.gateEpoch, (directory, env) => {
+        withTrustedGate(repo, base, candidate, (directory, env) => {
             const result = spawnSync(process.execPath,
                 [path.join(directory, 'scripts/ci/release-gate-trust.mjs'), args[0], '--ref', candidate],
                 { cwd: repo, env, stdio: 'inherit', windowsHide: true });
@@ -35,7 +34,7 @@ if (process.argv.length === 3 && process.argv[2] === '--version') {
         });
     }
 } else {
-    throw new Error('configured release Gate epoch 5 or 8 is required');
+    throw new Error('configured release Gate epoch is required');
 }
 
 function git(args) {

--- a/scripts/ci/trusted-gate-runner.mjs
+++ b/scripts/ci/trusted-gate-runner.mjs
@@ -2,24 +2,26 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { execFileSync, spawnSync } from 'node:child_process';
+import { materializeGate, readPolicy } from './gate-upgrade.mjs';
 
-export function withTrustedGate(repo, base, candidateEpoch, action) {
+export function withTrustedGate(repo, base, candidate, action, { localFeedback = false } = {}) {
     const read = (rel) => execFileSync('git', ['-C', repo, 'show', `${base}:${rel}`],
         { windowsHide: true, stdio: ['ignore', 'pipe', 'pipe'] });
     const policy = JSON.parse(read('scripts/ci/release-gate-policy.json').toString('utf8'));
-    if (![5, 8].includes(policy.gateEpoch) || ![5, 8].includes(candidateEpoch)) {
-        throw new Error('unsupported trusted gate epoch');
-    }
+    const candidateEpoch = readPolicy(repo, candidate).gateEpoch;
     const admission = policy.gateEpoch === 5 && candidateEpoch === 8;
-    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv-protected-gate-'));
+    const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv-protected-gate-'));
+    const directory = path.join(temporary, 'core');
     try {
-        for (const name of ['release-gate-trust.mjs', 'release-gate-verifier.mjs', 'resolve-trusted-base.mjs']) {
-            const rel = `scripts/ci/${name}`;
-            const target = path.join(directory, rel);
-            fs.mkdirSync(path.dirname(target), { recursive: true });
-            fs.writeFileSync(target, read(admission ? `scripts/ci/gate-admission/${name}` : rel));
+        if (!admission) materializeGate({ repo, trusted: base, candidate, directory, localFeedback });
+        else {
+            for (const name of ['release-gate-trust.mjs', 'release-gate-verifier.mjs', 'resolve-trusted-base.mjs']) {
+                const target = path.join(directory, 'scripts/ci', name);
+                fs.mkdirSync(path.dirname(target), { recursive: true });
+                fs.writeFileSync(target, read(`scripts/ci/gate-admission/${name}`));
+            }
+            for (const rel of ['package.json', 'package-lock.json']) fs.writeFileSync(path.join(directory, rel), read(rel));
         }
-        for (const rel of ['package.json', 'package-lock.json']) fs.writeFileSync(path.join(directory, rel), read(rel));
         const install = spawnSync(process.platform === 'win32'
             ? 'npm.cmd ci --offline --ignore-scripts --no-audit --no-fund' : 'npm',
             process.platform === 'win32' ? [] : ['ci', '--offline', '--ignore-scripts', '--no-audit', '--no-fund'], {
@@ -30,6 +32,17 @@ export function withTrustedGate(repo, base, candidateEpoch, action) {
         return action(directory, { ...process.env,
             TRUSTED_GATE_PACKAGE_JSON: path.join(directory, 'package.json') });
     } finally {
-        fs.rmSync(directory, { recursive: true, force: true });
+        fs.rmSync(temporary, { recursive: true, force: true });
     }
+}
+
+export function verifyProtectedCandidate({ repo, trusted, candidate, ...options }) {
+    return withTrustedGate(repo, trusted, candidate, (directory, env) => {
+        const result = spawnSync(process.execPath, [path.join(directory, 'scripts/ci/release-gate-verifier.mjs'),
+            '--repo-root', repo, '--trusted-ref', trusted, '--candidate-ref', candidate], {
+            cwd: repo, env, windowsHide: true, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        if (result.status !== 0) throw new Error(result.stderr || 'protected verifier rejected the candidate');
+        return readPolicy(repo, candidate);
+    }, options);
 }


### PR DESCRIPTION
## 变更内容

Gate 核心升级原先依赖逐个 Epoch 编写准入分支。增加受保护前驱批准的文件记录与通用加载协议，按 Git mode/blob 校验核心、策略和解析依赖，并接入 CI、本地合同检查与检查签发器。

待启用核心按来源与有效权限分类 Actions 凭据，允许普通构建使用内置只读令牌，继续保护独立秘密、App、OIDC 与显式运行时凭据。当前活动核心和策略保持 Epoch 8；启用必须经另一份 PR 使用前驱已批准的精确字节与受保护 root。

## 验证

- [x] 准备分支完整脚本测试 319 项通过，无失败或跳过
- [x] 当前 Epoch 8 合同与签名检查通过
- [x] i18n 检查通过，保留 1518 项既有 warnings
- [x] 独立 Git 夹具验证连续升级、拒绝路径、真实物化命令与原子锚点采用
- [x] 独立 Git 副本的启用后组合验收通过，完整脚本测试 327 项通过
- [x] 当前 PR 的 GitHub Quality Gate 与六项 App required checks 通过（run 34687016065，attempt 1）
- [x] 属于内部 CI 变更，无产品 CHANGELOG 条目
