### PR TITLE
feat(plugin): 补齐发布者密钥与社区操作签名 CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ sh run.sh
 
 插件开发包提供单个 `pixivdownload-sdk` 编译依赖、独立 Maven 工程及 Gradle / sbt 示例。带固定运行清单的 SDK 可通过自带 Run / Debug 入口构建当前插件，自动准备配套宿主和完整官方插件；运行数据保存在各工程的 `.dev/`。可下载版本及具体用法以对应 Release 和包内 README 为准。
 
+发布者签名 CLI 位于 `pixivdownload-plugin-signature`，只需 JDK 17。在仓库根执行 `./mvnw -pl pixivdownload-plugin-signature package` 后，以 `java -cp <该模块生成的JAR> top.sywyar.pixivdownload.plugin.signature.cli.PluginSignatureTool <命令>` 调用：
+
+- `keygen --directory <新目录>`：生成 `private-key.pem`（PKCS#8）和配套 `public-key.pem`（SPKI），目录及私钥仅允许当前用户访问。请选择源码仓库和临时目录之外的位置，备份这两个文件；命令不覆盖已有目录。
+- `public-key --public-key <public-key.pem> --key-id <标识> --out <public.json>`：导出规范 SPKI Base64 和 SHA-256 公钥指纹。此命令读取配套公钥文件，不从私钥推导公钥。
+- `community-operation --operation <PUBLISHER_KEY_ROTATION|VERSION_STATUS_REQUEST|OWNERSHIP_TRANSFER> --canonical-body <规范正文> --request-id <SHA-256> --key-id <标识> --private-key <private-key.pem> --out <sig.json>`：签署固定 SDK 生成的 JCS 正文字节。正文摘要必须与 requestId 一致；输出只含 detached 签名，不包含私钥。
+
+公钥导出和社区操作签名均拒绝覆盖已有输出。插件包继续使用 CLI 的 `artifact` 命令；`--help` 列出完整参数。私钥不得提交到 Git 或放入投稿附件。
+
 ---
 
 ## 免责声明

--- a/README_en.md
+++ b/README_en.md
@@ -148,6 +148,14 @@ For detailed installation steps, usage guides, configuration reference, and deve
 
 The plugin SDK provides one `pixivdownload-sdk` compile dependency, an independent Maven project, and Gradle / sbt examples. Packages with a fixed runtime manifest include Run / Debug entries that build the current plugin and prepare its matching host and complete official plugin set. Each project keeps runtime data in `.dev/`. Check the selected Release and its README for availability and instructions.
 
