### PR TITLE
fix(ci): 复用已构建产物执行发行边界验收

### DIFF
--- a/.github/actions/verify-release-boundaries/action.yml
+++ b/.github/actions/verify-release-boundaries/action.yml
@@ -15,14 +15,18 @@ runs:
     - name: Verify packaged distribution boundaries
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ github.token }}
         REQUIRE_PRODUCTION_CREDENTIAL_KEY: ${{ inputs.require_production_credential_key }}
         ADDITIONAL_TESTS: ${{ inputs.additional_tests }}
       run: |
         set -euo pipefail
         tests="DistributionPackagingBoundaryTest${ADDITIONAL_TESTS:+,$ADDITIONAL_TESTS}"
-        mvn -B -ntp -pl pixivdownload-app -am test "-Dtest=$tests" -Dsurefire.failIfNoSpecifiedTests=false -Ddistribution.packaging.require-artifacts=true "-Ddistribution.packaging.require-production-credential-key=$REQUIRE_PRODUCTION_CREDENTIAL_KEY" -Dexec.skip=true
         IFS=',' read -r -a selectors <<< "$tests"
+        mkdir -p pixivdownload-app/target/surefire-reports
+        for selector in "${selectors[@]}"; do
+          class=${selector%%#*}
+          find pixivdownload-app/target/surefire-reports -name "*$class.txt" -delete
+        done
+        mvn -B -ntp -pl pixivdownload-app -am surefire:test "-Dtest=$tests" -Dsurefire.failIfNoSpecifiedTests=false -Ddistribution.packaging.require-artifacts=true "-Ddistribution.packaging.require-production-credential-key=$REQUIRE_PRODUCTION_CREDENTIAL_KEY" -Dexec.skip=true
         for selector in "${selectors[@]}"; do
           class=${selector%%#*}
           report=$(find pixivdownload-app/target/surefire-reports -name "*$class.txt" -print -quit)

--- a/scripts/ci/sdk-release.mjs
+++ b/scripts/ci/sdk-release.mjs
@@ -373,7 +373,7 @@ export function initializeProjectGit(workspace, { repoRoot, sourceSha, sdkVersio
             + `- Set up the development workspace for SDK ${sdkVersion}\n`
             + '- Include plugin examples, build tools and API documentation\n'
             + `- Generate the baseline from source commit ${sourceSha}\n`, 'utf8');
-    git(['commit', '--quiet', '-F', message]);
+    git(['-c', 'maintenance.auto=false', 'commit', '--quiet', '-F', message]);
     fs.rmSync(message);
     // 索引只保留提交树，排除构建机的 inode、ctime 等信息。
     git(['read-tree', '--empty']);

--- a/scripts/ci/test/quality-gate-workflow.test.mjs
+++ b/scripts/ci/test/quality-gate-workflow.test.mjs
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import os from 'node:os';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import vm from 'node:vm';
@@ -319,6 +320,53 @@ test('应用资源构建与 SDK 宿主消费者显式取得内置 GitHub 读取�
         }
     }
     assert.ok(builds > 0);
+});
+
+test('发行边界命令只执行已编译测试，拒绝旧报告、零测试、失败与跳过', () => {
+    const step = load('.github/actions/verify-release-boundaries/action.yml').runs.steps[0];
+    for (const steps of [load('.github/workflows/quality-gate.yml').jobs['release-artifacts'].steps,
+        load('.github/actions/build-release-java/action.yml').runs.steps]) {
+        const boundary = steps.findIndex(item => item.uses === './.github/actions/verify-release-boundaries');
+        assert.ok(boundary > 0);
+        assert.ok(steps.slice(0, boundary).some(item => /\bmvn\b.*\binstall\b/u.test(item.run || '')),
+            '直接 Surefire 验收前必须安装本次 reactor 依赖，不能依赖 runner 的旧本地缓存');
+    }
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'release-boundary-command-'));
+    const reports = path.join(fixture, 'pixivdownload-app/target/surefire-reports');
+    const invoke = (mode) => execFileSync('bash', ['-e', '-o', 'pipefail', '-c', `
+        mvn() {
+          printf '%s\\n' "$@" > arguments.txt
+          if [ "$MODE" = failure ]; then return 7; fi
+          if [ "$MODE" = missing ]; then return 0; fi
+          tests=1 failures=0 errors=0 skipped=0
+          if [ "$MODE" = zero ]; then tests=0; fi
+          if [ "$MODE" = failed ]; then failures=1; fi
+          if [ "$MODE" = errored ]; then errors=1; fi
+          if [ "$MODE" = skipped ]; then skipped=1; fi
+          for class in DistributionPackagingBoundaryTest ExtraBoundaryTest; do
+            echo "Tests run: $tests, Failures: $failures, Errors: $errors, Skipped: $skipped" > "pixivdownload-app/target/surefire-reports/example.$class.txt"
+          done
+        }
+        ${step.run}
+    `], {
+        cwd: fixture, encoding: 'utf8', stdio: 'pipe',
+        env: { ...process.env, MODE: mode, REQUIRE_PRODUCTION_CREDENTIAL_KEY: 'true', ADDITIONAL_TESTS: 'ExtraBoundaryTest#one+two' },
+    });
+    try {
+        invoke('success');
+        const args = fs.readFileSync(path.join(fixture, 'arguments.txt'), 'utf8').trim().split(/\r?\n/u);
+        assert.ok(args.includes('surefire:test'));
+        assert.ok(!args.includes('test') && !args.includes('verify'));
+        assert.ok(args.includes('-Dtest=DistributionPackagingBoundaryTest,ExtraBoundaryTest#one+two'));
+        assert.ok(args.includes('-Ddistribution.packaging.require-artifacts=true'));
+        assert.ok(args.includes('-Ddistribution.packaging.require-production-credential-key=true'));
+        assert.throws(() => invoke('missing'));
+        assert.equal(fs.readdirSync(reports).length, 0, '旧的成功报告不能替代本次执行');
+        for (const mode of ['zero', 'failed', 'errored', 'skipped']) assert.throws(() => invoke(mode));
+        assert.throws(() => invoke('failure'), (error) => error.status === 7);
+    } finally {
+        fs.rmSync(fixture, { recursive: true, force: true });
+    }
 });
 
 test('发布链：所有凭据与写权限只在 release Environment 的门禁后使用', () => {


### PR DESCRIPTION
## 变更内容

发行边界检查在生产 install 构建后直接执行已编译的 Surefire 测试，避免再次进入资源生成生命周期、联网生成维护者目录。QG 与生产应用构建共用该入口。

运行前只清除本次 selector 对应的旧文本报告；运行后要求每份报告存在、测试数大于零，且失败、错误和跳过均为零。保留严格产物、生产凭据和附加测试参数。

SDK 初始 Git 提交仅在本次调用中关闭自动维护，避免后台临时文件变化导致紧接着的 ZIP 归档失败；归档继续完整读取文件并传播错误。

## 验证

- [x] 新 worktree 完整生产 install 与 24 项直接边界验收通过，29 个产物及维护者目录文件的摘要、时间戳不变
- [x] 完整脚本回归 327 项、合同、签名与 i18n 检查通过，测试无失败或跳过
- [x] SDK 归档与社区合同聚焦回归 12 项通过
- [x] 当前 head `5e5c933a` 的完整 Quality Gate `34696503658` 通过，六项 App required checks 在 head 和被测合并对象均成功，原生来源复验通过
- [x] 中英文工程网络说明已准备；内部构建修复无需产品 CHANGELOG 条目
