### PR TITLE
fix(ci): 提高维护者目录生成与边界验收可靠性

### DIFF
--- a/.github/actions/build-release-java/action.yml
+++ b/.github/actions/build-release-java/action.yml
@@ -41,8 +41,9 @@ runs:
       shell: bash
       env:
         RELEASE_VERSION: ${{ inputs.release_version }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: >
-        mvn -pl pixivdownload-app -am verify -Pofficial-surveys -DskipTests "-Dapp.release.version=$RELEASE_VERSION"
+        mvn -pl pixivdownload-app -am install -Pofficial-surveys -DskipTests "-Dapp.release.version=$RELEASE_VERSION"
         -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
         "-Dplugin.credential.filter=$PLUGIN_CREDENTIAL_FILTER"
 

--- a/.github/actions/verify-release-boundaries/action.yml
+++ b/.github/actions/verify-release-boundaries/action.yml
@@ -15,6 +15,7 @@ runs:
     - name: Verify packaged distribution boundaries
       shell: bash
       env:
+        GITHUB_TOKEN: ${{ github.token }}
         REQUIRE_PRODUCTION_CREDENTIAL_KEY: ${{ inputs.require_production_credential_key }}
         ADDITIONAL_TESTS: ${{ inputs.additional_tests }}
       run: |

--- a/.github/actions/verify-sdk/action.yml
+++ b/.github/actions/verify-sdk/action.yml
@@ -51,6 +51,7 @@ runs:
       shell: bash
       env:
         SOURCE_SHA: ${{ inputs.source_sha }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
         mvn -B -ntp -pl pixivdownload-app,pixivdownload-sdk-tools -am verify \
@@ -81,6 +82,7 @@ runs:
       shell: bash
       env:
         SOURCE_SHA: ${{ inputs.source_sha }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
         sdk_version="$(node scripts/ci/sdk-version.mjs --repo-root . --json | node -pe 'JSON.parse(require("fs").readFileSync(0,"utf8")).version')"

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -346,6 +346,8 @@ jobs:
 
       - name: Verify frozen SDK against public Central
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           node scripts/ci/sdk-consumer.mjs --repo-root . \
@@ -367,6 +369,8 @@ jobs:
 
       - name: Verify public SDK Release and clean consumer
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           public_release="$GITHUB_WORKSPACE/target/sdk-public-release"

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -57,8 +57,12 @@ jobs:
         with:
           node-version: '24'
       - name: Compile external plugin test fixtures
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: mvn -B -ntp -pl pixivdownload-official-plugins -am compile -Dexec.skip=true
       - name: Run Java tests
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: mvn -B -ntp test -Dexec.skip=true -Duser.language=en -Duser.country=US
 
   sdk-tests:
@@ -141,7 +145,9 @@ jobs:
         with:
           node-version: '24'
       - name: Build release artifacts with ProGuard
-        run: mvn -B -ntp verify -Pofficial-surveys -DskipTests '-Dmaven.javadoc.skip=true' '-Dmaven.source.skip=true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: mvn -B -ntp install -Pofficial-surveys -DskipTests '-Dmaven.javadoc.skip=true' '-Dmaven.source.skip=true'
       - name: Run Windows Compose tests using the compiled plugin
         working-directory: pixivdownload-plugin-gui-compose
         shell: pwsh

--- a/pixivdownload-plugin-gallery-tools/src/test/java/top/sywyar/pixivdownload/duplicate/DuplicateScanServiceTest.java
+++ b/pixivdownload-plugin-gallery-tools/src/test/java/top/sywyar/pixivdownload/duplicate/DuplicateScanServiceTest.java
@@ -167,6 +167,7 @@ class DuplicateScanServiceTest {
     void destroyWaitsForSynchronousPreparationAndRestoresInterrupt() throws Exception {
         CountDownLatch countEntered = new CountDownLatch(1);
         CountDownLatch releaseCount = new CountDownLatch(1);
+        CountDownLatch cancellationDelivered = new CountDownLatch(1);
         AtomicReference<Runnable> submitted = new AtomicReference<>();
         AtomicReference<Throwable> startFailure = new AtomicReference<>();
         AtomicBoolean interruptedAfterDestroy = new AtomicBoolean();
@@ -175,7 +176,14 @@ class DuplicateScanServiceTest {
             assertThat(releaseCount.await(2, TimeUnit.SECONDS)).isTrue();
             return 0;
         });
-        DuplicateScanService service = service(submitted::set);
+        DuplicateScanService service = new DuplicateScanService(
+                hashIndexMaintenance, duplicateService, messages, submitted::set) {
+            @Override
+            public void cancelQuiescedTasks() {
+                super.cancelQuiescedTasks();
+                cancellationDelivered.countDown();
+            }
+        };
         Thread starter = new Thread(() -> {
             try {
                 service.startScan(false);
@@ -192,8 +200,7 @@ class DuplicateScanServiceTest {
             interruptedAfterDestroy.set(Thread.currentThread().isInterrupted());
         }, "duplicate-interrupted-destroy-test");
         destroyer.start();
-        QueueTaskTracker tracker = (QueueTaskTracker) field(service, "taskTracker");
-        assertThat(awaitNotAccepting(tracker)).isTrue();
+        assertThat(cancellationDelivered.await(2, TimeUnit.SECONDS)).isTrue();
         assertThat(destroyer.isAlive()).isTrue();
         assertThat(submitted).hasValue(null);
 
@@ -217,13 +224,5 @@ class DuplicateScanServiceTest {
         Field field = target.getClass().getDeclaredField(name);
         field.setAccessible(true);
         return field.get(target);
-    }
-
-    private static boolean awaitNotAccepting(QueueTaskTracker tracker) throws InterruptedException {
-        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
-        while (tracker.isAccepting() && System.nanoTime() < deadline) {
-            Thread.sleep(1);
-        }
-        return !tracker.isAccepting();
     }
 }

--- a/scripts/ci/test/generate-maintainers.test.mjs
+++ b/scripts/ci/test/generate-maintainers.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { gitContributorIdentities, readBounded, selectMaintainers } from '../../generate-maintainers.mjs';
+import { fetchGitHub, gitContributorIdentities, readBounded, selectMaintainers } from '../../generate-maintainers.mjs';
 
 test('维护者为仓库所有者和提交协作者与真人白名单的交集', async () => {
   const identities = gitContributorIdentities(
@@ -50,4 +50,116 @@ test('提交协作者产生独立提交后自动成为提交贡献者', async ()
 
 test('头像响应超过上限时立即拒绝', async () => {
   await assert.rejects(readBounded(new Response(new Uint8Array(5)), 4), /too large/);
+});
+
+function requests(...responses) {
+  const calls = [];
+  const delays = [];
+  const warnings = [];
+  return {
+    calls, delays, warnings,
+    options: {
+      fetchImpl: async (url, options) => {
+        calls.push({ url, options });
+        const response = responses.shift();
+        if (response instanceof Error) throw response;
+        assert.ok(response, '不能超出预定请求次数');
+        return response;
+      },
+      wait: async (delay) => { delays.push(delay); },
+      now: () => 1_000_000,
+      warn: (message) => { warnings.push(message); },
+    },
+  };
+}
+
+test('GitHub API 使用现有令牌且拒绝把认证发送到其它主机', async (t) => {
+  const previous = process.env.GITHUB_TOKEN;
+  process.env.GITHUB_TOKEN = 'test-built-in-token';
+  t.after(() => {
+    if (previous === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = previous;
+  });
+  const request = requests(Response.json({ id: 101 }));
+  assert.deepEqual(await (await fetchGitHub('/repos/example/project', request.options)).json(), { id: 101 });
+  assert.equal(request.calls[0].options.headers.Authorization, 'Bearer test-built-in-token');
+  assert.equal(request.calls[0].options.redirect, 'error');
+  assert.ok(request.calls[0].options.signal instanceof AbortSignal);
+  await assert.rejects(fetchGitHub('https://example.com/stolen', request.options), /left api.github.com/);
+  await assert.rejects(fetchGitHub('https://user@api.github.com/repos/example/project', request.options), /left api.github.com/);
+  assert.equal(request.calls.length, 1);
+});
+
+test('权限错误立即失败并保留脱敏诊断，不输出响应中的令牌或换行', async (t) => {
+  const previous = process.env.GITHUB_TOKEN;
+  process.env.GITHUB_TOKEN = 'secret-fixture-token';
+  t.after(() => {
+    if (previous === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = previous;
+  });
+  for (const status of [401, 403, 404]) {
+    const request = requests(Response.json({ message: 'Permission denied: secret-fixture-token\n::error::injected' }, {
+      status, headers: { 'x-github-request-id': 'request-fixture', 'x-ratelimit-remaining': '42' },
+    }));
+    await assert.rejects(fetchGitHub('/repos/example/project', request.options), (error) => {
+      assert.match(error.message, new RegExp(`GitHub API ${status}`));
+      assert.match(error.message, /authenticated=true.*request-fixture.*remaining=42/);
+      assert.match(error.message, /Permission denied/);
+      assert.doesNotMatch(error.message, /secret-fixture-token|[\r\n]/);
+      return true;
+    });
+    assert.equal(request.calls.length, 1);
+    assert.deepEqual(request.delays, []);
+  }
+});
+
+test('明确限流遵守 Retry-After 与重置时刻，未提供时等待至少一分钟', async () => {
+  for (const [status, headers, message, expected] of [
+    [403, { 'retry-after': '2' }, 'slow down', 2000],
+    [429, { 'retry-after': new Date(1_005_000).toUTCString() }, 'slow down', 5000],
+    [403, { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': '1090' }, 'API rate limit exceeded', 91_000],
+    [403, {}, 'You have exceeded a secondary rate limit', 60_000],
+    [429, {}, 'slow down', 60_000],
+  ]) {
+    const request = requests(Response.json({ message }, { status, headers }), Response.json({ ok: true }));
+    assert.equal((await fetchGitHub('/repos/example/project', request.options)).status, 200);
+    assert.deepEqual(request.delays, [expected]);
+    assert.equal(request.warnings.length, 1);
+    assert.equal(request.calls.length, 2);
+  }
+});
+
+test('短暂服务和网络故障有限重试，重试用尽仍拒绝构建', async () => {
+  const request = requests(
+    new TypeError('fetch failed'),
+    Response.json({ message: 'unavailable' }, { status: 503 }),
+    Response.json({ ok: true }),
+  );
+  assert.equal((await fetchGitHub('/users/example', request.options)).status, 200);
+  assert.deepEqual(request.delays, [1000, 2000]);
+  const exhausted = requests(...Array.from({ length: 3 }, () => new DOMException('timeout', 'TimeoutError')));
+  await assert.rejects(fetchGitHub('/users/example', exhausted.options), /transport failure.*attempts=3/);
+  assert.equal(exhausted.calls.length, 3);
+  assert.deepEqual(exhausted.delays, [1000, 2000]);
+});
+
+test('限流等待超出累计预算时失败，不提前请求也不无限重试', async () => {
+  const tooLong = requests(Response.json({ message: 'slow down' }, { status: 429, headers: { 'retry-after': '3600' } }));
+  await assert.rejects(fetchGitHub('/users/example', tooLong.options), /retry wait budget/);
+  assert.deepEqual(tooLong.delays, []);
+  assert.equal(tooLong.calls.length, 1);
+  const repeated = requests(...Array.from({ length: 3 }, () => Response.json({ message: 'slow down' }, { status: 429 })));
+  await assert.rejects(fetchGitHub('/users/example', repeated.options), /attempts=3/);
+  assert.deepEqual(repeated.delays, [60_000, 120_000]);
+});
+
+test('诊断正文过大或不是 JSON 仍报告 HTTP 状态和请求编号', async () => {
+  for (const body of ['gateway error', 'x'.repeat(64 * 1024 + 1)]) {
+    const request = requests(new Response(body, { status: 403, headers: { 'x-github-request-id': 'error-body-fixture' } }));
+    await assert.rejects(fetchGitHub('/users/example', request.options), (error) => {
+      assert.match(error.message, /GitHub API 403.*error-body-fixture/);
+      assert.ok(error.message.length < 2000);
+      return true;
+    });
+  }
 });

--- a/scripts/ci/test/quality-gate-workflow.test.mjs
+++ b/scripts/ci/test/quality-gate-workflow.test.mjs
@@ -162,7 +162,7 @@ test('Quality Gate preserves required roles and the active event contract', () =
     }
     const javaSteps = Object.values(doc.jobs).flatMap(executionSteps);
     const sdkResolve = javaSteps.find((step) => step.env?.INPUT_TRUSTED_BASE_SHA !== undefined);
-    const releaseBuild = javaSteps.find((step) => /\bverify\b.*-Pofficial-surveys/.test(step.run || ''));
+    const releaseBuild = javaSteps.find((step) => /\b(?:verify|install)\b.*-Pofficial-surveys/.test(step.run || ''));
     const releaseBoundary = javaSteps.find((step) => /DistributionPackagingBoundaryTest/.test(step.run || ''));
     const sdkPackage = javaSteps.find((step) => /-DaltDeploymentRepository=/.test(step.run || ''));
     const sdkContract = javaSteps.find((step) => /sdk-contract\.mjs/.test(step.run || ''));
@@ -218,7 +218,7 @@ test('Java tests and ProGuard run independently and both gate the required Java 
         return visited;
     };
     const tests = owner(/\bmvn\b[^\n]*\btest\b[^\n]*-Duser\.language=/u);
-    const build = owner(/\bmvn\b[^\n]*\bverify\b[^\n]*-Pofficial-surveys/u);
+    const build = owner(/\bmvn\b[^\n]*\b(?:verify|install)\b[^\n]*-Pofficial-surveys/u);
     assert.notEqual(tests, build);
     assert.equal(ancestors(tests).has(build), false);
     assert.equal(ancestors(build).has(tests), false);
@@ -242,7 +242,7 @@ test('Java tests and ProGuard run independently and both gate the required Java 
 test('QG 覆盖 Compose、SDK 消费者和两种 PowerShell，并顺序复用构建产物', () => {
     const { jobs } = load('.github/workflows/quality-gate.yml');
     const artifacts = executionSteps(jobs['release-artifacts']);
-    const build = artifacts.findIndex(step => /mvn.*verify.*-Pofficial-surveys/u.test(step.run || ''));
+    const build = artifacts.findIndex(step => /mvn.*(?:verify|install).*-Pofficial-surveys/u.test(step.run || ''));
     const compose = artifacts.findIndex(step => /gradlew(?:\.bat)?.*mavenTest/u.test(step.run || ''));
     const boundaries = artifacts.findIndex(step => /DistributionPackagingBoundaryTest/u.test(step.run || ''));
     assert.ok(build >= 0 && compose > build && boundaries > build);
@@ -301,6 +301,24 @@ test('SDK 发布串行消费本次完整 QG 验证的候选，恢复继续使用
     assert.ok(steps.indexOf(download) < freeze);
     assert.match(steps[freeze].run, /--verify-directory target\/sdk-release --source-sha/u);
     assert.ok(steps.findIndex(step => /pixivdownload-plugin-signature package/u.test(step.run || '')) < freeze);
+});
+
+test('应用资源构建与 SDK 宿主消费者显式取得内置 GitHub 读取令牌', () => {
+    const workflows = ['quality-gate', 'publish-sdk', 'nightly', 'release'];
+    let builds = 0;
+    for (const workflow of workflows) {
+        const doc = load(`.github/workflows/${workflow}.yml`);
+        for (const step of Object.values(doc.jobs).flatMap(executionSteps)) {
+            const command = step.run || '';
+            const appBuild = command.split('\n').some(line => /\bmvn\b.*\b(?:compile|test|verify|install)\b/u.test(line)
+                && !line.includes('surefire:test')
+                && (!line.includes('-pl') || /-pl\s+pixivdownload-(?:app|official-plugins)\b/u.test(line)));
+            if (!appBuild && !command.includes('scripts/ci/sdk-consumer.mjs')) continue;
+            assert.equal(step.env?.GITHUB_TOKEN, '${{ github.token }}', `${workflow}: ${step.name}`);
+            builds++;
+        }
+    }
+    assert.ok(builds > 0);
 });
 
 test('发布链：所有凭据与写权限只在 release Environment 的门禁后使用', () => {
@@ -547,7 +565,7 @@ test('发行候选只来自同次完整 QG，生产应用继续重建并执行�
     const app = load('.github/actions/build-release-java/action.yml').runs.steps;
     assert.ok(app.findIndex(step => step.uses === './.github/actions/restore-release-candidates') <
         app.findIndex(step => step.name === 'Build JAR'));
-    assert.match(app.find(step => step.name === 'Build JAR').run, /-pl pixivdownload-app -am verify/u);
+    assert.match(app.find(step => step.name === 'Build JAR').run, /-pl pixivdownload-app -am (?:verify|install)/u);
     const boundary = app.find(step => step.uses === './.github/actions/verify-release-boundaries');
     assert.equal(boundary.with.require_production_credential_key, 'true');
 });

--- a/scripts/ci/test/workflow-orchestration.test.ps1
+++ b/scripts/ci/test/workflow-orchestration.test.ps1
@@ -40,7 +40,7 @@ $fixture = Join-Path $tempBase ('pixiv-workflow-test-' + [Guid]::NewGuid().ToStr
 try {
     & {
         $commands = @(Get-Content (Join-Path $repo '.github/workflows/quality-gate.yml') |
-            Where-Object { $_ -match '^\s+run: mvn\b.*\bverify\b.*-Pofficial-surveys' })
+            Where-Object { $_ -match '^\s+run: mvn\b.*-Pofficial-surveys' })
         Assert-Equal $commands.Count 1
         function mvn { $script:mavenArguments = @($args) }
         & ([scriptblock]::Create(($commands[0] -replace '^\s+run: ', '')))

--- a/scripts/generate-maintainers.mjs
+++ b/scripts/generate-maintainers.mjs
@@ -2,10 +2,15 @@ import { execFileSync } from 'node:child_process';
 import { readFile, mkdir, rename, writeFile } from 'node:fs/promises';
 import { basename, dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
 
 const API_BASE = 'https://api.github.com';
 const DEFAULT_REPOSITORY = 'Sywyar/PixivDownloader';
 const MAX_AVATAR_BYTES = 1024 * 1024;
+const MAX_API_ATTEMPTS = 3;
+const API_TIMEOUT_MS = 30_000;
+const MAX_RETRY_WAIT_MS = 180_000;
+const MAX_ERROR_BYTES = 64 * 1024;
 const LOGIN_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
 
 function isBot(user) {
@@ -67,29 +72,86 @@ export async function selectMaintainers({ owner, contributors, identities, allow
   return selected;
 }
 
-function headers(withToken = true) {
+function headers() {
   const result = {
     Accept: 'application/vnd.github+json',
     'User-Agent': 'PixivDownloader-maintainer-catalog',
     'X-GitHub-Api-Version': '2022-11-28',
   };
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
-  if (withToken && token) result.Authorization = `Bearer ${token}`;
+  if (token) result.Authorization = `Bearer ${token}`;
   return result;
 }
 
+export async function fetchGitHub(path, { fetchImpl = fetch, wait = sleep, now = Date.now, warn = console.warn } = {}) {
+  const url = new URL(path, API_BASE);
+  if (url.origin !== API_BASE || url.username || url.password) throw new Error('GitHub request left api.github.com');
+  const requestHeaders = headers();
+  const safe = (value) => {
+    let text = String(value ?? 'unavailable');
+    for (const token of [process.env.GITHUB_TOKEN, process.env.GH_TOKEN]) {
+      if (token) text = text.replaceAll(token, '[REDACTED]');
+    }
+    return text.replace(/[\r\n\t\x00-\x1f\x7f]/g, ' ').slice(0, 1024);
+  };
+  let waited = 0;
+  for (let attempt = 1; attempt <= MAX_API_ATTEMPTS; attempt++) {
+    let response;
+    let failure;
+    let delay = 1000 * 2 ** (attempt - 1);
+    try {
+      response = await fetchImpl(url, {
+        headers: requestHeaders, redirect: 'error', signal: AbortSignal.timeout(API_TIMEOUT_MS),
+      });
+    } catch (error) {
+      failure = new Error(`GitHub API transport failure: ${url.pathname}; authenticated=${Boolean(requestHeaders.Authorization)}; ${safe(error.cause?.code ?? error.name)}`);
+      if (!(error instanceof TypeError) && error.name !== 'TimeoutError') throw failure;
+    }
+    if (response?.ok) return response;
+    if (response) {
+      let message;
+      try {
+        message = JSON.parse((await readBounded(response, MAX_ERROR_BYTES)).toString('utf8')).message;
+      } catch {
+        // 诊断正文缺失或过大时，仍保留状态码与限流头；不输出原始响应。
+        await response.body?.cancel().catch(() => {});
+      }
+      const remaining = response.headers.get('x-ratelimit-remaining');
+      const reset = response.headers.get('x-ratelimit-reset');
+      const retryAfter = response.headers.get('retry-after');
+      const diagnostic = ['x-github-request-id', 'x-ratelimit-remaining', 'x-ratelimit-reset', 'retry-after']
+        .map((name) => `${name}=${safe(response.headers.get(name))}`).join('; ');
+      failure = new Error(`GitHub API ${response.status}: ${url.pathname}; authenticated=${Boolean(requestHeaders.Authorization)}; ${diagnostic}; message=${safe(message)}`);
+      const rateLimited = response.status === 429 || (response.status === 403
+        && (remaining === '0' || retryAfter !== null || /(?:secondary |API )rate limit/i.test(message ?? '')));
+      if (!rateLimited && ![500, 502, 503, 504].includes(response.status)) throw failure;
+      if (rateLimited) delay = 60_000 * 2 ** (attempt - 1);
+      if (retryAfter !== null) {
+        const seconds = /^\d+(?:\.\d+)?$/.test(retryAfter) ? Number(retryAfter) * 1000 : Date.parse(retryAfter) - now();
+        if (Number.isFinite(seconds)) delay = Math.max(1000, seconds);
+      }
+      if (remaining === '0' && reset !== null && /^\d+$/.test(reset)) {
+        delay = Math.max(delay, Number(reset) * 1000 - now() + 1000);
+      }
+    }
+    if (attempt === MAX_API_ATTEMPTS || waited + delay > MAX_RETRY_WAIT_MS) {
+      throw new Error(`${failure.message}; attempts=${attempt}; retry wait budget=${MAX_RETRY_WAIT_MS}ms`);
+    }
+    warn(`${failure.message}; retry ${attempt + 1}/${MAX_API_ATTEMPTS} after ${delay}ms`);
+    await wait(delay);
+    waited += delay;
+  }
+}
+
 async function fetchJson(path) {
-  const response = await fetch(`${API_BASE}${path}`, { headers: headers() });
-  if (!response.ok) throw new Error(`GitHub API ${response.status}: ${path}`);
-  return response.json();
+  return (await fetchGitHub(path)).json();
 }
 
 async function fetchContributors(repository) {
   const contributors = [];
   let url = `${API_BASE}/repos/${repository}/contributors?per_page=100&anon=false`;
   while (url) {
-    const response = await fetch(url, { headers: headers() });
-    if (!response.ok) throw new Error(`GitHub API ${response.status}: contributors`);
+    const response = await fetchGitHub(url);
     contributors.push(...await response.json());
     const next = response.headers.get('link')?.match(/<([^>]+)>; rel="next"/)?.[1];
     if (next) {


### PR DESCRIPTION
## 变更内容

应用资源构建与 SDK 宿主消费者显式取得内置只读 GITHUB_TOKEN，维护者目录生成器统一认证仓库、用户和贡献者请求。明确限流及暂时性故障最多尝试三次，累计等待不超过 180 秒；普通权限错误直接失败，日志保留脱敏消息、请求编号和限流头。API 与头像请求拒绝重定向，头像请求不携带凭据。

生产构建执行到 Maven install，将同次构建的 reactor 模块写入本地仓库，供后续独立验收解析。当前边界检查继续使用 test 生命周期，并显式取得内置读取令牌。

修正 DuplicateScanServiceTest 的同步条件：等待取消送达后再释放同步准备，保留销毁等待、中断恢复与任务引用断言。

PowerShell 编排回归按发行 profile 定位生产命令，保留唯一命令和实际参数断言，允许构建执行到 install。

## 验证

- [x] 本地完整生产 install 构建通过；已验证其产物可供独立边界检查解析
- [x] DuplicateScanServiceTest 五项测试通过，无失败或跳过
- [x] PowerShell 5.1 与 7 完整编排回归通过
- [x] 当前拆分后的完整脚本测试 326 项通过，无失败或跳过；合同、签名与 i18n 检查通过
- [x] 当前 PR 的完整 Quality Gate 与六项 App required checks 通过；run 34692889496 attempt 3，H/M 来源复验通过
- [x] 中英文工程网络说明已准备；内部构建修复无需产品 CHANGELOG 条目