+The publisher signing CLI is in `pixivdownload-plugin-signature` and requires only JDK 17. Run `./mvnw -pl pixivdownload-plugin-signature package` from the repository root, then invoke `java -cp <JAR produced by that module> top.sywyar.pixivdownload.plugin.signature.cli.PluginSignatureTool <command>`:
+
+- `keygen --directory <new-directory>` creates `private-key.pem` (PKCS#8) and its matching `public-key.pem` (SPKI), with access to the directory and private key restricted to the current user. Choose a location outside source repositories and temporary directories, and back up both files. The command never replaces an existing directory.
+- `public-key --public-key <public-key.pem> --key-id <id> --out <public.json>` exports canonical SPKI Base64 and the SHA-256 public key fingerprint. It reads the matching public key file; it does not derive a public key from a private key.
+- `community-operation --operation <PUBLISHER_KEY_ROTATION|VERSION_STATUS_REQUEST|OWNERSHIP_TRANSFER> --canonical-body <canonical-body> --request-id <SHA-256> --key-id <id> --private-key <private-key.pem> --out <sig.json>` signs the JCS body bytes produced by the pinned SDK. The body digest must match requestId. The output contains only the detached signature, with no private key material.
+
+Public key export and community operation signing refuse to overwrite output files. Use the existing `artifact` command to sign plugin packages; `--help` lists all arguments. Never commit private keys to Git or include them in submission attachments.
+
 ---
 
 ## Disclaimer

--- a/README_ja.md
+++ b/README_ja.md
@@ -130,6 +130,16 @@ OS またはブラウザーの「自動プロキシ設定スクリプト（PAC�
 
 ---
 
+## 発行者の署名ツール
+
+署名 CLI は `pixivdownload-plugin-signature` にあり、JDK 17 のみで動作します。リポジトリのルートで `./mvnw -pl pixivdownload-plugin-signature package` を実行し、`java -cp <このモジュールが生成したJAR> top.sywyar.pixivdownload.plugin.signature.cli.PluginSignatureTool <コマンド>` で呼び出します。
+
+- `keygen --directory <新規ディレクトリ>`：`private-key.pem`（PKCS#8）と対応する `public-key.pem`（SPKI）を生成します。ディレクトリと秘密鍵へのアクセスは現在のユーザーに限定されます。ソースリポジトリと一時ディレクトリの外を選び、両方のファイルをバックアップしてください。既存のディレクトリは上書きしません。
+- `public-key --public-key <public-key.pem> --key-id <識別子> --out <public.json>`：正規化された SPKI Base64 と SHA-256 公開鍵フィンガープリントを出力します。対応する公開鍵ファイルを読み取り、秘密鍵から公開鍵を導出する処理は行いません。
+- `community-operation --operation <PUBLISHER_KEY_ROTATION|VERSION_STATUS_REQUEST|OWNERSHIP_TRANSFER> --canonical-body <正規化本文> --request-id <SHA-256> --key-id <識別子> --private-key <private-key.pem> --out <sig.json>`：固定された SDK が生成した JCS 本文のバイト列に署名します。本文のダイジェストは requestId と一致する必要があります。出力には分離署名のみが含まれ、秘密鍵は含まれません。
+
+公開鍵の出力とコミュニティ操作の署名では既存の出力ファイルを上書きできません。プラグインパッケージの署名には従来の `artifact` コマンドを使います。引数の一覧は `--help` で確認できます。秘密鍵を Git にコミットしたり、提出ファイルに含めたりしないでください。
+
 ## 免責事項
 
 - 本プロジェクトは個人の学習・研究目的に限り使用してください。商用利用は禁止します。

--- a/README_ko.md
+++ b/README_ko.md
@@ -130,6 +130,16 @@ sh run.sh
 
 ---
 
+## 게시자 서명 도구
+
+서명 CLI는 `pixivdownload-plugin-signature`에 있으며 JDK 17만 있으면 실행할 수 있습니다. 저장소 루트에서 `./mvnw -pl pixivdownload-plugin-signature package`를 실행한 뒤 `java -cp <이 모듈이 생성한 JAR> top.sywyar.pixivdownload.plugin.signature.cli.PluginSignatureTool <명령>`으로 호출합니다.
+
+- `keygen --directory <새 디렉터리>`: `private-key.pem`(PKCS#8)과 해당 `public-key.pem`(SPKI)을 생성합니다. 디렉터리와 개인 키는 현재 사용자만 접근할 수 있습니다. 소스 저장소와 임시 디렉터리 밖의 위치를 선택하고 두 파일을 모두 백업하세요. 기존 디렉터리를 덮어쓰지 않습니다.
+- `public-key --public-key <public-key.pem> --key-id <식별자> --out <public.json>`: 정규화된 SPKI Base64와 SHA-256 공개 키 지문을 내보냅니다. 짝을 이루는 공개 키 파일을 읽으며, 개인 키에서 공개 키를 유도하지 않습니다.
+- `community-operation --operation <PUBLISHER_KEY_ROTATION|VERSION_STATUS_REQUEST|OWNERSHIP_TRANSFER> --canonical-body <정규화된 본문> --request-id <SHA-256> --key-id <식별자> --private-key <private-key.pem> --out <sig.json>`: 고정된 SDK가 생성한 JCS 본문 바이트에 서명합니다. 본문 해시는 requestId와 일치해야 합니다. 출력에는 분리 서명만 포함되며 개인 키는 포함되지 않습니다.
+
+공개 키 내보내기와 커뮤니티 작업 서명은 기존 출력 파일을 덮어쓰지 않습니다. 플러그인 패키지에는 기존 `artifact` 명령을 사용하세요. 전체 인수는 `--help`에서 확인할 수 있습니다. 개인 키를 Git에 커밋하거나 제출 첨부 파일에 넣지 마세요.
+
 ## 면책 조항
 
 - 이 프로젝트는 개인 학습 및 연구용이며 상업적 용도로 사용하지 마세요.

--- a/README_zh-Hant.md
+++ b/README_zh-Hant.md
@@ -130,6 +130,16 @@ sh run.sh
 
 ---
 
+## 發布者簽名工具
+
+簽名 CLI 位於 `pixivdownload-plugin-signature`，僅需 JDK 17。在儲存庫根目錄執行 `./mvnw -pl pixivdownload-plugin-signature package`，再以 `java -cp <該模組產生的JAR> top.sywyar.pixivdownload.plugin.signature.cli.PluginSignatureTool <命令>` 呼叫：
+
+- `keygen --directory <新目錄>`：產生 `private-key.pem`（PKCS#8）與配套的 `public-key.pem`（SPKI），目錄及私鑰僅允許目前使用者存取。請選擇原始碼儲存庫與暫存目錄以外的位置，備份這兩個檔案；命令不覆寫既有目錄。
+- `public-key --public-key <public-key.pem> --key-id <識別碼> --out <public.json>`：匯出標準化 SPKI Base64 與 SHA-256 公鑰指紋。此命令讀取配套公鑰檔案，不從私鑰推導公鑰。
+- `community-operation --operation <PUBLISHER_KEY_ROTATION|VERSION_STATUS_REQUEST|OWNERSHIP_TRANSFER> --canonical-body <標準化正文> --request-id <SHA-256> --key-id <識別碼> --private-key <private-key.pem> --out <sig.json>`：簽署固定版本 SDK 產生的 JCS 正文字節。正文摘要必須與 requestId 一致；輸出僅含 detached 簽名，不含私鑰。
+
+公鑰匯出與社群操作簽名均拒絕覆寫既有輸出。外掛套件繼續使用 CLI 的 `artifact` 命令；`--help` 列出完整參數。私鑰不得提交至 Git 或放入投稿附件。
+
 ## 免責聲明
 
 - 本項目僅供個人學習和研究使用，請勿用於任何商業用途。

--- a/pixivdownload-plugin-signature/src/main/java/top/sywyar/pixivdownload/plugin/signature/cli/PluginSignatureTool.java
+++ b/pixivdownload-plugin-signature/src/main/java/top/sywyar/pixivdownload/plugin/signature/cli/PluginSignatureTool.java
@@ -11,15 +11,18 @@ import top.sywyar.pixivdownload.plugin.signature.SignatureMetadata;
 import top.sywyar.pixivdownload.plugin.signature.TrustedPluginKey;
 import top.sywyar.pixivdownload.plugin.signature.VerificationPolicy;
 import top.sywyar.pixivdownload.plugin.signature.VerificationResult;
+import top.sywyar.pixivdownload.plugin.signature.community.CommunityOperation;
 import top.sywyar.pixivdownload.plugin.signature.internal.ed25519.Ed25519Signer;
 import top.sywyar.pixivdownload.plugin.signature.internal.envelope.EnvelopeV1Codec;
 import top.sywyar.pixivdownload.plugin.signature.internal.envelope.Hashing;
 import top.sywyar.pixivdownload.plugin.signature.internal.trust.KeyParsing;
+import top.sywyar.pixivdownload.plugin.signature.internal.trust.SigningKeyFiles;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.security.PrivateKey;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -44,6 +47,19 @@ public final class PluginSignatureTool {
         }
         String command = args[0];
         Map<String, String> options = parseOptions(args);
+        if ("keygen".equals(command)) {
+            onlyOptions(options, "directory");
+            SigningKeyFiles.generate(requiredPath(options, "directory"));
+            return;
+        }
+        if ("public-key".equals(command)) {
+            exportPublicKey(options);
+            return;
+        }
+        if ("community-operation".equals(command)) {
+            signCommunityOperation(options);
+            return;
+        }
         if ("artifact".equals(command)) {
             signArtifact(options);
             return;
@@ -174,12 +190,58 @@ public final class PluginSignatureTool {
                 Ed25519Signer.sign(privateKey(options), message));
     }
 
+    private static void exportPublicKey(Map<String, String> options) throws IOException {
+        onlyOptions(options, "public-key", "key-id", "out");
+        String keyId = communityKeyId(options);
+        String publicKey = SigningKeyFiles.publicKey(requiredPath(options, "public-key"));
+        var key = new TrustedPluginKey(keyId, SignatureMetadata.ED25519, publicKey,
+                TrustedPluginKey.State.ACTIVE, "CLI", "CLI", false);
+        PluginTrustStores.community(List.of(key));
+        String json = "{\"keyId\":\"" + keyId + "\",\"algorithm\":\"Ed25519\","
+                + "\"publicKeySpkiBase64\":\"" + publicKey + "\","
+                + "\"fingerprint\":\"" + key.publicKeyFingerprint() + "\"}\n";
+        Files.writeString(requiredPath(options, "out"), json, StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+    }
+
+    private static void signCommunityOperation(Map<String, String> options) throws IOException {
+        onlyOptions(options, "operation", "canonical-body", "request-id", "key-id", "private-key", "out");
+        CommunityOperation operation = CommunityOperation.valueOf(required(options, "operation"));
+        String keyId = communityKeyId(options);
+        // 规范正文由固定 SDK 生成，密码学模块只校验其原始字节摘要，不解析 JSON。
+        byte[] canonical = SigningKeyFiles.read(requiredPath(options, "canonical-body"), 64 * 1024);
+        byte[] digest = Hashing.sha256(canonical);
+        if (canonical.length == 0 || !Hashing.hex(digest).equals(required(options, "request-id"))) {
+            throw new IllegalArgumentException("REQUEST_ID_MISMATCH");
+        }
+        byte[] message = EnvelopeV1Codec.communityOperationMessage(operation, SignatureMetadata.ED25519,
+                keyId, canonical.length, digest);
+        writeMetadata(requiredPath(options, "out"), keyId, Ed25519Signer.sign(privateKey(options), message), true);
+    }
+
+    private static String communityKeyId(Map<String, String> options) {
+        String keyId = required(options, "key-id");
+        if (!keyId.matches("[A-Za-z0-9][A-Za-z0-9._:-]{0,127}")) {
+            throw new IllegalArgumentException("INVALID_KEY_ID");
+        }
+        return keyId;
+    }
+
+    private static void onlyOptions(Map<String, String> options, String... allowed) {
+        if (!List.of(allowed).containsAll(options.keySet())) throw new IllegalArgumentException("UNKNOWN_OPTION");
+    }
+
     private static PrivateKey privateKey(Map<String, String> options) throws IOException {
         Path path = requiredPath(options, "private-key");
-        return KeyParsing.ed25519PrivateKey(Files.readString(path, StandardCharsets.UTF_8));
+        return KeyParsing.ed25519PrivateKey(new String(SigningKeyFiles.read(path, SigningKeyFiles.MAX_KEY_BYTES),
+                StandardCharsets.UTF_8));
     }
 
     private static void writeMetadata(Path out, String keyId, byte[] signature) throws IOException {
+        writeMetadata(out, keyId, signature, false);
+    }
+
+    private static void writeMetadata(Path out, String keyId, byte[] signature, boolean createNew) throws IOException {
         SignatureMetadata metadata = new SignatureMetadata(SignatureMetadata.FORMAT_VERSION,
                 SignatureMetadata.ED25519, keyId, Base64.getEncoder().encodeToString(signature));
         String json = "{"
@@ -192,7 +254,12 @@ public final class PluginSignatureTool {
         if (parent != null) {
             Files.createDirectories(parent);
         }
-        Files.writeString(out, json + System.lineSeparator(), StandardCharsets.UTF_8);
+        if (createNew) {
+            Files.writeString(out, json + "\n", StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+        } else {
+            Files.writeString(out, json + System.lineSeparator(), StandardCharsets.UTF_8);
+        }
     }
 
     private static SignatureMetadata readMetadata(Path path) throws IOException {
@@ -265,7 +332,7 @@ public final class PluginSignatureTool {
             if (i + 1 >= args.length || args[i + 1].startsWith("--")) {
                 throw new IllegalArgumentException("missing value for --" + key);
             }
-            options.put(key, args[++i]);
+            if (options.putIfAbsent(key, args[++i]) != null) throw new IllegalArgumentException("DUPLICATE_OPTION");
         }
         return options;
     }
@@ -328,6 +395,11 @@ public final class PluginSignatureTool {
 
     private static void usage() {
         System.out.println("Usage:");
+        System.out.println("  keygen --directory <new-private-directory>");
+        System.out.println("  public-key --public-key <public-key.pem> --key-id <key> --out <public.json>");
+        System.out.println("  community-operation --operation PUBLISHER_KEY_ROTATION|VERSION_STATUS_REQUEST|OWNERSHIP_TRANSFER "
+                + "--canonical-body <jcs.bin> --request-id <sha256> --key-id <key> "
+                + "--private-key <pkcs8.pem> --out <sig.json>");
         System.out.println("  artifact --artifact <jar> --plugin-id <id> --version <version> "
                 + "--key-id <key> --private-key <pkcs8.pem> --out <sig.json>");
         System.out.println("  manifest --manifest <manifest.json> --repository-id <id> "

--- a/pixivdownload-plugin-signature/src/main/java/top/sywyar/pixivdownload/plugin/signature/internal/trust/SigningKeyFiles.java
+++ b/pixivdownload-plugin-signature/src/main/java/top/sywyar/pixivdownload/plugin/signature/internal/trust/SigningKeyFiles.java
@@ -1,0 +1,93 @@
+package top.sywyar.pixivdownload.plugin.signature.internal.trust;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryFlag;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.AclFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.GeneralSecurityException;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.EnumSet;
+import java.util.List;
+
+/** 签名 CLI 的密钥文件管理；私钥只写入新建且已收紧权限的目录。 */
+public final class SigningKeyFiles {
+    public static final int MAX_KEY_BYTES = 16 * 1024;
+
+    private SigningKeyFiles() { }
+
+    public static void generate(Path requested) throws IOException, GeneralSecurityException {
+        Path directory = requested.toAbsolutePath().normalize();
+        Path parent = directory.getParent();
+        if (parent == null || !Files.isDirectory(parent, LinkOption.NOFOLLOW_LINKS)
+                || !parent.equals(parent.toRealPath())) {
+            throw new IOException("KEY_DIRECTORY_PARENT_REQUIRED");
+        }
+        var posix = Files.getFileAttributeView(parent, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+        if (posix != null) {
+            Files.createDirectory(directory, PosixFilePermissions.asFileAttribute(
+                    PosixFilePermissions.fromString("rwx------")));
+        } else {
+            if (Files.getFileAttributeView(parent, AclFileAttributeView.class, LinkOption.NOFOLLOW_LINKS) == null) {
+                throw new IOException("KEY_FILE_PERMISSIONS_UNSUPPORTED");
+            }
+            Files.createDirectory(directory);
+            var acl = Files.getFileAttributeView(directory, AclFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+            var user = directory.getFileSystem().getUserPrincipalLookupService()
+                    .lookupPrincipalByName(System.getProperty("user.name"));
+            var entry = AclEntry.newBuilder().setType(AclEntryType.ALLOW).setPrincipal(user)
+                    .setPermissions(EnumSet.allOf(AclEntryPermission.class))
+                    .setFlags(AclEntryFlag.DIRECTORY_INHERIT, AclEntryFlag.FILE_INHERIT).build();
+            acl.setAcl(List.of(entry));
+            if (!acl.getAcl().equals(List.of(entry))) throw new IOException("KEY_FILE_PERMISSIONS_INVALID");
+        }
+        var pair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+        Path privateFile = directory.resolve("private-key.pem");
+        if (posix != null) {
+            Files.createFile(privateFile, PosixFilePermissions.asFileAttribute(
+                    PosixFilePermissions.fromString("rw-------")));
+            Files.writeString(privateFile, pem("PRIVATE KEY", pair.getPrivate().getEncoded()),
+                    StandardCharsets.UTF_8, StandardOpenOption.WRITE, LinkOption.NOFOLLOW_LINKS);
+        } else {
+            Files.writeString(privateFile, pem("PRIVATE KEY", pair.getPrivate().getEncoded()),
+                    StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+        }
+        Files.writeString(directory.resolve("public-key.pem"), pem("PUBLIC KEY", pair.getPublic().getEncoded()),
+                StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+    }
+
+    /** 导出配套公钥的规范 SPKI；不自行实现从私钥种子推导公钥。 */
+    public static String publicKey(Path path) throws IOException {
+        String text = new String(read(path, MAX_KEY_BYTES), StandardCharsets.UTF_8).strip();
+        if (text.startsWith("-----BEGIN PUBLIC KEY-----") && text.endsWith("-----END PUBLIC KEY-----")) {
+            text = text.substring("-----BEGIN PUBLIC KEY-----".length(),
+                    text.length() - "-----END PUBLIC KEY-----".length()).replaceAll("\\s+", "");
+        }
+        KeyParsing.canonicalEd25519PublicKey(text);
+        return text;
+    }
+
+    public static byte[] read(Path path, int maximum) throws IOException {
+        if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) throw new IOException("REGULAR_FILE_REQUIRED");
+        try (var input = Files.newInputStream(path, LinkOption.NOFOLLOW_LINKS)) {
+            byte[] bytes = input.readNBytes(maximum + 1);
+            if (bytes.length > maximum) throw new IOException("INPUT_LIMIT_EXCEEDED");
+            return bytes;
+        }
+    }
+
+    private static String pem(String type, byte[] bytes) {
+        return "-----BEGIN " + type + "-----\n"
+                + Base64.getMimeEncoder(64, new byte[]{'\n'}).encodeToString(bytes)
+                + "\n-----END " + type + "-----\n";
+    }
+}

--- a/pixivdownload-plugin-signature/src/test/java/top/sywyar/pixivdownload/plugin/signature/PluginSignatureToolTest.java
+++ b/pixivdownload-plugin-signature/src/test/java/top/sywyar/pixivdownload/plugin/signature/PluginSignatureToolTest.java
@@ -4,10 +4,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import top.sywyar.pixivdownload.plugin.signature.cli.PluginSignatureTool;
+import top.sywyar.pixivdownload.plugin.signature.community.CommunityOperation;
+import top.sywyar.pixivdownload.plugin.signature.community.CommunityOperationVerificationRequest;
 import top.sywyar.pixivdownload.plugin.signature.internal.envelope.Hashing;
+import top.sywyar.pixivdownload.plugin.signature.internal.trust.SigningKeyFiles;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.AclFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.util.Base64;
@@ -23,6 +31,88 @@ class PluginSignatureToolTest {
 
     @TempDir
     Path tempDir;
+
+    @Test
+    @DisplayName("初始化密钥限制文件权限，导出规范公钥并拒绝覆盖或错误参数")
+    void initializesPrivateKeysWithoutOverwriting() throws Exception {
+        Path directory = tempDir.resolve("publisher keys");
+        PluginSignatureTool.main(new String[]{"keygen", "--directory", directory.toString()});
+        Path privateKey = directory.resolve("private-key.pem");
+        byte[] original = Files.readAllBytes(privateKey);
+        assertThatThrownBy(() -> PluginSignatureTool.main(new String[]{"keygen", "--directory", directory.toString()}))
+                .isInstanceOf(java.nio.file.FileAlreadyExistsException.class);
+        assertThat(Files.readAllBytes(privateKey)).isEqualTo(original);
+        if (Files.getFileAttributeView(privateKey, PosixFileAttributeView.class) != null) {
+            assertThat(Files.getPosixFilePermissions(directory)).isEqualTo(PosixFilePermissions.fromString("rwx------"));
+            assertThat(Files.getPosixFilePermissions(privateKey)).isEqualTo(PosixFilePermissions.fromString("rw-------"));
+        } else {
+            var acl = Files.getFileAttributeView(privateKey, AclFileAttributeView.class);
+            assertThat(acl).isNotNull();
+            var owner = privateKey.getFileSystem().getUserPrincipalLookupService()
+                    .lookupPrincipalByName(System.getProperty("user.name"));
+            assertThat(acl.getAcl()).filteredOn(entry -> entry.type() == AclEntryType.ALLOW)
+                    .allMatch(entry -> entry.principal().equals(owner));
+        }
+        Path exported = tempDir.resolve("public.json");
+        String[] export = {"public-key", "--public-key", directory.resolve("public-key.pem").toString(),
+                "--key-id", "test:key", "--out", exported.toString()};
+        PluginSignatureTool.main(export);
+        String json = Files.readString(exported, StandardCharsets.UTF_8);
+        assertThat(json).doesNotContain("PRIVATE KEY", Base64.getEncoder().encodeToString(original));
+        var key = new TrustedPluginKey("test:key", "Ed25519", value(json, "publicKeySpkiBase64"),
+                TrustedPluginKey.State.ACTIVE, "test", "test", false);
+        assertThat(value(json, "fingerprint")).isEqualTo(key.publicKeyFingerprint());
+        Path artifact = Files.writeString(tempDir.resolve("plugin.jar"), "real signature input", StandardCharsets.UTF_8);
+        Path signature = tempDir.resolve("artifact.sig");
+        PluginSignatureTool.main(new String[]{"artifact", "--artifact", artifact.toString(), "--plugin-id", "demo",
+                "--version", "4.5.6", "--key-id", key.keyId(), "--private-key", privateKey.toString(),
+                "--out", signature.toString()});
+        assertThat(new PluginSupplyChainVerifier(PluginTrustStores.community(List.of(key))).verifyArtifact(
+                new ArtifactVerificationRequest(artifact, "demo", "4.5.6", Files.size(artifact),
+                        Hashing.hex(Hashing.sha256(artifact)), readMetadata(signature), VerificationPolicy.customRepository())))
+                .extracting(VerificationResult::accepted).isEqualTo(true);
+        assertThatThrownBy(() -> PluginSignatureTool.main(export)).isInstanceOf(java.nio.file.FileAlreadyExistsException.class);
+        assertThatThrownBy(() -> PluginSignatureTool.main(new String[]{"keygen", "--directory", directory.toString(),
+                "--directory", tempDir.resolve("other").toString()})).hasMessage("DUPLICATE_OPTION");
+        assertThatThrownBy(() -> PluginSignatureTool.main(new String[]{"keygen", "--directory", directory.toString(),
+                "--unknown", "value"})).hasMessage("UNKNOWN_OPTION");
+        Path oversized = Files.write(tempDir.resolve("oversized.pem"), new byte[SigningKeyFiles.MAX_KEY_BYTES + 1]);
+        assertThatThrownBy(() -> SigningKeyFiles.publicKey(oversized)).hasMessage("INPUT_LIMIT_EXCEEDED");
+    }
+
+    @Test
+    @DisplayName("社区 CLI 签名由统一 verifier 验证，拒绝跨域、过期摘要及重复输出")
+    void signsCommunityOperationsWithExactBody() throws Exception {
+        Path directory = tempDir.resolve("keys");
+        PluginSignatureTool.main(new String[]{"keygen", "--directory", directory.toString()});
+        var key = new TrustedPluginKey("operation:key", "Ed25519",
+                SigningKeyFiles.publicKey(directory.resolve("public-key.pem")), TrustedPluginKey.State.ACTIVE,
+                "test", "test", false);
+        var verifier = new PluginSupplyChainVerifier(PluginTrustStores.community(List.of(key)));
+        Path canonical = Files.writeString(tempDir.resolve("body.bin"), "{\"payload\":{},\"schemaVersion\":1}", StandardCharsets.UTF_8);
+        byte[] bytes = Files.readAllBytes(canonical);
+        String requestId = Hashing.hex(Hashing.sha256(bytes));
+        for (var operation : CommunityOperation.values()) {
+            Path signature = tempDir.resolve(operation.name() + ".sig");
+            String[] command = {"community-operation", "--operation", operation.name(),
+                    "--canonical-body", canonical.toString(), "--request-id", requestId, "--key-id", key.keyId(),
+                    "--private-key", directory.resolve("private-key.pem").toString(), "--out", signature.toString()};
+            PluginSignatureTool.main(command);
+            for (var target : CommunityOperation.values()) {
+                assertThat(verifier.verifyCommunityOperation(new CommunityOperationVerificationRequest(
+                        target, bytes, requestId, readMetadata(signature), false)).accepted()).isEqualTo(target == operation);
+            }
+            assertThatThrownBy(() -> PluginSignatureTool.main(command)).isInstanceOf(java.nio.file.FileAlreadyExistsException.class);
+            command[6] = "00".repeat(32);
+            command[12] = tempDir.resolve("must-not-exist.sig").toString();
+            assertThatThrownBy(() -> PluginSignatureTool.main(command)).hasMessage("REQUEST_ID_MISMATCH");
+            assertThat(Path.of(command[12])).doesNotExist();
+            command[6] = requestId;
+            Files.write(canonical, new byte[64 * 1024 + 1]);
+            assertThatThrownBy(() -> PluginSignatureTool.main(command)).hasMessage("INPUT_LIMIT_EXCEEDED");
+            Files.write(canonical, bytes);
+        }
+    }
 
     @Test
     @DisplayName("artifact / manifest 签名 JSON 可被统一 verifier 离线验证")


### PR DESCRIPTION
## 变更内容

补齐插件发布者的密钥初始化、公钥导出和社区操作请求签名入口。密钥文件采用受限权限，初始化拒绝覆盖已有文件；签名复用现有社区操作签名域，校验正文摘要并限制输入读取。五种语言的 README 同步补充命令用法。

## 影响范围

- [x] 变更仅涉及签名 CLI、相关测试和使用说明。
- [x] 已检查文档、测试和 CHANGELOG 范围；内部开发工具变更不新增 CHANGELOG 条目。

## 验证

- [x] 签名模块 22 项 JUnit 测试通过。
- [x] 独立 JDK 17 JAR 已验证密钥初始化、公钥导出和社区操作签名互验。
- [x] `git diff --check origin/master...HEAD` 通过。
- [x] 当前 PR 的完整 Quality Gate 和六项绑定 App 的 required checks 通过：[运行记录](https://github.com/Sywyar/PixivDownloader/actions/runs/34704867875)。

## 补充说明

GitHub 已完成测试合并对象的 Java、SDK、Windows 产物及其它质量检查，App 检查绑定同一 base、head 和内容树。社区仓库固定消费本提交生成的独立签名 JAR 及其 SHA-256。
