### PR TITLE
feat(ci): 启用按来源和权限分类的 Gate 核心

### DIFF
--- a/scripts/ci/release-gate-policy.json
+++ b/scripts/ci/release-gate-policy.json
@@ -1,13 +1,15 @@
 {
   "schemaVersion": 1,
-  "gateEpoch": 8,
-  "contractVersion": 9,
-  "rootTag": "refs/tags/release-gate-epoch-8-root",
+  "gateEpoch": 9,
+  "contractVersion": 10,
+  "rootTag": "refs/tags/release-gate-epoch-9-root",
   "protectedBranch": "refs/heads/master",
   "protectedCore": [
     "scripts/ci/release-gate-trust.mjs",
     "scripts/ci/release-gate-verifier.mjs",
-    "scripts/ci/resolve-trusted-base.mjs"
+    "scripts/ci/resolve-trusted-base.mjs",
+    "scripts/ci/gate-upgrade.mjs",
+    "scripts/ci/gate-credentials.mjs"
   ],
   "qualityGate": {
     "workflow": ".github/workflows/quality-gate.yml",
@@ -164,6 +166,11 @@
         "allowDeletion": false,
         "allowNonFastForward": false,
         "allowBypass": false
+      },
+      "refs/tags/release-gate-epoch-9-root": {
+        "allowDeletion": false,
+        "allowNonFastForward": false,
+        "allowBypass": false
       }
     },
     "requiredCheckSources": {
@@ -174,5 +181,6 @@
       "i18n-check": 4837005,
       "check-shared-snippets": 4837005
     }
-  }
+  },
+  "upgradeProtocol": 1
 }

--- a/scripts/ci/release-gate-trust.mjs
+++ b/scripts/ci/release-gate-trust.mjs
@@ -1,172 +1,49 @@
 #!/usr/bin/env node
-'use strict';
-
-import { execFileSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
-import process from 'node:process';
+import { readGit, readPolicy } from './gate-upgrade.mjs';
+import { verifyCandidate } from './release-gate-verifier.mjs';
 
-const EPOCH = 8;
-const ROOT_TAG = 'refs/tags/release-gate-epoch-8-root';
-const POLICY = 'scripts/ci/release-gate-policy.json';
 const REF_KEY = 'pixiv.release.trustedGateRef';
 const EPOCH_KEY = 'pixiv.release.trustedGateEpoch';
-const SHA = /^[0-9a-f]{40}$/;
-
-function fail(message) {
-    throw new Error(message);
-}
-
-function git(root, args, options = {}) {
-    const result = execFileSync('git', args, {
-        cwd: root, encoding: options.encoding === null ? null : 'utf8',
-        stdio: ['ignore', 'pipe', 'pipe'], maxBuffer: 128 * 1024 * 1024,
-    });
-    return Buffer.isBuffer(result) ? result : result.trim();
-}
-
-function config(root, key) {
-    try { return git(root, ['config', '--local', '--get', key]) || null; } catch { return null; }
-}
-
-function commit(root, ref) {
-    try {
-        const value = git(root, ['rev-parse', '--verify', `${ref}^{commit}`]);
-        return SHA.test(value) ? value : null;
-    } catch { return null; }
-}
-
-function ancestor(root, older, newer) {
-    try { git(root, ['merge-base', '--is-ancestor', older, newer]); return true; } catch { return false; }
-}
-
-function clean(root) {
-    if (git(root, ['status', '--porcelain'])) fail('trust commands require a clean worktree');
-}
-
-function materialize(root, ref, files, admission = false) {
-    const out = fs.mkdtempSync(path.join(os.tmpdir(), 'pixiv-release-gate-core-'));
-    try {
-        for (const rel of [...files, 'package.json', 'package-lock.json']) {
-            const target = path.join(out, ...rel.split('/'));
-            fs.mkdirSync(path.dirname(target), { recursive: true });
-            const source = admission && files.includes(rel)
-                ? `scripts/ci/gate-admission/${path.posix.basename(rel)}` : rel;
-            fs.writeFileSync(target, git(root, ['show', `${ref}:${source}`], { encoding: null }));
-        }
-        const install = spawnSync(process.platform === 'win32'
-            ? 'npm.cmd ci --offline --ignore-scripts --no-audit --no-fund' : 'npm',
-            process.platform === 'win32' ? [] : ['ci', '--offline', '--ignore-scripts', '--no-audit', '--no-fund'], {
-                cwd: out, shell: process.platform === 'win32', windowsHide: true,
-                stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8',
-            });
-        if (install.status !== 0) fail('protected parser is not available in the local npm cache; install the protected base dependencies first');
-        return out;
-    } catch (error) {
-        fs.rmSync(out, { recursive: true, force: true });
-        throw error;
+function fail(message) { throw new Error(message); }
+function main() {
+    const repo = readGit(process.cwd(), ['rev-parse', '--show-toplevel']).trim();
+    const config = (key) => readGit(repo, ['config', '--local', '--get', key]).trim();
+    const commit = (ref) => readGit(repo, ['rev-parse', '--verify', '--end-of-options', ref + '^{commit}']).trim();
+    const args = process.argv.slice(2);
+    if (args.length !== 3 || !['--advance', '--adopt-root'].includes(args[0]) || args[1] !== '--ref') {
+        fail('usage: release-gate-trust.mjs --advance|--adopt-root --ref <commit>');
     }
-}
-
-function run(root, script, args) {
-    const result = spawnSync(process.execPath, [script, '--repo-root', root, ...args], {
-        cwd: root, encoding: 'utf8', stdio: ['ignore', 'inherit', 'inherit'],
-        maxBuffer: 128 * 1024 * 1024, windowsHide: true,
-    });
-    if (result.status !== 0) fail('protected verifier rejected the candidate');
-}
-
-function setAnchor(root, sha) {
-    const common = git(root, ['rev-parse', '--path-format=absolute', '--git-common-dir']);
-    const configFile = path.join(common, 'config');
-    const lock = `${configFile}.lock`;
+    if (process.env.CI === 'true') fail('anchor changes are forbidden in CI');
+    if (readGit(repo, ['status', '--porcelain']).trim()) fail('trust commands require a clean worktree');
+    const trusted = commit(config(REF_KEY)), candidate = commit(args[2]);
+    const before = readPolicy(repo, trusted), after = readPolicy(repo, candidate);
+    if (config(EPOCH_KEY) !== String(before.gateEpoch)
+        || readGit(repo, ['symbolic-ref', '--quiet', 'HEAD']).trim() !== 'refs/heads/master'
+        || candidate !== commit('HEAD') || candidate !== commit('refs/remotes/origin/master')) {
+        fail('anchor changes require the configured predecessor and protected master tip');
+    }
+    if ((args[0] === '--adopt-root') !== (before.gateEpoch !== after.gateEpoch)) {
+        fail('use --adopt-root for an approved epoch transition, otherwise --advance');
+    }
+    verifyCandidate({ repo, trusted, candidate });
+    const common = readGit(repo, ['rev-parse', '--path-format=absolute', '--git-common-dir']).trim();
+    const file = path.join(common, 'config'), lock = file + '.lock';
     const fd = fs.openSync(lock, 'wx');
     try {
-        try { fs.writeFileSync(fd, fs.readFileSync(configFile)); } finally { fs.closeSync(fd); }
-        git(root, ['config', '--file', lock, EPOCH_KEY, String(EPOCH)]);
-        git(root, ['config', '--file', lock, REF_KEY, sha]);
-        if (git(root, ['config', '--file', lock, '--get', EPOCH_KEY]) !== String(EPOCH)
-            || git(root, ['config', '--file', lock, '--get', REF_KEY]) !== sha) fail('invalid proposed anchor');
-        fs.renameSync(lock, configFile);
+        try { fs.writeFileSync(fd, fs.readFileSync(file)); } finally { fs.closeSync(fd); }
+        // 锁内再次核对原锚点，验证期间的并发推进不能被覆盖。
+        for (const [key, expected] of [[REF_KEY, trusted], [EPOCH_KEY, String(before.gateEpoch)]]) {
+            if (readGit(repo, ['config', '--file', lock, '--get', key]).trim() !== expected) fail('anchor changed during verification');
+        }
+        readGit(repo, ['config', '--file', lock, EPOCH_KEY, String(after.gateEpoch)]);
+        readGit(repo, ['config', '--file', lock, REF_KEY, candidate]);
+        fs.renameSync(lock, file);
     } finally {
         if (fs.existsSync(lock)) fs.unlinkSync(lock);
     }
-    if (config(root, EPOCH_KEY) !== String(EPOCH) || config(root, REF_KEY) !== sha) {
-        fail('trusted anchor verification failed');
-    }
+    if (config(REF_KEY) !== candidate || config(EPOCH_KEY) !== String(after.gateEpoch)) fail('anchor update did not persist');
+    console.log('release-gate-trust: trusted anchor advanced to ' + candidate + ' (epoch ' + after.gateEpoch + ')');
 }
-
-function adopt(root, ref) {
-    if (process.env.CI === 'true') fail('root adoption is forbidden in CI');
-    clean(root);
-    const candidate = commit(root, ref);
-    const source = commit(root, config(root, REF_KEY));
-    const master = commit(root, 'refs/remotes/origin/master');
-    const rootTag = commit(root, ROOT_TAG);
-    if (config(root, EPOCH_KEY) !== '5' || !candidate || !source || !rootTag
-        || git(root, ['symbolic-ref', '--quiet', 'HEAD']) !== 'refs/heads/master'
-        || candidate !== master || candidate !== commit(root, 'HEAD')) {
-        fail('adoption requires the Epoch 5 anchor, protected master tip, HEAD and Epoch 8 root');
-    }
-    const parents = git(root, ['rev-list', '--parents', '-n', '1', candidate]).split(/\s+/u).slice(1);
-    if (parents.length !== 2 || parents[0] !== source || !ancestor(root, rootTag, parents[1])) {
-        fail('Epoch 8 adoption requires a merge of the sealed core from the Epoch 5 anchor');
-    }
-    const files = JSON.parse(git(root, ['show', `${source}:${POLICY}`])).protectedCore;
-    const oldCore = materialize(root, source, files, true);
-    try {
-        run(root, path.join(oldCore, 'scripts', 'ci', 'release-gate-verifier.mjs'),
-            ['--trusted-ref', source, '--candidate-ref', candidate]);
-    } finally {
-        fs.rmSync(oldCore, { recursive: true, force: true });
-    }
-    setAnchor(root, candidate);
-    console.log(`release-gate-trust: Epoch 8 root adopted at ${candidate}`);
-}
-
-function advance(root, ref) {
-    if (process.env.CI === 'true') fail('trusted anchor advancement is forbidden in CI');
-    clean(root);
-    const current = commit(root, config(root, REF_KEY));
-    const candidate = commit(root, ref);
-    const master = commit(root, 'refs/remotes/origin/master');
-    const rootSha = commit(root, ROOT_TAG);
-    if (config(root, EPOCH_KEY) !== String(EPOCH) || !current || !candidate || !rootSha
-        || candidate !== master || candidate !== commit(root, 'HEAD')
-        || git(root, ['symbolic-ref', '--quiet', 'HEAD']) !== 'refs/heads/master'
-        || candidate === current || !ancestor(root, rootSha, current)
-        || !ancestor(root, current, candidate)) {
-        fail('advance requires root <= current anchor < protected master tip');
-    }
-    const verifier = materialize(root, current, ['scripts/ci/release-gate-verifier.mjs']);
-    try {
-        run(root, path.join(verifier, 'scripts', 'ci', 'release-gate-verifier.mjs'),
-            ['--trusted-ref', current, '--candidate-ref', candidate]);
-    } finally {
-        fs.rmSync(verifier, { recursive: true, force: true });
-    }
-    setAnchor(root, candidate);
-    console.log(`release-gate-trust: trusted anchor advanced to ${candidate}`);
-}
-
-function show(root) {
-    console.log(`trustedGateEpoch=${config(root, EPOCH_KEY) || '<unset>'}`);
-    console.log(`trustedGateRef=${config(root, REF_KEY) || '<unset>'}`);
-    console.log(`root=${commit(root, ROOT_TAG) || '<missing>'}`);
-}
-
-function main() {
-    const args = process.argv.slice(2);
-    const root = git(process.cwd(), ['rev-parse', '--show-toplevel']);
-    if (args[0] === '--show') show(root);
-    else if (args[0] === '--adopt-root' && args[1] === '--ref' && args[2]) adopt(root, args[2]);
-    else if (args[0] === '--advance' && args[1] === '--ref' && args[2]) advance(root, args[2]);
-    else if (args[0] === '--version') console.log('release-gate-trust 8');
-    else fail('usage: release-gate-trust.mjs --show | --adopt-root --ref <commit> | --advance --ref <commit>');
-}
-
-try { main(); } catch (error) {
-    console.error(`release-gate-trust: ${error.message}`);
-    process.exitCode = 1;
-}
+try { main(); } catch (error) { console.error('release-gate-trust: ' + error.message); process.exitCode = 1; }

--- a/scripts/ci/release-gate-verifier.mjs
+++ b/scripts/ci/release-gate-verifier.mjs
@@ -7,9 +7,10 @@ import process from 'node:process';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
+import { verifyUpgrade } from './gate-upgrade.mjs';
+import { credentialSources, privilegedCredentials, workflowCredentialBindings } from './gate-credentials.mjs';
+
 const POLICY = 'scripts/ci/release-gate-policy.json';
-const ROOT_TAG = 'refs/tags/release-gate-epoch-8-root';
-const ADMISSION = 'scripts/ci/gate-admission/';
 const REPOSITORY = 'Sywyar/PixivDownloader';
 const REPOSITORY_ID = 1089943605;
 const APP_ID = 4837005;
@@ -21,13 +22,15 @@ const CORE = [
     'scripts/ci/release-gate-trust.mjs',
     'scripts/ci/release-gate-verifier.mjs',
     'scripts/ci/resolve-trusted-base.mjs',
+    'scripts/ci/gate-upgrade.mjs',
+    'scripts/ci/gate-credentials.mjs',
 ];
 const FLOOR = {
     checks: ['java-tests', 'javascript-tests', 'signature-guard', 'trusted-gate-contract',
         'i18n-check', 'check-shared-snippets'],
     roots: ['refs/tags/i18n-gate-epoch-2-root', 'refs/tags/i18n-gate-epoch-3-root',
         'refs/tags/i18n-gate-epoch-4-root', 'refs/tags/release-gate-epoch-5-root',
-        'refs/tags/release-gate-epoch-6-root', 'refs/tags/release-gate-epoch-7-root', ROOT_TAG],
+        'refs/tags/release-gate-epoch-6-root', 'refs/tags/release-gate-epoch-7-root', 'refs/tags/release-gate-epoch-8-root'],
     workflows: {
         '.github/workflows/release.yml': ['validate-release-tag', 'draft-quality-gate',
             'publish-plugins', 'publish-plugin-artifacts', 'build-jar',
@@ -91,10 +94,11 @@ function exactIdentity(trusted, candidate, label) {
 }
 
 function validateRootPolicy(policy) {
-    if (policy.schemaVersion !== 1 || policy.gateEpoch !== 8 || policy.contractVersion !== 9) {
-        fail('Epoch 8 policy identity is invalid');
+    if (policy.schemaVersion !== 1 || !Number.isSafeInteger(policy.gateEpoch) || policy.gateEpoch <= 8
+        || !Number.isSafeInteger(policy.contractVersion) || policy.contractVersion < 10 || policy.upgradeProtocol !== 1) {
+        fail('upgradable Gate policy identity is invalid');
     }
-    if (policy.rootTag !== ROOT_TAG || policy.protectedBranch !== BRANCH) {
+    if (policy.rootTag !== `refs/tags/release-gate-epoch-${policy.gateEpoch}-root` || policy.protectedBranch !== BRANCH) {
         fail('protected root or branch identity changed');
     }
     if (!same(policy.protectedCore, CORE)) fail('immutable core declaration differs from verifier');
@@ -123,7 +127,7 @@ function validateRootPolicy(policy) {
             fail(`required check ${context} must be bound to the Gate App`);
         }
     }
-    for (const root of FLOOR.roots) {
+    for (const root of [...FLOOR.roots, policy.rootTag]) {
         if (!rules.roots?.[root]) fail(`Ruleset policy removed historical root ${root}`);
     }
     if (rules.requireStrict !== true || rules.requirePullRequest !== true
@@ -145,7 +149,7 @@ function validateMonotonic(trusted, candidate) {
     validateRootPolicy(trusted);
     validateRootPolicy(candidate);
     for (const key of ['schemaVersion', 'gateEpoch', 'contractVersion', 'rootTag',
-        'protectedBranch', 'protectedCore', 'releaseEnvironment']) {
+        'protectedBranch', 'protectedCore', 'releaseEnvironment', 'upgradeProtocol']) {
         exactIdentity(trusted[key], candidate[key], `policy.${key}`);
     }
     for (const key of ['workflow', 'workflowName']) {
@@ -225,9 +229,7 @@ function dependsOn(jobs, id, roots, seen = new Set()) {
 }
 
 function containsSecret(job) {
-    const expressions = JSON.stringify(job)?.match(/\$\{\{.*?\}\}/gu) || [];
-    return expressions.some((expression) => /\bsecrets\b/iu.test(expression)
-        || /\bgithub\s*(?:\.\s*token|\[\s*\\?['"]token\\?['"]\s*\])/iu.test(expression));
+    return credentialSources(job).has('secret');
 }
 
 function localWorkflow(uses) {
@@ -298,7 +300,7 @@ function validateCheckPublisher(doc) {
             delete inputs['private-key'];
         }
     }
-    if (/\bsecrets\b/iu.test((JSON.stringify(publicDocument).match(/\$\{\{.*?\}\}/gu) || []).join('\n'))) {
+    if (containsSecret(publicDocument)) {
         fail('check publisher cannot consume other release credentials');
     }
 }
@@ -320,6 +322,7 @@ function workflowSecurityProblems(rel, doc, policy, providerPaths) {
         }
     }
     const jobs = doc.jobs;
+    const credentialBindings = workflowCredentialBindings(doc);
     const roots = new Set(Object.entries(jobs)
         .filter(([, job]) => providerPaths.has(localWorkflow(job.uses)))
         .map(([id]) => id));
@@ -327,8 +330,8 @@ function workflowSecurityProblems(rel, doc, policy, providerPaths) {
         if (job.secrets === 'inherit') problems.push(`${rel} job ${id} uses secrets: inherit`);
         const condition = String(job.if || '');
         const provider = roots.has(id);
-        const sensitive = permissionsWrite(job.permissions === undefined ? doc.permissions : job.permissions)
-            || containsSecret(doc.env) || containsSecret(job) || environmentName(job) !== undefined;
+        const sensitive = privilegedCredentials([doc.env, job], doc.permissions, job.permissions, credentialBindings.get(id))
+            || environmentName(job) !== undefined;
         const required = provider || (rel === policy.qualityGate.workflow
             && policy.qualityGate.requiredJobs.some((role) => dependsOn(jobs, role, new Set([id]))));
         if ((required || sensitive) && (/\b(?:always|failure|cancelled)\s*\(/iu.test(condition)
@@ -336,7 +339,7 @@ function workflowSecurityProblems(rel, doc, policy, providerPaths) {
                 && step['continue-on-error'] !== false))) {
             problems.push(`${rel} job ${id} can bypass a failed dependency or suppress a failure`);
         }
-        if (provider && (containsSecret(job) || containsSecret(doc.env))) {
+        if (provider && privilegedCredentials([doc.env, job], doc.permissions, job.permissions, credentialBindings.get(id))) {
             problems.push(`${rel} job ${id} cannot forward credentials into the quality provider`);
         }
         if (!sensitive || provider) continue;
@@ -360,7 +363,33 @@ function validateWorkflows(repo, ref, policy) {
     }
     const names = git(repo, ['ls-tree', '-r', '--name-only', ref, '--', '.github/workflows'])
         .split(/\r?\n/u).filter((name) => /\.ya?ml$/u.test(name));
-    const docs = new Map(names.map((rel) => [rel, parseWorkflow(YAML, repo, ref, rel)]));
+    const expand = (steps, seen = new Set()) => {
+        for (const step of steps || []) {
+            if (!step.uses?.startsWith('./')) continue;
+            const action = step.uses.slice(2);
+            if (!action || path.posix.isAbsolute(action) || path.posix.normalize(action) !== action
+                || action.startsWith('../') || action.includes('\\') || seen.has(action)) {
+                fail('invalid or recursive local action: ' + action);
+            }
+            const files = git(repo, ['ls-tree', '--name-only', ref, '--', action + '/action.yml', action + '/action.yaml'])
+                .trim().split(/\r?\n/u).filter(Boolean);
+            if (files.length !== 1) fail('missing or ambiguous local action: ' + action);
+            if (!/^100(?:644|755) blob /u.test(git(repo, ['ls-tree', ref, '--', files[0]]))) {
+                fail('local action descriptor must be a regular file: ' + action);
+            }
+            const definition = YAML.parse(show(repo, ref, files[0]));
+            if (definition?.runs?.using !== 'composite') continue;
+            const steps = definition.runs.steps;
+            validateActionPins(files[0], { jobs: { action: { steps } } });
+            expand(steps, new Set([...seen, action]));
+            step.gateLocalAction = definition;
+        }
+    };
+    const docs = new Map(names.map((rel) => {
+        const doc = parseWorkflow(YAML, repo, ref, rel);
+        for (const job of Object.values(doc.jobs)) expand(job.steps);
+        return [rel, doc];
+    }));
     const required = new Map([[policy.qualityGate.workflow, policy.qualityGate],
         ...Object.entries(policy.workflows)]);
     for (const [rel, spec] of required) {
@@ -413,58 +442,8 @@ function validateCore(repo, trusted, candidate) {
     }
 }
 
-function validateAdmission(repo, trusted, candidate, localFeedback) {
-    const oldPolicy = json(repo, trusted, POLICY);
-    if (oldPolicy.gateEpoch !== 5) fail('first admission requires an Epoch 5 protected predecessor');
-    const next = json(repo, candidate, POLICY);
-    requireSubset(oldPolicy.qualityGate.requiredJobs, next.qualityGate.requiredJobs, 'admission Quality Gate roles');
-    requireSubset(oldPolicy.ruleset.requiredChecks, next.ruleset.requiredChecks, 'admission required checks');
-    if (next.ruleset.minimumApprovals < oldPolicy.ruleset.minimumApprovals) fail('admission lowered approvals');
-    for (const [rel, spec] of Object.entries(oldPolicy.workflows)) {
-        if (rel === '.github/workflows/shared-snippets-check.yml') continue;
-        const current = next.workflows[rel];
-        if (!current || current.workflowName !== spec.workflowName) fail(`admission removed workflow ${rel}`);
-        requireSubset(spec.requiredJobs, current.requiredJobs, `${rel} admission jobs`);
-        requireSubset(spec.requiredTriggers, current.requiredTriggers, `${rel} admission triggers`);
-    }
-    for (const [root, rules] of Object.entries(oldPolicy.ruleset.roots)) {
-        if (!same(rules, next.ruleset.roots[root])) fail(`admission changed historical root ${root}`);
-    }
-    for (const rel of CORE) {
-        const approved = `${ADMISSION}${path.posix.basename(rel)}`;
-        const entry = (ref, file) => git(repo, ['ls-tree', ref, '--', file]).trim().split(/\s+/u).slice(0, 3);
-        const before = entry(trusted, approved);
-        if (!['100644', '100755'].includes(before[0]) || before[1] !== 'blob'
-            || !same(before, entry(candidate, rel))) fail(`unapproved admission core: ${rel}`);
-    }
-    const ancestor = (older, newer) => spawnSync('git', ['-C', repo, 'merge-base',
-        '--is-ancestor', older, newer], { windowsHide: true, stdio: 'ignore' }).status === 0;
-    if (trusted === candidate || !ancestor(trusted, 'refs/remotes/origin/master')
-        || !ancestor('refs/tags/release-gate-epoch-5-root', trusted) || !ancestor(trusted, candidate)) {
-        fail('admission base must be a protected Epoch 5 predecessor');
-    }
-    if (localFeedback) {
-        if (process.env.CI === 'true') fail('local admission feedback is forbidden in CI');
-        return;
-    }
-    const root = resolveCommit(repo, ROOT_TAG, 'Epoch 8 root');
-    const parents = (sha) => git(repo, ['rev-list', '--parents', '-n', '1', sha]).trim().split(/\s+/u).slice(1);
-    const rootParents = parents(root);
-    if (rootParents.length !== 1 || !ancestor(rootParents[0], trusted)
-        || json(repo, rootParents[0], POLICY).gateEpoch !== 5) {
-        fail('Epoch 8 root must directly descend from a protected Epoch 5 admission base');
-    }
-    validateCore(repo, root, candidate);
-    validateMonotonic(json(repo, root, POLICY), next);
-    const candidateParents = parents(candidate);
-    if (candidate !== root && (candidateParents.length !== 2 || candidateParents[0] !== trusted
-        || !ancestor(root, candidateParents[1]))) {
-        fail('first admission requires the root or a two-parent merge of its unchanged core descendants');
-    }
-}
-
 function validateAncestry(repo, trusted, candidate) {
-    const root = resolveCommit(repo, ROOT_TAG, 'Epoch 8 root');
+    const root = resolveCommit(repo, json(repo, trusted, POLICY).rootTag, 'Gate root');
     if (trusted === candidate) fail('trusted base must be a strict predecessor of the candidate');
     for (const [ancestor, descendant, label] of [
         [root, trusted, 'root to trusted base'],
@@ -511,8 +490,8 @@ export function verifyCandidate({ repo, trusted, candidate, invariants = false,
     const candidatePolicy = json(repo, candidate, POLICY);
     validateRootPolicy(candidatePolicy);
     if (!invariants) {
-        if (json(repo, trusted, POLICY).gateEpoch === 5) {
-            validateAdmission(repo, trusted, candidate, localFeedback);
+        if (json(repo, trusted, POLICY).gateEpoch !== candidatePolicy.gateEpoch) {
+            verifyUpgrade({ repo, trusted, candidate, localFeedback });
         } else {
             validateMonotonic(json(repo, trusted, POLICY), candidatePolicy);
             validateCore(repo, trusted, candidate);
@@ -613,14 +592,14 @@ export function verifyAppChecks({ checks, evidence, requiredChecks = FLOOR.check
 function main() {
     const args = parseArgs(process.argv.slice(2));
     if (args.version) {
-        console.log('release-gate-verifier epoch=8 contract=9 schema=1');
+        console.log('release-gate-verifier upgrade-protocol=1 schema=1');
         return;
     }
     const repo = path.resolve(args.repo);
     const candidate = resolveCommit(repo, args.candidate || 'HEAD', 'candidate');
     const trusted = args.invariants ? null : resolveCommit(repo, args.trusted, 'trusted base');
     verifyCandidate({ ...args, repo, trusted, candidate });
-    console.log(`TRUSTED RELEASE GATE 8 OK (${candidate})`);
+    console.log(`TRUSTED RELEASE GATE ${json(repo, candidate, POLICY).gateEpoch} OK (${candidate})`);
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/ci/resolve-trusted-base.mjs
+++ b/scripts/ci/resolve-trusted-base.mjs
@@ -46,7 +46,10 @@ export function resolveTrustedBase({ repo = '.', candidate, event, before, ref,
     git(repo, ['merge-base', '--is-ancestor', base, tested]);
     git(repo, ['merge-base', '--is-ancestor', base, master]);
     const policy = JSON.parse(git(repo, ['show', base + ':scripts/ci/release-gate-policy.json']));
-    if (![5, 8].includes(policy.gateEpoch)) throw new Error('unsupported predecessor epoch');
+    if (!Number.isSafeInteger(policy.gateEpoch) || policy.gateEpoch < 5
+        || policy.rootTag !== 'refs/tags/release-gate-epoch-' + policy.gateEpoch + '-root') {
+        throw new Error('invalid predecessor epoch');
+    }
     const root = commit('refs/tags/release-gate-epoch-' + policy.gateEpoch + '-root');
     git(repo, ['merge-base', '--is-ancestor', root, base]);
     return { mode: 'NORMAL', base, root };


### PR DESCRIPTION
## 变更内容

启用受保护前驱已批准的 Gate 核心与策略。Actions 凭据按来源和有效权限分类，普通构建可使用内置只读令牌；独立秘密、App、OIDC 和显式运行时凭据继续受原有质量与发布保护约束。

升级使用前驱批准的精确 Git mode/blob 和不可变签名 root，保留六项质量职责、App 检查来源、release Environment 与全部历史 root。

## 验证

- [x] 八项执行文件的 Git mode/blob 与受保护批准记录一致
- [x] 本地可信合同与 i18n 检查通过
- [x] 启用分支完整脚本测试 319 项通过，无失败或跳过；签名检查通过
- [x] 签名 root release-gate-epoch-9-root 已创建并核验，指向 51c4d3807fa647b05d779330da7fb74783edbb85；远端 Ruleset 禁止更新和删除，无 bypass
- [x] 当前 PR 的完整 Quality Gate 与六项 App required checks 通过（run 34688433954，attempt 2）
- [x] 属于内部 CI 变更，无产品 CHANGELOG 条目
